### PR TITLE
Fix pet sprite animation not playing

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -61,6 +61,7 @@ body,
   width: 192px;
   height: 208px;
   background-image: var(--sprite-url);
+  background-position: 0 var(--sprite-y);
   background-repeat: no-repeat;
   background-size: 1536px 1872px;
   image-rendering: pixelated;


### PR DESCRIPTION
## Problem
The pet sprite animation was not playing - the spritesheet remained static instead of animating through frames.

## Root Cause
The `.pet-sprite` CSS class was missing the `background-position` initial value. While the `@keyframes pet-state` animation defined the start and end positions, without an initial `background-position` on the element itself, the animation had no baseline to work from.

## Solution
Added `background-position: 0 var(--sprite-y);` to the `.pet-sprite` class in `apps/desktop/src/renderer/src/styles.css`.

## Testing
Tested with Admin Penguin pet - animations now play correctly for all states (idle, thinking, working, success, error, etc.).