### PR TITLE
fix(desktop): show pet window on all macOS Spaces

### DIFF
--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -194,6 +194,13 @@ function createBasePetWindow(title: string, position: Point): BrowserWindow {
   window.setMenu(null);
   window.setAlwaysOnTop(true, "floating");
 
+  // Show the pet window on all macOS Spaces (desktop workspaces).
+  // Without this, the window is bound to the Space where it was created
+  // and disappears when the user switches to another Space.
+  if (process.platform === "darwin") {
+    window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  }
+
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   window.webContents.on("will-navigate", (event, url) => {
     if (isAllowedPetDocumentUrl(url)) return;


### PR DESCRIPTION
The pet window only appeared on the macOS Space (desktop workspace) where it was initially created. Switching to another Space made the pet disappear.

Root cause: Electron BrowserWindow defaults to being bound to the Space where it's created. The alwaysOnTop + floating level keeps it above other windows *within the same Space*, but does not make it span across Spaces.

Fix: Call setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true }) on macOS after creating the window. This tells macOS to show the window on all Spaces and even over fullscreen apps.

The visibleOnFullScreen option ensures the pet remains visible when a fullscreen application occupies the current Space, matching the 'always visible companion' UX intent.

This is safe because OpenPets already hides its dock icon via app.dock.hide(), so the known Electron issue #26350 (dock icon disappearing after setVisibleOnAllWorkspaces) is irrelevant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/alvinunreal/codesmith/openpets/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->