### PR TITLE
Add Codex integration: CLI support, project config generation, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For project-local setup, run the CLI from the project you want to configure:
 ```bash
 npx -y @open-pets/cli configure --agent claude --pet <petId>
 npx -y @open-pets/cli configure --agent opencode --pet <petId>
+npx -y @open-pets/cli configure --agent codex --pet <petId>
 ```
 
 Project-local setup can create project files such as `.claude/settings.local.json` or `.opencode/opencode.jsonc`. Review them before committing because they may include the selected pet id.
@@ -133,6 +134,30 @@ npx -y @open-pets/cli configure --agent opencode --pet <petId>
 ```
 
 See [`docs/opencode.md`](docs/opencode.md) for global config selection, plugin behavior, project-local setup, and safety rules.
+
+
+### Codex
+
+Codex integration supports:
+
+- Project-local MCP setup through `openpets configure --agent codex --pet <petId>`.
+- Automatic creation/update of `.codex/config.toml` with an `openpets` MCP server entry.
+
+Project-local setup:
+
+```bash
+npx -y @open-pets/cli configure --agent codex --pet <petId>
+```
+
+This writes a project-scoped Codex MCP launcher:
+
+```toml
+[mcp_servers.openpets]
+command = "npx"
+args = ["-y", "@open-pets/cli@<version>", "mcp", "--pet", "<petId>"]
+```
+
+Restart Codex in the project after setup so the MCP tools load.
 
 ### Generic MCP clients
 
@@ -270,6 +295,7 @@ docs/                     Documentation
 
 - [`docs/claude-integration.md`](docs/claude-integration.md) - Claude Code setup, MCP, memory, hooks, and safety.
 - [`docs/opencode.md`](docs/opencode.md) - OpenCode global/project setup, plugin behavior, and safety.
+- [`docs/codex-integration.md`](docs/codex-integration.md) - Codex project setup and validation checklist.
 - [`docs/testing.md`](docs/testing.md) - test/check strategy.
 - [`docs/release.md`](docs/release.md) - desktop release process.
 - [`docs/workflow.md`](docs/workflow.md) - project workflow notes.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,0 +1,93 @@
+# Codex integration
+
+This guide validates OpenPets with Codex in a project-local setup.
+
+## Prerequisites
+
+- OpenPets Desktop running.
+- At least one usable installed pet in OpenPets.
+- Node.js and npm/npx available in your shell.
+
+## Local desktop development workflow (openpets-desktop)
+
+If you want to run everything locally from this repository instead of published npm packages:
+
+1. Install dependencies in the monorepo root:
+
+```bash
+pnpm install
+```
+
+2. Start OpenPets Desktop in dev mode (from repo root):
+
+```bash
+pnpm dev:desktop
+```
+
+3. In your target project directory (another terminal), configure Codex using local CLI wiring:
+
+```bash
+node /path/to/openpets/packages/cli/dist/index.js configure --agent codex --pet <petId> --local-dev --force
+```
+
+4. Confirm `.codex/config.toml` now points to a local Node command (not pinned npm package).
+
+5. Restart Codex in that project and run `openpets_status`.
+
+Tip: if `dist/index.js` does not exist yet, build once in repo root:
+
+```bash
+pnpm build
+```
+
+## 1) Configure this project for Codex
+
+From your project root:
+
+```bash
+npx -y @open-pets/cli configure --agent codex --pet <petId>
+```
+
+Expected output includes:
+
+- `OpenPets configured for Codex ...`
+- `Config: <project>/.codex/config.toml`
+
+## 2) Verify generated Codex MCP config
+
+Open `.codex/config.toml` and confirm an `openpets` server entry exists:
+
+```toml
+[mcp_servers.openpets]
+command = "npx"
+args = ["-y", "@open-pets/cli@<version>", "mcp", "--pet", "<petId>"]
+```
+
+## 3) Restart Codex in the project
+
+Restart the Codex session so it reloads MCP servers from `.codex/config.toml`.
+
+## 4) Run smoke checks via Codex MCP tools
+
+From Codex, call these tools in order:
+
+1. `openpets_status` → should report OpenPets reachable.
+2. `openpets_react` with `thinking` → pet should change reaction.
+3. `openpets_say` with short safe text (e.g., `Build done`) → speech bubble appears.
+
+## 5) Troubleshooting
+
+- **"OpenPets desktop app is not running"**: open/restart OpenPets Desktop.
+- **Pet not applied**: verify `<petId>` exists and is not broken.
+- **Config already present**: rerun with `--force` to replace OpenPets Codex block.
+- **MCP tools missing after setup**: fully restart Codex in that project.
+
+## 6) Reconfigure with local dev command (optional)
+
+For local package development:
+
+```bash
+npx -y @open-pets/cli configure --agent codex --pet <petId> --local-dev --force
+```
+
+This rewrites OpenPets Codex config to invoke the local CLI entrypoint instead of a published package version.

--- a/docs/repository-analysis.md
+++ b/docs/repository-analysis.md
@@ -1,0 +1,78 @@
+# Repository Analysis (OpenPets)
+
+Date: 2026-05-11
+
+## Product Context (from README)
+
+OpenPets is a tray-first desktop companion for coding agents. It shows a reactive animated pet that reflects agent state (thinking, editing, testing, waiting, success, error), supports safe short speech bubbles, and integrates with Claude Code, OpenCode, and generic MCP clients. Privacy is core: automatic hook/plugin speech is static/local and intentionally excludes prompts, code, logs, paths, URLs, and secrets.
+
+## What the Repository Is Optimized For
+
+This monorepo is optimized for **agent-to-desktop signaling** rather than autonomous workflows:
+
+- Agent tools and hooks emit coarse-grained events.
+- Events are translated into reactions/speech over a local IPC contract.
+- The Electron runtime renders default or selected pet windows.
+- Setup flows focus on global and project-local integration ergonomics.
+
+## Top-Level Architecture
+
+- **Desktop runtime (`apps/desktop`)**
+  - Electron main process, tray/menu UX, pet windows, onboarding/settings, pet management, and local IPC server.
+- **Core client/protocol (`packages/client`)**
+  - Shared contracts plus discovery/transport client used by all integrations.
+- **Integration surfaces**
+  - `packages/mcp`: MCP stdio server exposing OpenPets tools.
+  - `packages/cli`: configure/setup flows plus MCP entrypoint for user workflows.
+  - `packages/claude`: Claude Code MCP + memory + hook management.
+  - `packages/opencode`: OpenCode instruction/config/plugin integration.
+- **Shared domain packages**
+  - `packages/agent-events`: static safe speech/event utilities.
+  - `packages/install-pet`: pet install command implementation.
+  - `packages/pet-format`: pet package format marker/types.
+
+## Runtime Control/Data Flow
+
+1. Desktop app starts and writes local IPC discovery metadata (endpoint + run token).
+2. External integrations (MCP server, CLI, Claude hooks, OpenCode plugin) call `@open-pets/client`.
+3. Client discovers endpoint and sends token-authenticated local IPC requests.
+4. Desktop controllers resolve target pet (default or selected non-default via lease).
+5. Pet window applies reaction/speech updates with safety validation and fallback behavior.
+
+## Integration Model (Important for Contributors)
+
+OpenPets integrations are intentionally layered:
+
+1. **MCP tools** for explicit calls (`openpets_status`, `openpets_react`, `openpets_say`).
+2. **Instruction files** that teach agents when/how to use tools safely.
+3. **Hooks/plugins** that provide decorative automatic reactions during normal coding.
+
+This layering means behavior changes often span multiple packages and should be validated end-to-end (desktop + integration + client contract).
+
+## Workspace & Build Conventions
+
+- Monorepo managed with pnpm workspaces (`apps/*`, `packages/*`).
+- TypeScript + ESM across packages, Node 20+ expectation.
+- Root scripts orchestrate recursive checks/build/test (`pnpm check`, `pnpm typecheck`, `pnpm build`, `pnpm test`).
+- Repo uses lightweight contract checks (`check-*.ts`) in place of a full centralized test framework.
+
+## Strengths
+
+- Strong package boundaries between runtime, protocol, and integrations.
+- Good onboarding aids via codemap files and explicit docs per integration.
+- Privacy/safety constraints are first-class in product behavior, not afterthoughts.
+- Local IPC token model provides practical protection for desktop command routing.
+
+## Risks / Attention Areas
+
+- **Single-runtime dependency**: all integrations depend on desktop availability and healthy discovery metadata.
+- **Cross-package compatibility drift**: MCP/CLI/hooks/plugins can diverge if contract evolution is not tightly versioned.
+- **Test surface growth**: each new integration feature multiplies end-to-end scenarios.
+- **Lease edge cases**: selected-pet fallback behavior needs robust regression coverage.
+
+## Recommended Next Deep Dives
+
+1. **IPC contract/version policy**: document strict compatibility guarantees and rollout strategy.
+2. **Lease lifecycle validation**: disconnect/reconnect, stale lease, and fallback paths.
+3. **Integration regression matrix**: explicit smoke suite across Claude/OpenCode/generic MCP.
+4. **Release hardening**: verify packaging + npm release dry-runs and rollback playbooks.

--- a/packages/cli/src/check-cli-contract.ts
+++ b/packages/cli/src/check-cli-contract.ts
@@ -17,6 +17,7 @@ assert.equal(parseConfigureArgs(["--pet", "fixer", "--replace"]).force, true);
 assert.equal(parseConfigureArgs(["--pet", "fixer", "--local-dev"]).localDev, true);
 assert.equal(parseConfigureArgs(["--pet=fixer"]).petId, "fixer");
 assert.equal(parseConfigureArgs(["--agent", "opencode", "--pet", "fixer"]).agent, "opencode");
+assert.equal(parseConfigureArgs(["--agent", "codex", "--pet", "fixer"]).agent, "codex");
 assert.throws(() => parseConfigureArgs(["--agent", "cursor"]));
 assert.throws(() => parseConfigureArgs(["--pet", "bad/pet"]));
 assert.deepEqual(parseInstallArgs(["review-owl"]), { petId: "review-owl" });
@@ -165,6 +166,20 @@ try {
   assert.match(instructionText, /User text/);
   assert.match(instructionText, /OPENPETS:START/);
 
+
+
+  const codexProject = join(dir, "codex-project");
+  mkdirSync(codexProject);
+  await configureProject({ agent: "codex", petId: "fixer", cwd: codexProject, yes: true, force: false, localDev: false });
+  const codexConfigPath = join(codexProject, ".codex", "config.toml");
+  const codexConfig = readFileSync(codexConfigPath, "utf8");
+  assert.match(codexConfig, /\[mcp_servers\.openpets\]/);
+  assert.match(codexConfig, /@open-pets\/cli@2.0.3/);
+  await assert.rejects(() => configureProject({ agent: "codex", petId: "fixer", cwd: codexProject, yes: true, force: false, localDev: false }));
+  await configureProject({ agent: "codex", petId: "fixer", cwd: codexProject, yes: true, force: true, localDev: true });
+  const codexConfigForced = readFileSync(codexConfigPath, "utf8");
+  assert.match(codexConfigForced, /command = "node"/);
+
   const symlinkOpenCodeProject = join(dir, "opencode-symlink");
   const outsideOpenCode = join(dir, "outside-opencode");
   mkdirSync(symlinkOpenCodeProject);
@@ -176,7 +191,6 @@ try {
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }
-
 const invalidHook = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, "hook", "--openpets-managed", "--pet", "bad/pet"], { input: JSON.stringify({ hook_event_name: "Notification" }), encoding: "utf8" });
 assert.equal(invalidHook.status, 1);
 const missingPetHook = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, "hook", "--openpets-managed", "--pet"], { input: JSON.stringify({ hook_event_name: "Notification" }), encoding: "utf8" });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,7 @@ import { prepareOpenCodeProjectSetup, writePreparedOpenCodeProjectSetup } from "
 export const cliPackageName = "@open-pets/cli";
 
 interface ConfigureOptions {
-  readonly agent: "claude" | "opencode";
+  readonly agent: "claude" | "opencode" | "codex";
   readonly petId?: string;
   readonly cwd: string;
   readonly yes: boolean;
@@ -97,6 +97,10 @@ export async function configureProject(options: ConfigureOptions): Promise<void>
     await configureOpenCodeProject(options, projectDir);
     return;
   }
+  if (options.agent === "codex") {
+    await configureCodexProject(options, projectDir);
+    return;
+  }
   assertClaudeAvailable();
   assertSafeProjectHookPath(projectDir);
   const client = createOpenPetsClient();
@@ -154,7 +158,7 @@ export function parseConfigureArgs(args: readonly string[]): ConfigureOptions {
     else if (arg.startsWith("--cwd=")) cwd = arg.slice("--cwd=".length);
     else throw new CliError(`Unknown configure option: ${arg}`);
   }
-  if (agent !== "claude" && agent !== "opencode") throw new CliError(`Unsupported agent: ${agent}. Supported agents: claude, opencode.`);
+  if (agent !== "claude" && agent !== "opencode" && agent !== "codex") throw new CliError(`Unsupported agent: ${agent}. Supported agents: claude, opencode, codex.`);
   return { agent, petId, cwd, yes, force, localDev };
 }
 
@@ -215,6 +219,48 @@ function runClaudeMcpRemove(projectDir: string): void {
   if (result.status !== 0 && !/not found|does not exist|no server|unknown/i.test(output)) {
     throw new CliError(`Claude MCP remove failed: ${(result.stderr || result.stdout || "unknown error").trim()}`);
   }
+}
+
+
+async function configureCodexProject(options: ConfigureOptions, projectDir: string): Promise<void> {
+  const client = createOpenPetsClient();
+  const selectedPet = await resolveConfiguredPet(client, options.petId);
+  const packageVersion = getPackageVersion();
+  const mcpCommand = options.localDev ? createLocalDevCliCommand(["mcp", "--pet", selectedPet.id]) : createVersionPinnedCliCommand(packageVersion, ["mcp", "--pet", selectedPet.id]);
+  const configPath = join(projectDir, ".codex", "config.toml");
+  writeCodexProjectConfig(configPath, mcpCommand, options.force);
+  process.stdout.write(`OpenPets configured for Codex in ${projectDir}.\nPet: ${sanitizeTerminalText(selectedPet.displayName)} (${selectedPet.id})\nConfig: ${configPath}\nRestart Codex in this project to load OpenPets tools.\n`);
+}
+
+function writeCodexProjectConfig(configPath: string, command: CommandSpec, force: boolean): void {
+  const existing = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+  if (!force && /\[mcp_servers\.openpets\]/.test(existing)) {
+    throw new CliError("Codex config already has [mcp_servers.openpets]. Use --force to replace the OpenPets block.");
+  }
+  const block = buildCodexOpenPetsBlock(command);
+  const cleaned = existing.replace(/\n?\[mcp_servers\.openpets\][\s\S]*?(?=\n\[[^\]]+\]|$)/g, "").trimEnd();
+  const next = `${cleaned.length > 0 ? `${cleaned}\n\n` : ""}${block}\n`;
+  writeTextFile(configPath, next);
+}
+
+function buildCodexOpenPetsBlock(command: CommandSpec): string {
+  const args = command.args.map((arg) => tomlString(arg)).join(", ");
+  return `[mcp_servers.openpets]\ncommand = ${tomlString(command.command)}\nargs = [${args}]`;
+}
+
+function tomlString(value: string): string {
+  if (/\r|\n|\0/.test(value)) throw new CliError("Codex TOML value contains unsupported characters.");
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function writeTextFile(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const parentStats = lstatSync(dirname(path));
+  if (parentStats.isSymbolicLink() || !parentStats.isDirectory()) throw new CliError("Config directory is unsafe after creation.");
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, value, { encoding: "utf8", mode: 0o600 });
+  renameSync(tempPath, path);
+  try { chmodSync(path, 0o600); } catch { /* best effort */ }
 }
 
 async function runMcp(args: readonly string[]): Promise<void> {
@@ -357,7 +403,7 @@ function getPackageVersion(): string {
 }
 
 function printUsage(): void {
-  process.stdout.write("Usage:\n  openpets install <pet-id>\n  openpets configure [--agent claude|opencode] [--pet <id>] [--cwd <path>] [--yes] [--force]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
+  process.stdout.write("Usage:\n  openpets install <pet-id>\n  openpets configure [--agent claude|opencode|codex] [--pet <id>] [--cwd <path>] [--yes] [--force]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
 }
 
 function printInstallUsage(): void {
@@ -365,7 +411,7 @@ function printInstallUsage(): void {
 }
 
 function printConfigureUsage(): void {
-  process.stdout.write("Usage:\n  openpets configure [--agent claude|opencode] [--pet <id>] [--cwd <path>] [--yes] [--force]\n\nOptions:\n  --pet <id>           Pet id to use for this project. If omitted, prompts with installed pets.\n  --agent <agent>      Agent to configure: claude or opencode. Defaults to claude.\n  --cwd <path>         Project directory to configure. Defaults to current directory.\n  --yes, -y            Accepted for scripts; no confirmation prompt is shown.\n  --force              Replace supported managed entries where applicable.\n  --replace            Alias for --force.\n  --local-dev          Use local development command paths where supported.\n  -h, --help           Show this help.\n");
+  process.stdout.write("Usage:\n  openpets configure [--agent claude|opencode|codex] [--pet <id>] [--cwd <path>] [--yes] [--force]\n\nOptions:\n  --pet <id>           Pet id to use for this project. If omitted, prompts with installed pets.\n  --agent <agent>      Agent to configure: claude, opencode, or codex. Defaults to claude.\n  --cwd <path>         Project directory to configure. Defaults to current directory.\n  --yes, -y            Accepted for scripts; no confirmation prompt is shown.\n  --force              Replace supported managed entries where applicable.\n  --replace            Alias for --force.\n  --local-dev          Use local development command paths where supported.\n  -h, --help           Show this help.\n");
 }
 
 function printMcpUsage(): void {


### PR DESCRIPTION
### Motivation

- Add support for Codex as a first-class project-local integration so users can configure OpenPets for Codex MCP usage.
- Provide documentation and a validation guide to help users configure and verify Codex integration locally.
- Extend CLI project-configuration tooling to consistently emit Codex MCP entries with secure file handling.

### Description

- Added Codex documentation at `docs/codex-integration.md` and linked it from `README.md` with usage examples and expected `.codex/config.toml` output.
- Updated `README.md` to include `codex` in the integrations list and reference the new docs page.
- Introduced `docs/repository-analysis.md` describing repository architecture, risks, and recommended deep dives.
- Extended CLI parsing and help text in `packages/cli/src/index.ts` to accept `--agent codex` and implemented `configureCodexProject`, `writeCodexProjectConfig`, and TOML construction helpers to atomically write `.codex/config.toml` with secure permissions.
- Updated `packages/cli/src/check-cli-contract.ts` to include automated contract tests for the `codex` configure flow and related behaviors.

### Testing

- Ran the CLI contract validation script in `packages/cli/src/check-cli-contract.ts`, which exercised parsing, project configuration flows (including Codex), and help output assertions, and it completed with the contract validation message indicating success.
- The `codex` configure path was validated by assertions that `.codex/config.toml` contains an `[mcp_servers.openpets]` block and that the `--local-dev --force` variations produce a `node`-based command entry, and those assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02119e6c58832d8d57ee9efc5a5993)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/alvinunreal/codesmith/openpets/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->