### PR TITLE
fix: add @img/sharp-win32-x64 as direct dep to bundle Windows native binary

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,6 +35,7 @@
     "@open-pets/cli": "workspace:*",
     "@open-pets/mcp": "workspace:*",
     "@open-pets/opencode": "workspace:*",
+    "@img/sharp-win32-x64": "0.34.5",
     "sharp": "^0.34.5",
     "yauzl": "3.3.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@img/sharp-win32-x64':
+        specifier: 0.34.5
+        version: 0.34.5
       '@open-pets/agent-events':
         specifier: workspace:*
         version: link:../../packages/agent-events
@@ -3201,8 +3204,7 @@ snapshots:
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
+  '@img/sharp-win32-x64@0.34.5': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Fixes #18 — Windows build crashes because `@img/sharp-win32-x64` optional dependency is not installed during macOS-based packaging
- Added `@img/sharp-win32-x64` as a direct dependency in `apps/desktop/package.json`

## Root Cause
`sharp@0.34.5` declares `@img/sharp-win32-x64` as an **optional dependency**. Since release builds happen on macOS, pnpm skips Windows-specific optional deps. The native binary is missing from the packaged app, causing the crash on Windows.

## Fix
Making `@img/sharp-win32-x64` a direct dependency ensures it is always installed regardless of build platform, and is included in the packaged app.

## Tested
- `sharp` loads correctly with the native binary
- `node dist/check-codex-pets.js` passes
- All other tests unaffected