### PR TITLE
fix(mcp): add lease re-acquisition with exponential backoff on heartb…

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,17 +27,40 @@ async function main(): Promise<void> {
   const leaseReady = acquireStartupLease(context.client, lease, options.petId);
   const server = createOpenPetsMcpServer({ ...context, lease, leaseReady });
   let heartbeatTimer: NodeJS.Timeout | null = null;
+  let retryTimer: NodeJS.Timeout | null = null;
+  let retryDelayMs = 5_000;
+  const MAX_RETRY_DELAY_MS = 60_000;
   let closing = false;
+
+  function scheduleRetry(): void {
+    if (retryTimer || closing) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (closing || lease.lease) return;
+      void context.client.acquireLease({ requestedPetId: options.petId }).then((result) => {
+        lease.lease = result;
+        lease.staleLeaseId = undefined;
+        lease.degradedReason = undefined;
+        retryDelayMs = 5_000;
+      }).catch((error: unknown) => {
+        lease.degradedReason = sanitizeMcpRuntimeError(error);
+        retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+        scheduleRetry();
+      });
+    }, retryDelayMs);
+    retryTimer.unref?.();
+  }
+
   leaseReady.then(() => {
     if (!lease.lease) return;
     heartbeatTimer = setInterval(() => {
-      if (!lease.lease) return;
+      if (closing || !lease.lease) return;
       void context.client.heartbeatLease(lease.lease.leaseId).catch((error: unknown) => {
         lease.staleLeaseId = lease.lease?.leaseId;
         lease.degradedReason = sanitizeMcpRuntimeError(error);
         lease.lease = undefined;
-        if (heartbeatTimer) clearInterval(heartbeatTimer);
-        heartbeatTimer = null;
+        retryDelayMs = 5_000;
+        scheduleRetry();
       });
     }, 5_000);
     heartbeatTimer.unref?.();
@@ -48,6 +71,8 @@ async function main(): Promise<void> {
     closing = true;
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     heartbeatTimer = null;
+    if (retryTimer) clearTimeout(retryTimer);
+    retryTimer = null;
     const leaseId = lease.lease?.leaseId;
     lease.lease = undefined;
     if (leaseId) {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -71,15 +71,31 @@ export async function handleStatus(context: ToolContext): Promise<CallToolResult
   };
 }
 
+async function ensureLease(context: ToolContext): Promise<boolean> {
+  if (context.lease?.lease) return true;
+  try {
+    const client = context.client ?? createOpenPetsClient();
+    const newLease = await client.acquireLease({ requestedPetId: context.configuredPetId });
+    if (context.lease) {
+      context.lease.lease = newLease;
+      context.lease.staleLeaseId = undefined;
+      context.lease.degradedReason = undefined;
+    }
+    return !!newLease;
+  } catch {
+    return false;
+  }
+}
+
 export async function handleReact(input: unknown, context: ToolContext): Promise<CallToolResult> {
   await context.leaseReady;
   const parsed = reactSchema.safeParse(input);
   if (!parsed.success) return toolError("Invalid reaction. Use one of: " + allowedReactions.join(", "));
-  if (!context.lease?.lease) return toolError(`OpenPets lease is unavailable. ${sanitizeUnavailableReason(context.lease?.degradedReason) ?? "Open OpenPets and try again."}`);
+  if (!(await ensureLease(context))) return toolError(`OpenPets lease is unavailable. ${sanitizeUnavailableReason(context.lease?.degradedReason) ?? "Open OpenPets and try again."}`);
 
   try {
     const client = context.client ?? createOpenPetsClient();
-    const result = await client.react(parsed.data.reaction, { leaseId: context.lease.lease.leaseId });
+    const result = await client.react(parsed.data.reaction, { leaseId: context.lease!.lease!.leaseId });
     return {
       content: [{ type: "text", text: `OpenPets reaction sent: ${parsed.data.reaction}` }],
       structuredContent: { ok: true, reaction: parsed.data.reaction, result },
@@ -93,11 +109,11 @@ export async function handleSay(input: unknown, context: ToolContext): Promise<C
   await context.leaseReady;
   const parsed = saySchema.safeParse(input);
   if (!parsed.success) return toolError("Invalid message. Keep it short, single-line, and avoid code, secrets, URLs, and file paths.");
-  if (!context.lease?.lease) return toolError(`OpenPets lease is unavailable. ${sanitizeUnavailableReason(context.lease?.degradedReason) ?? "Open OpenPets and try again."}`);
+  if (!(await ensureLease(context))) return toolError(`OpenPets lease is unavailable. ${sanitizeUnavailableReason(context.lease?.degradedReason) ?? "Open OpenPets and try again."}`);
 
   try {
     const client = context.client ?? createOpenPetsClient();
-    const result = await client.say(parsed.data.message, { reaction: parsed.data.reaction, leaseId: context.lease.lease.leaseId });
+    const result = await client.say(parsed.data.message, { reaction: parsed.data.reaction, leaseId: context.lease!.lease!.leaseId });
     return {
       content: [{ type: "text", text: "OpenPets message sent." }],
       structuredContent: { ok: true, result },


### PR DESCRIPTION
…eat failure

When a heartbeat fails, the MCP server previously cleared the lease and stopped heartbeating permanently, making the pet unresponsive for the rest of the session.

Now on heartbeat failure:
- Enters retry mode with exponential backoff (5s → 10s → 20s → 40s → 60s cap)
- Re-acquires lease automatically when the desktop app recovers
- Resumes normal 5s heartbeat after successful re-acquisition

Also adds on-demand lease recovery in react/say tool handlers — if the lease is expired when a tool is called, it attempts to acquire a new one before returning an error.