### PR TITLE
feat: add missing locale files for the virtual-pet official plugin

### DIFF
--- a/plugins/official/openpets.virtual-pet/locales/es-419.json
+++ b/plugins/official/openpets.virtual-pet/locales/es-419.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "Mascota virtual",
+  "plugin.description": "Cuida a una pequeña mascota de escritorio y mira cómo crece su vínculo con interacciones cotidianas suaves.",
+  "hud.food": "Comida",
+  "hud.energy": "Energía",
+  "hud.play": "Juego",
+  "hud.bond": "Vínculo",
+  "config.sound.label": "Sonido de acción",
+  "config.sound.description": "Opcionalmente reproduce un sonido para acciones directas de cuidado como alimentar, jugar, acariciar o descansar.",
+
+  "command.feed.title": "Dar snack",
+  "command.feed.description": "Dale un snack a tu mascota.",
+  "command.play.title": "Jugar",
+  "command.play.description": "Juega un juego rápido.",
+  "command.pet.title": "Acariciar",
+  "command.pet.description": "Dale cariño a tu mascota.",
+  "command.nap.title": "Dejar descansar",
+  "command.nap.description": "Deja que tu mascota descanse 15 minutos.",
+  "command.status.title": "Revisar mascota",
+  "command.status.description": "Revisa cómo se siente tu mascota.",
+
+  "speech.feed.0": "¡Gracias por la comida!",
+  "speech.feed.1": "*ñam ñam ñam*",
+  "speech.feed.2": "¡Qué rico!",
+  "speech.feed.3": "¡Estuvo delicioso!",
+
+  "speech.play.0": "¡Eso fue divertido!",
+  "speech.play.1": "¡Yupi!",
+  "speech.play.2": "¡Me encanta jugar!",
+  "speech.play.3": "¡Otra vez!",
+
+  "speech.pet.0": "Prrr...",
+  "speech.pet.1": "*se acurruca*",
+  "speech.pet.2": "Qué calientito...",
+  "speech.pet.3": "¡Tan suave!",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*se acurruca*",
+  "speech.nap.2": "Tengo sueñito...",
+  "speech.nap.3": "Descansando...",
+
+  "speech.levelup": "¡Estamos más cerca!",
+
+  "speech.status.sleeping": "Zzz... descansando.",
+  "speech.status.hungry": "Tengo un poco de hambre.",
+  "speech.status.tired": "Tengo sueño.",
+  "speech.status.bored": "Quiero jugar.",
+  "speech.status.happy": "¡Me siento genial!",
+  "speech.status.content": "Estoy a gusto.",
+
+  "nudge.hungry": "Me está dando un poquito de hambre.",
+  "nudge.tired": "Me está dando sueño.",
+  "nudge.bored": "¿Quieres jugar?",
+  "nudge.neglected": "¿Me das un poco de atención?"
+}

--- a/plugins/official/openpets.virtual-pet/locales/ja.json
+++ b/plugins/official/openpets.virtual-pet/locales/ja.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "バーチャルペット",
+  "plugin.description": "小さなデスクトップの相棒をお世話して、穏やかな日々のふれあいで絆が育つのを見守ります。",
+  "hud.food": "ごはん",
+  "hud.energy": "元気",
+  "hud.play": "遊び",
+  "hud.bond": "絆",
+  "config.sound.label": "アクション音",
+  "config.sound.description": "ごはん、遊び、なでる、休むなど直接のお世話で任意の音を鳴らします。",
+
+  "command.feed.title": "おやつをあげる",
+  "command.feed.description": "ペットにおやつをあげます。",
+  "command.play.title": "遊ぶ",
+  "command.play.description": "短いゲームで遊びます。",
+  "command.pet.title": "なでる",
+  "command.pet.description": "ペットに愛情を伝えます。",
+  "command.nap.title": "休ませる",
+  "command.nap.description": "ペットを15分休ませます。",
+  "command.status.title": "様子を見る",
+  "command.status.description": "ペットの気分を確認します。",
+
+  "speech.feed.0": "おやつありがとう！",
+  "speech.feed.1": "*もぐもぐ*",
+  "speech.feed.2": "おいしい！",
+  "speech.feed.3": "とってもおいしかった！",
+
+  "speech.play.0": "楽しかった！",
+  "speech.play.1": "やった！",
+  "speech.play.2": "ゲームで遊ぶの大好き！",
+  "speech.play.3": "もう一回！",
+
+  "speech.pet.0": "ゴロゴロ...",
+  "speech.pet.1": "*すりすり*",
+  "speech.pet.2": "あったかい...",
+  "speech.pet.3": "ふわふわ！",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*丸くなる*",
+  "speech.nap.2": "眠い...",
+  "speech.nap.3": "休憩中...",
+
+  "speech.levelup": "もっと仲良くなったね！",
+
+  "speech.status.sleeping": "Zzz...休んでるよ。",
+  "speech.status.hungry": "少しお腹がすいたよ。",
+  "speech.status.tired": "眠くなってきたよ。",
+  "speech.status.bored": "遊びたいな。",
+  "speech.status.happy": "とても元気だよ！",
+  "speech.status.content": "満ち足りてるよ。",
+
+  "nudge.hungry": "少しお腹がすいてきたよ。",
+  "nudge.tired": "眠くなってきたよ。",
+  "nudge.bored": "遊んでくれる？",
+  "nudge.neglected": "少しかまってくれる？"
+}

--- a/plugins/official/openpets.virtual-pet/locales/ko.json
+++ b/plugins/official/openpets.virtual-pet/locales/ko.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "가상 펫",
+  "plugin.description": "작은 데스크톱 펫을 돌보며 부드러운 일상 상호작용으로 유대가 자라는 모습을 지켜보세요.",
+  "hud.food": "먹이",
+  "hud.energy": "에너지",
+  "hud.play": "놀이",
+  "hud.bond": "유대감",
+  "config.sound.label": "동작 소리",
+  "config.sound.description": "먹이 주기, 놀기, 쓰다듬기, 쉬기 같은 직접 돌봄 동작에 선택적으로 소리를 재생합니다.",
+
+  "command.feed.title": "간식 주기",
+  "command.feed.description": "펫에게 간식을 주세요.",
+  "command.play.title": "게임하기",
+  "command.play.description": "짧은 게임을 해요.",
+  "command.pet.title": "쓰다듬기",
+  "command.pet.description": "펫에게 애정을 주세요.",
+  "command.nap.title": "쉬게 하기",
+  "command.nap.description": "펫이 15분 동안 쉬게 합니다.",
+  "command.status.title": "펫 살피기",
+  "command.status.description": "펫이 어떤 기분인지 확인합니다.",
+
+  "speech.feed.0": "간식 고마워요!",
+  "speech.feed.1": "*냠냠냠*",
+  "speech.feed.2": "맛있어요!",
+  "speech.feed.3": "정말 맛있었어요!",
+
+  "speech.play.0": "재밌었어요!",
+  "speech.play.1": "야호!",
+  "speech.play.2": "게임하는 거 좋아요!",
+  "speech.play.3": "또 해요!",
+
+  "speech.pet.0": "골골골...",
+  "speech.pet.1": "*부비부비*",
+  "speech.pet.2": "따뜻해요...",
+  "speech.pet.3": "정말 부드러워요!",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*몸을 말아요*",
+  "speech.nap.2": "졸려요...",
+  "speech.nap.3": "쉬는 중...",
+
+  "speech.levelup": "우리 더 가까워지고 있어요!",
+
+  "speech.status.sleeping": "Zzz... 쉬고 있어요.",
+  "speech.status.hungry": "조금 배고파요.",
+  "speech.status.tired": "졸려요.",
+  "speech.status.bored": "놀고 싶어요.",
+  "speech.status.happy": "기분이 아주 좋아요!",
+  "speech.status.content": "편안해요.",
+
+  "nudge.hungry": "조금 배고파지고 있어요.",
+  "nudge.tired": "졸려지고 있어요.",
+  "nudge.bored": "같이 놀까요?",
+  "nudge.neglected": "조금 관심을 줄 수 있나요?"
+}

--- a/plugins/official/openpets.virtual-pet/locales/pt-BR.json
+++ b/plugins/official/openpets.virtual-pet/locales/pt-BR.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "Pet virtual",
+  "plugin.description": "Cuide de um pequeno companheiro de desktop e veja o vínculo de vocês crescer com interações leves do dia a dia.",
+  "hud.food": "Comida",
+  "hud.energy": "Energia",
+  "hud.play": "Brincar",
+  "hud.bond": "Vínculo",
+  "config.sound.label": "Som de ação",
+  "config.sound.description": "Opcionalmente reproduz um som para ações diretas de cuidado, como alimentar, brincar, fazer carinho ou descansar.",
+
+  "command.feed.title": "Dar petisco",
+  "command.feed.description": "Dê um petisco ao seu pet.",
+  "command.play.title": "Brincar",
+  "command.play.description": "Jogue uma partida rápida.",
+  "command.pet.title": "Fazer carinho",
+  "command.pet.description": "Dê carinho ao seu pet.",
+  "command.nap.title": "Deixar descansar",
+  "command.nap.description": "Deixe seu pet descansar por 15 minutos.",
+  "command.status.title": "Ver pet",
+  "command.status.description": "Veja como seu pet está se sentindo.",
+
+  "speech.feed.0": "Valeu pelo petisco!",
+  "speech.feed.1": "*nhac nhac nhac*",
+  "speech.feed.2": "Que delícia!",
+  "speech.feed.3": "Estava delicioso!",
+
+  "speech.play.0": "Foi divertido!",
+  "speech.play.1": "Eba!",
+  "speech.play.2": "Eu adoro brincar!",
+  "speech.play.3": "De novo!",
+
+  "speech.pet.0": "Ronron...",
+  "speech.pet.1": "*se aconchega*",
+  "speech.pet.2": "Quentinho...",
+  "speech.pet.3": "Tão macio!",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*se enrosca*",
+  "speech.nap.2": "Com soninho...",
+  "speech.nap.3": "Descansando...",
+
+  "speech.levelup": "Estamos ficando mais próximos!",
+
+  "speech.status.sleeping": "Zzz... descansando.",
+  "speech.status.hungry": "Estou com um pouco de fome.",
+  "speech.status.tired": "Estou com sono.",
+  "speech.status.bored": "Quero brincar.",
+  "speech.status.happy": "Estou me sentindo muito bem!",
+  "speech.status.content": "Estou em paz.",
+
+  "nudge.hungry": "Estou ficando com um pouco de fome.",
+  "nudge.tired": "Estou ficando com sono.",
+  "nudge.bored": "Quer brincar?",
+  "nudge.neglected": "Posso receber um pouco de atenção?"
+}

--- a/plugins/official/openpets.virtual-pet/locales/zh-Hans.json
+++ b/plugins/official/openpets.virtual-pet/locales/zh-Hans.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "虚拟宠物",
+  "plugin.description": "照顾一个小小的桌面伙伴，通过温柔的日常互动看着你们的羁绊成长。",
+  "hud.food": "食物",
+  "hud.energy": "能量",
+  "hud.play": "玩耍",
+  "hud.bond": "羁绊",
+  "config.sound.label": "动作声音",
+  "config.sound.description": "喂食、玩耍、抚摸或休息等直接照顾动作可选择播放声音。",
+
+  "command.feed.title": "喂零食",
+  "command.feed.description": "给你的宠物喂一份零食。",
+  "command.play.title": "玩游戏",
+  "command.play.description": "玩一个小游戏。",
+  "command.pet.title": "抚摸",
+  "command.pet.description": "给你的宠物一点关爱。",
+  "command.nap.title": "让它休息",
+  "command.nap.description": "让你的宠物休息 15 分钟。",
+  "command.status.title": "查看宠物",
+  "command.status.description": "看看你的宠物感觉怎么样。",
+
+  "speech.feed.0": "谢谢你的零食！",
+  "speech.feed.1": "*嚼嚼嚼*",
+  "speech.feed.2": "好吃！",
+  "speech.feed.3": "太美味了！",
+
+  "speech.play.0": "真好玩！",
+  "speech.play.1": "耶！",
+  "speech.play.2": "我喜欢玩游戏！",
+  "speech.play.3": "再来一次！",
+
+  "speech.pet.0": "呼噜...",
+  "speech.pet.1": "*蹭蹭*",
+  "speech.pet.2": "暖暖的...",
+  "speech.pet.3": "好柔软！",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*蜷起来*",
+  "speech.nap.2": "困困的...",
+  "speech.nap.3": "休息中...",
+
+  "speech.levelup": "我们更亲近了！",
+
+  "speech.status.sleeping": "Zzz...正在休息。",
+  "speech.status.hungry": "我有点饿了。",
+  "speech.status.tired": "我有点困。",
+  "speech.status.bored": "我想玩。",
+  "speech.status.happy": "我感觉棒极了！",
+  "speech.status.content": "我很满足。",
+
+  "nudge.hungry": "我有点饿了。",
+  "nudge.tired": "我有点困了。",
+  "nudge.bored": "想一起玩吗？",
+  "nudge.neglected": "可以陪陪我吗？"
+}

--- a/plugins/official/openpets.virtual-pet/locales/zh-Hant.json
+++ b/plugins/official/openpets.virtual-pet/locales/zh-Hant.json
@@ -1,0 +1,55 @@
+{
+  "plugin.name": "虛擬寵物",
+  "plugin.description": "照顧一個小小的桌面夥伴，透過溫柔的日常互動看著你們的羈絆成長。",
+  "hud.food": "食物",
+  "hud.energy": "能量",
+  "hud.play": "玩耍",
+  "hud.bond": "羈絆",
+  "config.sound.label": "動作聲音",
+  "config.sound.description": "餵食、玩耍、撫摸或休息等直接照顧動作可選擇播放聲音。",
+
+  "command.feed.title": "餵零食",
+  "command.feed.description": "給你的寵物餵一份零食。",
+  "command.play.title": "玩遊戲",
+  "command.play.description": "玩一個小遊戲。",
+  "command.pet.title": "撫摸",
+  "command.pet.description": "給你的寵物一點關愛。",
+  "command.nap.title": "讓牠休息",
+  "command.nap.description": "讓你的寵物休息 15 分鐘。",
+  "command.status.title": "查看寵物",
+  "command.status.description": "看看你的寵物感覺怎麼樣。",
+
+  "speech.feed.0": "謝謝你的零食！",
+  "speech.feed.1": "*嚼嚼嚼*",
+  "speech.feed.2": "好吃！",
+  "speech.feed.3": "太美味了！",
+
+  "speech.play.0": "真好玩！",
+  "speech.play.1": "耶！",
+  "speech.play.2": "我喜歡玩遊戲！",
+  "speech.play.3": "再來一次！",
+
+  "speech.pet.0": "呼嚕...",
+  "speech.pet.1": "*蹭蹭*",
+  "speech.pet.2": "暖暖的...",
+  "speech.pet.3": "好柔軟！",
+
+  "speech.nap.0": "Zzz...",
+  "speech.nap.1": "*蜷起來*",
+  "speech.nap.2": "困困的...",
+  "speech.nap.3": "休息中...",
+
+  "speech.levelup": "我們更親近了！",
+
+  "speech.status.sleeping": "Zzz...正在休息。",
+  "speech.status.hungry": "我有點餓了。",
+  "speech.status.tired": "我有點困。",
+  "speech.status.bored": "我想玩。",
+  "speech.status.happy": "我感覺棒極了！",
+  "speech.status.content": "我很滿足。",
+
+  "nudge.hungry": "我有點餓了。",
+  "nudge.tired": "我有點困了。",
+  "nudge.bored": "想一起玩嗎？",
+  "nudge.neglected": "可以陪陪我嗎？"
+}


### PR DESCRIPTION
## Summary

The virtual-pet plugin gets the same 7-locale coverage the other 8 official plugins already ship. `plugins/official/openpets.virtual-pet/locales/` previously contained only `en.json`, so non-English users saw English for every speech line, nudge, HUD string, and command title even after the i18n framework landed.

## Why this matters

#45 asked for i18n support so pet speech bubbles and UI strings follow the user's language. The framework half is done ("locally support is added, new langs can be easily added now"), and the sibling plugins each carry es-419, ja, ko, pt-BR, zh-Hans, and zh-Hant. This closes the parity gap for virtual-pet: six new locale files translating all keys in `en.json`, with terminology matched to the same locales in sibling plugins (for example `openpets.water-reminder`) so command titles and casual pet speech stay consistent.

## Testing

`node scripts/check-plugin-locales.mjs` passes: every locale file matches the `en.json` key set exactly (flat string values, no missing or extra keys).

Refs #45
