### PR TITLE
feat(cli): add openpets doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ When you configure an agent, OpenPets exposes standard MCP tools. The agent can 
   <img src="assets/claude.png" alt="Claude Code integration with OpenPets" width="100%" />
 </p>
 
+### Diagnose your setup
+Check whether the Claude hook and project Cursor MCP integrations are installed, need an update, or are broken, and whether the desktop app is reachable:
+```bash
+npx @open-pets/cli doctor
+```
+Pass `--cwd <path>` to inspect a different project's `.cursor/mcp.json`, or `--json` for machine-readable output. The command exits non-zero only when an integration is broken, so it is safe to run before reporting a bug.
+
 ### MCP Server Configuration
 To run OpenPets as an MCP tool, add the server to your agent's configuration:
 ```json

--- a/packages/cli/src/check-cli-contract.ts
+++ b/packages/cli/src/check-cli-contract.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 
-import { assertSafeProjectHookPath, cliPackageName, configureProject, createClaudeMcpAddJsonArgs, createLocalDevCliCommand, createVersionPinnedCliCommand, installProjectLocalHooks, parseConfigureArgs, parseInstallArgs, parsePluginNewArgs, parseReactArgs, parseSayArgs, resolveConfiguredPet, runClaudeMcpAddJson, scaffoldPlugin } from "./index.js";
+import { assertSafeProjectHookPath, cliPackageName, configureProject, createClaudeMcpAddJsonArgs, createLocalDevCliCommand, createVersionPinnedCliCommand, installProjectLocalHooks, parseConfigureArgs, parseDoctorArgs, parseInstallArgs, parsePluginNewArgs, parseReactArgs, parseSayArgs, resolveConfiguredPet, runClaudeMcpAddJson, runDoctor, scaffoldPlugin } from "./index.js";
 import { pluginTemplateNames } from "./plugin-templates.js";
 import { validatePluginFolder } from "./plugin-validate.js";
 
@@ -41,6 +41,14 @@ assert.deepEqual(parseSayArgs(["--reaction=success", "Tests", "passed"]), { mess
 assert.throws(() => parseSayArgs([]));
 assert.throws(() => parseSayArgs(["Hello", "--reaction", "bad"]));
 assert.throws(() => parseSayArgs(["Hello", "--unknown"]));
+
+assert.deepEqual(parseDoctorArgs([]), { cwd: process.cwd(), json: false });
+assert.equal(parseDoctorArgs(["--json"]).json, true);
+assert.equal(parseDoctorArgs(["--cwd", "/tmp/project"]).cwd, "/tmp/project");
+assert.equal(parseDoctorArgs(["--cwd=/tmp/project"]).cwd, "/tmp/project");
+assert.deepEqual(parseDoctorArgs(["--cwd=/tmp/project", "--json"]), { cwd: "/tmp/project", json: true });
+assert.throws(() => parseDoctorArgs(["--unknown"]));
+assert.throws(() => parseDoctorArgs(["--cwd"]));
 
 assert.deepEqual(parsePluginNewArgs(["My Plugin"]), { name: "My Plugin", id: "local.my-plugin", dir: "my-plugin", author: undefined, template: "blank" });
 assert.equal(parsePluginNewArgs(["My Plugin", "--id", "acme.my-plugin"]).id, "acme.my-plugin");
@@ -313,15 +321,50 @@ try {
   rmSync(dir, { recursive: true, force: true });
 }
 
+async function captureDoctorJson(cwd: string): Promise<Record<string, unknown>> {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let captured = "";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  process.stdout.write = ((chunk: any) => { captured += typeof chunk === "string" ? chunk : String(chunk); return true; }) as typeof process.stdout.write;
+  try {
+    await runDoctor({ cwd, json: true });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return JSON.parse(captured) as Record<string, unknown>;
+}
+
+const doctorInstalledProject = mkdtempSync(join(tmpdir(), "openpets-doctor-installed-"));
+mkdirSync(join(doctorInstalledProject, ".cursor"), { recursive: true });
+writeFileSync(
+  join(doctorInstalledProject, ".cursor", "mcp.json"),
+  JSON.stringify({ mcpServers: { openpets: { type: "stdio", command: "npx", args: ["-y", `@open-pets/mcp@${packageVersion}`] } } }, null, 2),
+  "utf8"
+);
+const doctorInstalledReport = await captureDoctorJson(doctorInstalledProject);
+assert.equal((doctorInstalledReport.cursor as { status?: string }).status, "installed");
+// The OpenPets app IPC is unreachable in CI, so doctor must report app state without throwing.
+assert.equal((doctorInstalledReport.app as { running?: boolean }).running, false);
+rmSync(doctorInstalledProject, { recursive: true, force: true });
+
+const doctorMissingProject = mkdtempSync(join(tmpdir(), "openpets-doctor-missing-"));
+const doctorMissingReport = await captureDoctorJson(doctorMissingProject);
+assert.equal((doctorMissingReport.cursor as { status?: string }).status, "missing");
+rmSync(doctorMissingProject, { recursive: true, force: true });
+
 const invalidHook = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, "hook", "--openpets-managed", "--pet", "bad/pet"], { input: JSON.stringify({ hook_event_name: "Notification" }), encoding: "utf8" });
 assert.equal(invalidHook.status, 1);
 const missingPetHook = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, "hook", "--openpets-managed", "--pet"], { input: JSON.stringify({ hook_event_name: "Notification" }), encoding: "utf8" });
 assert.equal(missingPetHook.status, 1);
 
-for (const args of [["--help"], ["-h"], ["status", "--help"], ["pets", "--help"], ["react", "--help"], ["say", "--help"], ["install", "--help"], ["configure", "--help"], ["configure", "-h"], ["plugin", "--help"], ["plugin", "new", "--help"], ["mcp", "--help"], ["hook", "--help"]]) {
+for (const args of [["--help"], ["-h"], ["status", "--help"], ["doctor", "--help"], ["pets", "--help"], ["react", "--help"], ["say", "--help"], ["install", "--help"], ["configure", "--help"], ["configure", "-h"], ["plugin", "--help"], ["plugin", "new", "--help"], ["mcp", "--help"], ["hook", "--help"]]) {
   const help = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, ...args], { encoding: "utf8" });
   assert.equal(help.status, 0);
   assert.match(help.stdout, /Usage:/);
 }
+
+const doctorHelp = spawnSync(process.execPath, [new URL("./index.js", import.meta.url).pathname, "doctor", "--help"], { encoding: "utf8" });
+assert.equal(doctorHelp.status, 0);
+assert.match(doctorHelp.stdout, /doctor/);
 
 console.error("CLI contract validation passed.");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { stdin as input, stdout as output } from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { allowedReactions, createOpenPetsClient, OpenPetsClientError, type OpenPetsPetListItem, type OpenPetsReaction } from "@open-pets/client";
-import { claudeHookEvents, openPetsHookMarker, removeOpenPetsHooks, runClaudeHookFromStdin, validateOpenPetsPetArg } from "@open-pets/claude";
+import { claudeHookEvents, doctorClaudeHooks, openPetsHookMarker, removeOpenPetsHooks, runClaudeHookFromStdin, validateOpenPetsPetArg } from "@open-pets/claude";
 import { buildCursorRulesPreview, buildOpenPetsOnlyPreview, classifyCursorMcpStatus, classifyCursorRulesStatus, executeCursorMcpWrite, executeCursorRulesWrite, getCursorProjectMcpPath, getCursorProjectRulesPath, planCursorMcpInstall, planCursorMcpReplace, planCursorRulesInstall, planCursorRulesRemove, planCursorRulesReplace, readCursorMcpConfig, readCursorOpenPetsRules } from "@open-pets/cursor";
 import { prepareOpenCodeProjectSetup, writePreparedOpenCodeProjectSetup } from "@open-pets/opencode";
 
@@ -38,6 +38,11 @@ interface ReactOptions {
 interface SayOptions {
   readonly message: string;
   readonly reaction?: OpenPetsReaction;
+}
+
+interface DoctorOptions {
+  readonly cwd: string;
+  readonly json: boolean;
 }
 
 interface CommandSpec {
@@ -101,6 +106,14 @@ async function main(): Promise<void> {
       return;
     }
     await showPets(args);
+    return;
+  }
+  if (command === "doctor") {
+    if (hasHelp(args)) {
+      printDoctorUsage();
+      return;
+    }
+    await runDoctor(parseDoctorArgs(args));
     return;
   }
   if (command === "react") {
@@ -182,6 +195,45 @@ async function showStatus(args: readonly string[]): Promise<void> {
   const result = await createOpenPetsClient().status();
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.ok || !result.appRunning) process.exitCode = 1;
+}
+
+export function parseDoctorArgs(args: readonly string[]): DoctorOptions {
+  let cwd = process.cwd();
+  let json = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--json") json = true;
+    else if (arg === "--cwd") { cwd = readRequiredArg(args, index, "--cwd"); index += 1; }
+    else if (arg.startsWith("--cwd=")) cwd = arg.slice("--cwd=".length);
+    else throw new CliError(`Unknown doctor option: ${arg}`);
+  }
+  return { cwd, json };
+}
+
+export async function runDoctor(options: DoctorOptions): Promise<void> {
+  const claude = doctorClaudeHooks();
+
+  const projectDir = resolveProjectDir(options.cwd);
+  const cursorConfigPath = getCursorProjectMcpPath(projectDir);
+  const cursorRead = readCursorMcpConfig(cursorConfigPath);
+  const cursor = classifyCursorMcpStatus(cursorRead, cursorConfigPath, { mcpVersion: getPackageVersion() });
+
+  const appStatus = await createOpenPetsClient().status();
+  const app = { running: appStatus.appRunning, reason: appStatus.unavailableReason };
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({
+      claude: { status: claude.status, settingsPath: claude.settingsPath, asyncSupported: claude.asyncSupported },
+      cursor: { status: cursor.status, configPath: cursor.configPath },
+      app,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`Claude hooks: ${claude.status} (${claude.settingsPath})\n`);
+    process.stdout.write(`Cursor MCP: ${cursor.status} (${cursor.configPath})\n`);
+    process.stdout.write(`OpenPets app: ${app.running ? "running" : `not running${app.reason ? ` (${app.reason})` : ""}`}\n`);
+  }
+
+  if (claude.status === "error" || cursor.status === "error" || cursor.status === "invalid") process.exitCode = 1;
 }
 
 async function showPets(args: readonly string[]): Promise<void> {
@@ -727,7 +779,7 @@ function getPackageVersion(): string {
 }
 
 function printUsage(): void {
-  process.stdout.write("Usage:\n  openpets status\n  openpets pets\n  openpets react <reaction>\n  openpets say <message> [--reaction <reaction>]\n  openpets install <pet-id>\n  openpets configure [--agent claude|opencode|cursor] [--pet <id>] [--cwd <path>] [--yes] [--force] [--with-rules|--rules-only|--remove-rules]\n  openpets plugin new <name> [--id <id>] [--dir <path>] [--author <name>]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
+  process.stdout.write("Usage:\n  openpets status\n  openpets doctor [--cwd <path>] [--json]\n  openpets pets\n  openpets react <reaction>\n  openpets say <message> [--reaction <reaction>]\n  openpets install <pet-id>\n  openpets configure [--agent claude|opencode|cursor] [--pet <id>] [--cwd <path>] [--yes] [--force] [--with-rules|--rules-only|--remove-rules]\n  openpets plugin new <name> [--id <id>] [--dir <path>] [--author <name>]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
 }
 
 function printPluginUsage(): void {
@@ -754,6 +806,10 @@ function printInstallUsage(): void {
 
 function printStatusUsage(): void {
   process.stdout.write("Usage:\n  openpets status\n\nChecks whether the OpenPets desktop app is reachable and prints the status response as JSON.\n");
+}
+
+function printDoctorUsage(): void {
+  process.stdout.write("Usage:\n  openpets doctor [--cwd <path>] [--json]\n\nReports whether the Claude hook and project Cursor MCP integrations are installed, need an update, or are broken, and whether the OpenPets desktop app is reachable.\n\nOptions:\n  --cwd <path>   Project directory to inspect for .cursor/mcp.json. Defaults to current directory.\n  --json         Print the report as JSON instead of labeled lines.\n  -h, --help     Show this help.\n");
 }
 
 function printPetsUsage(): void {


### PR DESCRIPTION
## Summary

Adds an `openpets doctor` command that reports, in one place, whether the Claude hook and project Cursor MCP integrations are installed, need an update, or are broken, plus whether the OpenPets desktop app is reachable. Supports `--cwd <path>` to point at a specific project and `--json` for machine-readable output.

## Why this matters

There was no read-only way to check integration health before reporting a problem, so users had to inspect `~/.claude/settings.json` and `.cursor/mcp.json` by hand. This is the command requested in https://github.com/alvinunreal/openpets/issues/9.

The command reuses existing detection functions: `doctorClaudeHooks()` from `@open-pets/claude` and `readCursorMcpConfig()` + `classifyCursorMcpStatus()` from `@open-pets/cursor`, so no new detection logic is introduced. It exits non-zero only when an integration reports `error` or `invalid`; a `not_installed` or `missing` integration is informational and exits 0, which keeps it safe to run in scripts. A missing or unreachable desktop app is reported as "not running" rather than throwing.

## Testing

Run from `packages/cli`:

```
pnpm typecheck   # passes
pnpm build       # passes
pnpm test        # CLI contract validation passed.
```

Added contract assertions in `packages/cli/src/check-cli-contract.ts` covering `parseDoctorArgs` (defaults, `--json`, `--cwd`/`--cwd=`, unknown-option and missing-value throws), a `runDoctor` run against a fixture project with an OpenPets `.cursor/mcp.json` (asserts `cursor.status` is `installed`), a fixture with no config (asserts `missing`), confirmation that `runDoctor` does not throw when the app IPC is unreachable, and a `doctor --help` smoke test that exits 0 and prints usage.

Manual run on a machine with no integrations:

```
$ openpets doctor
Claude hooks: not_installed (~/.claude/settings.json)
Cursor MCP: missing (.../.cursor/mcp.json)
OpenPets app: not running (...)
```

Fixes #9
