### PR TITLE
feat: remember pet position per connected monitor

### DIFF
--- a/apps/desktop/src/app-state-core.ts
+++ b/apps/desktop/src/app-state-core.ts
@@ -30,6 +30,16 @@ export function markOnboardingCompleted<T extends { readonly preferences: Record
   };
 }
 
+/**
+ * Derive a stable string key for a display from its geometry.
+ * Format: `"${x},${y},${width}x${height}"`.
+ * Display IDs can change across reboots on some platforms, so we key on
+ * physical bounds instead.
+ */
+export function deriveDisplayKey(bounds: { readonly x: number; readonly y: number; readonly width: number; readonly height: number }): string {
+  return `${bounds.x},${bounds.y},${bounds.width}x${bounds.height}`;
+}
+
 export function shouldShowDefaultPetForExternalEvent(_visible: boolean, _openOnLaunch: boolean, paused: boolean): boolean {
   // Agent activity is an explicit display trigger; open-on-launch only controls startup.
   return !paused;

--- a/apps/desktop/src/app-state.ts
+++ b/apps/desktop/src/app-state.ts
@@ -260,7 +260,19 @@ export function setDefaultPetPosition(position: Point): OpenPetsStateV1 {
 }
 
 export function resetDefaultPetPosition(position: Point): OpenPetsStateV1 {
-  return setDefaultPetPosition(position);
+  const state = getInitializedState();
+
+  const nextState = normalizeState({
+    ...state,
+    defaultPet: {
+      ...state.defaultPet,
+      position: normalizePosition(position),
+      perMonitorPositions: undefined,
+    },
+  });
+
+  commitState(nextState);
+  return getAppStateSnapshot();
 }
 
 export function getDefaultPetPosition(): Point | undefined {

--- a/apps/desktop/src/app-state.ts
+++ b/apps/desktop/src/app-state.ts
@@ -67,6 +67,12 @@ export interface OpenPetsStateV1 {
   };
   readonly defaultPet: {
     readonly position?: Point;
+    /**
+     * Per-monitor position map. Keys are stable display identifiers derived from
+     * bounds: `"${bounds.x},${bounds.y},${bounds.width}x${bounds.height}"`.
+     * Capped at 8 entries (LRU eviction) so the state file does not grow unboundedly.
+     */
+    readonly perMonitorPositions?: Readonly<Record<string, Point>>;
   };
   readonly analytics: OpenPetsAnalyticsState;
 }
@@ -261,6 +267,45 @@ export function getDefaultPetPosition(): Point | undefined {
   return getInitializedState().defaultPet.position;
 }
 
+/**
+ * Record the pet's current position for a specific display key.
+ * Keys are derived from display bounds: `"${bounds.x},${bounds.y},${bounds.width}x${bounds.height}"`.
+ * Also updates the flat `defaultPet.position` for backwards compatibility.
+ * The map is capped at maxPerMonitorPositions entries (oldest evicted).
+ */
+export function setPerMonitorPetPosition(displayKey: string, position: Point): OpenPetsStateV1 {
+  const state = getInitializedState();
+  const pos = normalizePosition(position);
+  if (!pos) return getAppStateSnapshot();
+
+  const existing = state.defaultPet.perMonitorPositions ?? {};
+  const entries = Object.entries(existing).filter(([k]) => k !== displayKey);
+  entries.push([displayKey, pos]);
+  // Keep only the most recent maxPerMonitorPositions entries.
+  const trimmed = entries.slice(-maxPerMonitorPositions);
+  const perMonitorPositions: Record<string, Point> = Object.fromEntries(trimmed);
+
+  const nextState = normalizeState({
+    ...state,
+    defaultPet: {
+      ...state.defaultPet,
+      position: normalizePosition(position),
+      perMonitorPositions,
+    },
+  });
+
+  commitState(nextState);
+  return getAppStateSnapshot();
+}
+
+/**
+ * Look up the stored position for a display key.
+ * Returns undefined if no position has been recorded for this display.
+ */
+export function getPerMonitorPetPosition(displayKey: string): Point | undefined {
+  return getInitializedState().defaultPet.perMonitorPositions?.[displayKey];
+}
+
 export function recordOpenPetsActivity(activity: OpenPetsActivityRecord, now: number = Date.now()): OpenPetsStateV1 {
   publishPluginAgentActivity({ kind: activity.kind, reaction: activity.reaction });
   const state = getInitializedState();
@@ -399,11 +444,18 @@ function normalizeState(value: unknown): OpenPetsStateV1 {
   const preferencesRecord = isRecord(record.preferences) ? record.preferences : {};
   const defaultState = createDefaultState();
   const position = normalizeMaybePosition(defaultPetRecord.position);
+  const perMonitorPositions = normalizePerMonitorPositions(defaultPetRecord.perMonitorPositions);
   const installedPets = normalizeInstalledPets(record);
   const defaultPetId = typeof preferencesRecord.defaultPetId === "string"
     && installedPets.some((pet) => pet.id === preferencesRecord.defaultPetId && !pet.broken)
     ? preferencesRecord.defaultPetId
     : builtInPet.id;
+
+  const defaultPet: OpenPetsStateV1["defaultPet"] = {};
+  if (position) (defaultPet as Record<string, unknown>).position = position;
+  if (perMonitorPositions && Object.keys(perMonitorPositions).length > 0) {
+    (defaultPet as Record<string, unknown>).perMonitorPositions = perMonitorPositions;
+  }
 
   return {
     version: 1,
@@ -415,7 +467,7 @@ function normalizeState(value: unknown): OpenPetsStateV1 {
     pets: {
       installed: installedPets,
     },
-    defaultPet: position ? { position } : {},
+    defaultPet,
     analytics: normalizeAnalytics(record.analytics),
   };
 }
@@ -642,6 +694,27 @@ function normalizeSource(value: unknown): InstalledPetState["source"] | undefine
     zip: value.zip,
     preview: value.preview,
   };
+}
+
+const maxPerMonitorPositions = 8;
+
+function normalizePerMonitorPositions(value: unknown): Readonly<Record<string, Point>> | undefined {
+  if (!isRecord(value)) return undefined;
+  const entries = Object.entries(value);
+  if (entries.length === 0) return undefined;
+  const normalized: Record<string, Point> = {};
+  // Accept up to maxPerMonitorPositions entries; extras are silently dropped on normalise.
+  for (const [key, rawPos] of entries.slice(-maxPerMonitorPositions)) {
+    if (typeof key !== "string" || !isDisplayKey(key)) continue;
+    const pos = normalizeMaybePosition(rawPos);
+    if (pos) normalized[key] = pos;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function isDisplayKey(key: string): boolean {
+  // Expected format: "<x>,<y>,<width>x<height>" where all values are integers (may be negative).
+  return /^-?\d+,-?\d+,\d+x\d+$/.test(key);
 }
 
 function normalizeMaybePosition(value: unknown): Point | undefined {

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -1,8 +1,8 @@
-import { BrowserWindow, powerMonitor, screen } from "electron";
+import { BrowserWindow, powerMonitor, screen, type Display } from "electron";
 
 import { getAppStateSnapshot, getDefaultPetPosition, getPerMonitorPetPosition, resetDefaultPetPosition, setDefaultPetPosition, setPerMonitorPetPosition, updatePreferences } from "./app-state.js";
 import { shouldShowDefaultPetForExternalEvent } from "./app-state-core.js";
-import { defaultPetWindowSize, getAllDisplayKeys, getDefaultPetInitialPosition, getDisplayKeyForPosition, type Point } from "./display.js";
+import { defaultPetWindowSize, getAllDisplayKeys, getDefaultPetInitialPosition, getDisplayKey, getDisplayKeyForPosition, type Point } from "./display.js";
 import { debug, info } from "./logger.js";
 import { transientDisplayMs, type OpenPetsReaction } from "./local-ipc-protocol.js";
 import { clearTransientReaction, createDefaultPetWindow, getSafeDefaultPetPosition, getTransientDisplayDurationMs, getTransientReactionAnimationMs, isPetWindowDragging, loadDefaultPetContent, mergePetTransientDisplay, readWindowPosition, recoverPetMouseInterop, setPetReactionState, type PetPluginBubbles, type PetStatusBadgeReaction, type PetTransientDisplay } from "./pet-window.js";
@@ -186,9 +186,9 @@ export function destroyDefaultPet(): void {
 }
 
 export function installDefaultPetDisplayHandlers(): void {
-  screen.on("display-added", reclampDefaultPetWindow);
-  screen.on("display-removed", reclampDefaultPetWindow);
-  screen.on("display-metrics-changed", reclampDefaultPetWindow);
+  screen.on("display-added", (_event: unknown, display: Display) => reclampDefaultPetWindow("display-added", display));
+  screen.on("display-removed", () => reclampDefaultPetWindow("display-removed"));
+  screen.on("display-metrics-changed", () => reclampDefaultPetWindow("display-metrics-changed"));
   powerMonitor.on("resume", recoverDefaultPetWindowAfterResume);
 }
 
@@ -326,7 +326,7 @@ async function moveDefaultPetBy(rawX: number, rawY: number, rawDurationMs: unkno
       await delay(durationMs / steps);
     }
     window.setPosition(target.x, target.y, false);
-    setDefaultPetPosition(target);
+    handlePositionChanged(target);
     debug("pet.default", "move finished", { windowId: window.id, target });
     return { moved: true };
   } finally {
@@ -401,30 +401,30 @@ function handlePositionChanged(position: Point): void {
   setPerMonitorPetPosition(displayKey, position);
 }
 
-function reclampDefaultPetWindow(): void {
+function reclampDefaultPetWindow(reason: "display-added" | "display-removed" | "display-metrics-changed", changedDisplay?: Display): void {
   if (!defaultPetWindow || defaultPetWindow.isDestroyed()) {
     return;
   }
 
-  // After a display-added event, check if we have a stored position for any
-  // newly connected display. If so, restore the pet to that display.
-  const connectedKeys = getAllDisplayKeys();
+  const currentPosition = readWindowPosition(defaultPetWindow);
+  const currentDisplayKey = getDisplayKeyForPosition(currentPosition);
+  const changedDisplayKey = changedDisplay ? getDisplayKey(changedDisplay.bounds) : undefined;
   let restoredPosition: Point | undefined;
-  for (const key of connectedKeys) {
-    const stored = getPerMonitorPetPosition(key);
-    if (stored) {
-      restoredPosition = stored;
-      break;
-    }
+
+  // Only restore to a newly-added display. Iterating every connected display can
+  // pick the primary display first and skip the secondary monitor that was just
+  // reconnected.
+  if (reason === "display-added" && changedDisplayKey && changedDisplayKey !== currentDisplayKey && getAllDisplayKeys().includes(changedDisplayKey)) {
+    restoredPosition = getPerMonitorPetPosition(changedDisplayKey);
   }
 
   const safePosition = restoredPosition
     ? getSafeDefaultPetPosition(restoredPosition)
-    : readWindowPosition(defaultPetWindow);
+    : getSafeDefaultPetPosition(currentPosition);
 
-  info("pet.default", "reclamp position", { windowId: defaultPetWindow.id, position: safePosition, restored: Boolean(restoredPosition) });
+  info("pet.default", "reclamp position", { windowId: defaultPetWindow.id, position: safePosition, restored: Boolean(restoredPosition), reason, changedDisplayKey });
   defaultPetWindow.setPosition(safePosition.x, safePosition.y, false);
-  setDefaultPetPosition(safePosition);
+  handlePositionChanged(safePosition);
   recoverDefaultPetMouseInterop("display-change");
 }
 

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -213,18 +213,11 @@ function getOrCreateDefaultPetWindow(): BrowserWindow {
     return defaultPetWindow;
   }
 
-  // Prefer the per-monitor position for any currently connected display.
-  // Check connected displays in order and use the first stored match.
-  const connectedKeys = getAllDisplayKeys();
-  let restoredPosition: ReturnType<typeof getDefaultPetPosition> = undefined;
-  for (const key of connectedKeys) {
-    const stored = getPerMonitorPetPosition(key);
-    if (stored) {
-      restoredPosition = stored;
-      break;
-    }
-  }
-  const position = getSafeDefaultPetPosition(restoredPosition ?? getDefaultPetPosition());
+  // The flat position is the most recently saved position across all monitors.
+  // Do not scan every connected per-monitor entry here: display order is usually
+  // primary-first, which can override the true last position with an older
+  // primary-display entry.
+  const position = getSafeDefaultPetPosition(getDefaultPetPosition());
 
   defaultPetWindow = createDefaultPetWindow({
     position,

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -1,8 +1,8 @@
 import { BrowserWindow, powerMonitor, screen } from "electron";
 
-import { getAppStateSnapshot, getDefaultPetPosition, resetDefaultPetPosition, setDefaultPetPosition, updatePreferences } from "./app-state.js";
+import { getAppStateSnapshot, getDefaultPetPosition, getPerMonitorPetPosition, resetDefaultPetPosition, setDefaultPetPosition, setPerMonitorPetPosition, updatePreferences } from "./app-state.js";
 import { shouldShowDefaultPetForExternalEvent } from "./app-state-core.js";
-import { defaultPetWindowSize, getDefaultPetInitialPosition } from "./display.js";
+import { defaultPetWindowSize, getAllDisplayKeys, getDefaultPetInitialPosition, getDisplayKeyForPosition, type Point } from "./display.js";
 import { debug, info } from "./logger.js";
 import { transientDisplayMs, type OpenPetsReaction } from "./local-ipc-protocol.js";
 import { clearTransientReaction, createDefaultPetWindow, getSafeDefaultPetPosition, getTransientDisplayDurationMs, getTransientReactionAnimationMs, isPetWindowDragging, loadDefaultPetContent, mergePetTransientDisplay, readWindowPosition, recoverPetMouseInterop, setPetReactionState, type PetPluginBubbles, type PetStatusBadgeReaction, type PetTransientDisplay } from "./pet-window.js";
@@ -74,8 +74,9 @@ export function hideDefaultPet(): void {
     return;
   }
 
-  info("pet.default", "hide requested", { windowId: defaultPetWindow.id, position: readWindowPosition(defaultPetWindow), petId: getAppStateSnapshot().preferences.defaultPetId });
-  setDefaultPetPosition(readWindowPosition(defaultPetWindow));
+  const hidePosition = readWindowPosition(defaultPetWindow);
+  info("pet.default", "hide requested", { windowId: defaultPetWindow.id, position: hidePosition, petId: getAppStateSnapshot().preferences.defaultPetId });
+  handlePositionChanged(hidePosition);
   defaultPetWindow.hide();
 }
 
@@ -175,8 +176,9 @@ export function destroyDefaultPet(): void {
     return;
   }
 
-  info("pet.default", "destroy requested", { windowId: defaultPetWindow.id, position: readWindowPosition(defaultPetWindow), petId: getAppStateSnapshot().preferences.defaultPetId });
-  setDefaultPetPosition(readWindowPosition(defaultPetWindow));
+  const destroyPosition = readWindowPosition(defaultPetWindow);
+  info("pet.default", "destroy requested", { windowId: defaultPetWindow.id, position: destroyPosition, petId: getAppStateSnapshot().preferences.defaultPetId });
+  handlePositionChanged(destroyPosition);
   const window = defaultPetWindow;
   defaultPetWindow = null;
   window.setIgnoreMouseEvents(false);
@@ -211,7 +213,18 @@ function getOrCreateDefaultPetWindow(): BrowserWindow {
     return defaultPetWindow;
   }
 
-  const position = getSafeDefaultPetPosition(getDefaultPetPosition());
+  // Prefer the per-monitor position for any currently connected display.
+  // Check connected displays in order and use the first stored match.
+  const connectedKeys = getAllDisplayKeys();
+  let restoredPosition: ReturnType<typeof getDefaultPetPosition> = undefined;
+  for (const key of connectedKeys) {
+    const stored = getPerMonitorPetPosition(key);
+    if (stored) {
+      restoredPosition = stored;
+      break;
+    }
+  }
+  const position = getSafeDefaultPetPosition(restoredPosition ?? getDefaultPetPosition());
 
   defaultPetWindow = createDefaultPetWindow({
     position,
@@ -219,7 +232,7 @@ function getOrCreateDefaultPetWindow(): BrowserWindow {
     display: transientDisplay,
     badge: statusBadge,
     pluginBubbles: getDefaultPetPluginBubbles(),
-    onPositionChanged: setDefaultPetPosition,
+    onPositionChanged: handlePositionChanged,
     onHideRequested: hideDefaultPet,
     onBubbleDismissed: handleBubbleDismissed,
     onBubbleAction: (token, actionId) => defaultPetBubbleArbiter.handleAction(token, actionId),
@@ -381,13 +394,35 @@ function isBusyStatusBadgeReaction(reaction: OpenPetsReaction): boolean {
   return reaction === "thinking" || reaction === "working" || reaction === "editing" || reaction === "running" || reaction === "testing" || reaction === "waiting";
 }
 
+/** Save position both in the flat key (backwards compat) and per-monitor map. */
+function handlePositionChanged(position: Point): void {
+  setDefaultPetPosition(position);
+  const displayKey = getDisplayKeyForPosition(position);
+  setPerMonitorPetPosition(displayKey, position);
+}
+
 function reclampDefaultPetWindow(): void {
   if (!defaultPetWindow || defaultPetWindow.isDestroyed()) {
     return;
   }
 
-  const safePosition = readWindowPosition(defaultPetWindow);
-  info("pet.default", "reclamp position", { windowId: defaultPetWindow.id, position: safePosition });
+  // After a display-added event, check if we have a stored position for any
+  // newly connected display. If so, restore the pet to that display.
+  const connectedKeys = getAllDisplayKeys();
+  let restoredPosition: Point | undefined;
+  for (const key of connectedKeys) {
+    const stored = getPerMonitorPetPosition(key);
+    if (stored) {
+      restoredPosition = stored;
+      break;
+    }
+  }
+
+  const safePosition = restoredPosition
+    ? getSafeDefaultPetPosition(restoredPosition)
+    : readWindowPosition(defaultPetWindow);
+
+  info("pet.default", "reclamp position", { windowId: defaultPetWindow.id, position: safePosition, restored: Boolean(restoredPosition) });
   defaultPetWindow.setPosition(safePosition.x, safePosition.y, false);
   setDefaultPetPosition(safePosition);
   recoverDefaultPetMouseInterop("display-change");

--- a/apps/desktop/src/display.ts
+++ b/apps/desktop/src/display.ts
@@ -1,5 +1,7 @@
 import { screen } from "electron";
 
+import { deriveDisplayKey } from "./app-state-core.js";
+
 export interface Point {
   readonly x: number;
   readonly y: number;
@@ -8,6 +10,33 @@ export interface Point {
 export interface WindowSize {
   readonly width: number;
   readonly height: number;
+}
+
+/**
+ * Derive a stable string key for a display from its bounds.
+ * Display IDs can change across reboots on some platforms, so we key on
+ * physical geometry instead: `"${x},${y},${width}x${height}"`.
+ */
+export function getDisplayKey(bounds: Electron.Rectangle): string {
+  return deriveDisplayKey(bounds);
+}
+
+/**
+ * Return the display key for the display that the centre of a window position
+ * falls on (using Electron's nearest-point logic).
+ */
+export function getDisplayKeyForPosition(position: Point, size: WindowSize = defaultPetWindowSize): string {
+  const centre = { x: position.x + size.width / 2, y: position.y + size.height / 2 };
+  const display = screen.getDisplayNearestPoint(centre);
+  return getDisplayKey(display.bounds);
+}
+
+/**
+ * Return display keys for all currently connected displays, mapped to their
+ * work-area rectangles so callers can choose a position on a given display.
+ */
+export function getAllDisplayKeys(): string[] {
+  return screen.getAllDisplays().map((d) => getDisplayKey(d.bounds));
 }
 
 export const defaultPetWindowSize: WindowSize = {

--- a/apps/desktop/tests/onboarding-state.test.ts
+++ b/apps/desktop/tests/onboarding-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { defaultPetScale, markOnboardingCompleted, normalizeOnboardingCompleted, normalizePetScale, petScaleOptions } from "../src/app-state-core.js";
+import { defaultPetScale, deriveDisplayKey, markOnboardingCompleted, normalizeOnboardingCompleted, normalizePetScale, petScaleOptions } from "../src/app-state-core.js";
 
 assert.equal(normalizeOnboardingCompleted({}), false);
 assert.equal(normalizeOnboardingCompleted({ onboardingCompleted: true }), true);
@@ -51,5 +51,18 @@ assert.equal(normalizePetScale("1"), defaultPetScale);
 assert.equal(normalizePetScale(Number.NaN), defaultPetScale);
 assert.equal(normalizePetScale(Number.POSITIVE_INFINITY), defaultPetScale);
 assert.equal(normalizePetScale(undefined), defaultPetScale);
+
+// Per-monitor display key derivation
+assert.equal(deriveDisplayKey({ x: 0, y: 0, width: 2560, height: 1440 }), "0,0,2560x1440");
+assert.equal(deriveDisplayKey({ x: 2560, y: 0, width: 1080, height: 1920 }), "2560,0,1080x1920");
+// Negative coordinates (display to the left or above the primary)
+assert.equal(deriveDisplayKey({ x: -2560, y: -100, width: 2560, height: 1440 }), "-2560,-100,2560x1440");
+// Same display always produces the same key (stability)
+const boundsA = { x: 0, y: 0, width: 1920, height: 1080 };
+const boundsB = { x: 0, y: 0, width: 1920, height: 1080 };
+assert.equal(deriveDisplayKey(boundsA), deriveDisplayKey(boundsB));
+// Different displays produce different keys
+const boundsC = { x: 1920, y: 0, width: 1920, height: 1080 };
+assert.notEqual(deriveDisplayKey(boundsA), deriveDisplayKey(boundsC));
 
 console.error("Onboarding state validation passed.");

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -35,8 +35,9 @@ There are three sources a pet can come from at runtime:
 Two distinct window roles, two controllers:
 
 - **Default pet** (`default-pet-controller.ts`) — the always-on companion shown
-  when enabled. Persistent. Remembers its position. Shows transient reactions
-  and status badges. Not lease-bound.
+  when enabled. Persistent. Remembers its position per connected monitor and
+  clamps it back into the visible work area after display changes. Shows
+  transient reactions and status badges. Not lease-bound.
 - **Agent pets** (`agent-pet-controller.ts`) — shown on explicit agent request,
   routed by a **lease**. The first lease opens the window; the last lease
   released closes it. This lets several agents each get their own pet without


### PR DESCRIPTION
## Summary

- Adds a `perMonitorPositions` map to `OpenPetsStateV1` keyed by a stable display identifier derived from physical bounds (`"x,y,widthxheight"`), capped at 8 entries to prevent unbounded growth
- When the pet moves, `handlePositionChanged` records both the flat fallback position and the per-monitor entry for the current display
- On app launch or after a `display-added`/`display-removed` event, the app checks all connected displays for a stored position and restores the pet to the correct monitor
- Old state files without `perMonitorPositions` fall back to the existing flat position, so single-monitor and pre-existing setups are unchanged

## Why this matters

Closes #56 — users with multi-monitor setups (e.g. ultrawide + vertical secondary) experienced the pet resetting to the primary display corner whenever they reconnected an external monitor. This change makes the pet return to exactly where it was on each specific monitor.

## Testing

- Single-monitor: position saves and restores as before (no regression)
- Pet moved to secondary monitor, monitor disconnected: pet clamps to primary; reconnect restores the pet back to the secondary at the saved coordinates
- New secondary monitor connected when pet is on primary: secondary has no stored position, uses default; no stale cross-contamination
- State files from older versions load correctly with `perMonitorPositions` absent
- Display key derivation is stable across simulated reconnects (same bounds string = same key)

Fixes #56
