### PR TITLE
fix: stop pet window stealing focus on Linux while keeping bubble inputs focusable

### DIFF
--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -17,7 +17,7 @@ import type { ActiveBubble } from "./plugin-bubble-arbiter.js";
 import type { PluginBubbleIndicator, PluginCommandForm, PluginBubbleHud, PluginBubbleHudItem } from "./plugin-sdk-bridge.js";
 import { defaultPetSprite, motionToSpriteState, resolveReactionSpriteState, type PetMotionState, type UniversalSpriteState } from "./reaction-animation-mapping.js";
 import { isFocusActionAvailable } from "./capabilities.js";
-import { computeEffectiveWaylandBackend } from "./wayland-backend.js";
+import { computeEffectiveWaylandBackend, shouldPetWindowBeFocusable } from "./wayland-backend.js";
 
 export interface PetWindowInteractionHooks {
   readonly onBubbleDismissed?: (dismissToken: string) => void;
@@ -612,6 +612,7 @@ function createBasePetWindow(title: string, position: Point): BrowserWindow {
     fullscreenable: false,
     skipTaskbar: true,
     alwaysOnTop: true,
+    focusable: shouldPetWindowBeFocusable(process.platform, isEffectiveWaylandBackend()),
     show: false,
     hasShadow: false,
     backgroundColor: "#00000000",

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -80,6 +80,7 @@ const petWindowRenderCache = new WeakMap<BrowserWindow, string>();
 
 const windowLoadChains = new WeakMap<BrowserWindow, Promise<void>>();
 const windowLoadSequences = new WeakMap<BrowserWindow, number>();
+const petWindowFocusPolicy = new WeakMap<BrowserWindow, boolean>();
 const petMouseInteropRecovery = new WeakMap<BrowserWindow, (reason: string) => void>();
 const petWindowDragging = new WeakMap<BrowserWindow, boolean>();
 
@@ -123,7 +124,9 @@ export function isPetWindowDragging(window: BrowserWindow): boolean {
 }
 
 export function createDefaultPetWindow(options: DefaultPetWindowOptions, dismissToken?: string): BrowserWindow {
-  const window = createBasePetWindow("OpenPets — Default Pet", options.position);
+  const window = createBasePetWindow("OpenPets — Default Pet", options.position, {
+    hasInteractiveInput: petPluginBubblesHaveInteractiveInput(options.pluginBubbles ?? null),
+  });
   info("pet.window", "default window create", { windowId: window.id, position: options.position, paused: options.paused, hasDisplay: Boolean(options.display), badge: options.badge });
   installMousePassthroughAndDrag(window, options);
   installMotionStatePublisher(window);
@@ -597,7 +600,9 @@ function isScreenPoint(value: unknown): value is { readonly screenX: number; rea
   return typeof value === "object" && value !== null && typeof (value as { readonly screenX?: unknown }).screenX === "number" && typeof (value as { readonly screenY?: unknown }).screenY === "number";
 }
 
-function createBasePetWindow(title: string, position: Point): BrowserWindow {
+function createBasePetWindow(title: string, position: Point, focusOptions: { readonly hasInteractiveInput?: boolean } = {}): BrowserWindow {
+  const effectiveWaylandBackend = isEffectiveWaylandBackend();
+  const focusable = shouldPetWindowBeFocusable(process.platform, effectiveWaylandBackend, focusOptions.hasInteractiveInput === true);
   const window = new BrowserWindow({
     title,
     width: defaultPetWindowSize.width,
@@ -612,7 +617,7 @@ function createBasePetWindow(title: string, position: Point): BrowserWindow {
     fullscreenable: false,
     skipTaskbar: true,
     alwaysOnTop: true,
-    focusable: shouldPetWindowBeFocusable(process.platform, isEffectiveWaylandBackend()),
+    focusable,
     show: false,
     hasShadow: false,
     backgroundColor: "#00000000",
@@ -624,6 +629,7 @@ function createBasePetWindow(title: string, position: Point): BrowserWindow {
     },
   });
 
+  petWindowFocusPolicy.set(window, focusable);
   window.setMenu(null);
   applyPetAlwaysOnTop(window);
   window.on("show", () => applyPetAlwaysOnTop(window));
@@ -675,6 +681,7 @@ function applyPetAlwaysOnTop(window: BrowserWindow): void {
 export async function loadDefaultPetContent(window: BrowserWindow, paused: boolean, display: PetTransientDisplay | null = null, badge: PetStatusBadgeReaction | null = null, dismissToken?: string, pluginBubbles: PetPluginBubbles | null = null): Promise<void> {
   const sequence = allocateWindowLoadSequence(window);
   debug("pet.window", "default content render begin", { windowId: window.id, sequence, paused, hasDisplay: Boolean(display), reaction: display?.reaction, hasMessage: Boolean(display?.message), badge, hasPluginBubble: Boolean(pluginBubbles?.transient), hasPinned: Boolean(pluginBubbles?.pinned), defaultPetId: getAppStateSnapshot().preferences.defaultPetId });
+  applyPetWindowFocusPolicy(window, petPluginBubblesHaveInteractiveInput(pluginBubbles));
   const render = await createDefaultPetRender(paused, display, badge, dismissToken, pluginBubbles);
   applyLinuxPetWindowShape(window, getAppStateSnapshot().preferences.petScale as PetScaleValue, Boolean(display?.message || display?.reactionMessage || display?.reaction || badge || paused || pluginBubbles?.transient || pluginBubbles?.pinned));
   if (tryUpdateLoadedPetContent(window, render, "default", sequence)) return;
@@ -689,6 +696,7 @@ export async function loadDefaultPetContent(window: BrowserWindow, paused: boole
 export async function loadExplicitPetContent(window: BrowserWindow, petId: string, display: PetTransientDisplay | null = null, badge: PetStatusBadgeReaction | null = null, dismissToken?: string, scaleOverride?: PetScaleValue, pluginBubbles: PetPluginBubbles | null = null): Promise<void> {
   const sequence = allocateWindowLoadSequence(window);
   try {
+    applyPetWindowFocusPolicy(window, petPluginBubblesHaveInteractiveInput(pluginBubbles));
     const state = getAppStateSnapshot();
     const pet = state.pets.installed.find((candidate) => candidate.id === petId);
     if (!pet || pet.broken || pet.id === builtInPet.id) {
@@ -704,6 +712,24 @@ export async function loadExplicitPetContent(window: BrowserWindow, petId: strin
   } catch (error: unknown) {
     logError("pet.window", "explicit content load failed", error instanceof Error ? error : { petId, error });
     console.error(`Failed to load explicit pet ${petId} URL.`, error);
+  }
+}
+
+function petPluginBubblesHaveInteractiveInput(pluginBubbles: PetPluginBubbles | null | undefined): boolean {
+  return Boolean(pluginBubbles?.transient?.bubble.input || pluginBubbles?.pinned?.bubble.input);
+}
+
+function applyPetWindowFocusPolicy(window: BrowserWindow, hasInteractiveInput: boolean): void {
+  if (window.isDestroyed()) return;
+  const effectiveWaylandBackend = isEffectiveWaylandBackend();
+  const focusable = shouldPetWindowBeFocusable(process.platform, effectiveWaylandBackend, hasInteractiveInput);
+  if (petWindowFocusPolicy.get(window) === focusable) return;
+  try {
+    window.setFocusable(focusable);
+    petWindowFocusPolicy.set(window, focusable);
+    debug("pet.window", "focus policy applied", { windowId: window.id, focusable, hasInteractiveInput, platform: process.platform, effectiveWaylandBackend });
+  } catch (error) {
+    logError("pet.window", "focus policy failed", error instanceof Error ? error : { windowId: window.id, focusable, hasInteractiveInput, error });
   }
 }
 

--- a/apps/desktop/src/wayland-backend.ts
+++ b/apps/desktop/src/wayland-backend.ts
@@ -36,12 +36,15 @@ export function computeEffectiveWaylandBackend(
  *
  * Linux compositors, especially native Wayland compositors such as Niri, can
  * treat the pet as a normal focusable toplevel unless Electron opts it out.
- * Keep the overlay non-focusable on Linux while preserving the existing
- * focusable behavior on macOS and Windows.
+ * Keep passive overlays non-focusable on Linux, but allow focus when a plugin
+ * bubble hosts an inline input/select that needs keyboard input. Preserve the
+ * existing focusable behavior on macOS and Windows.
  */
 export function shouldPetWindowBeFocusable(
   platform: NodeJS.Platform | string,
   _effectiveWaylandBackend: boolean,
+  hasInteractiveInput = false,
 ): boolean {
+  if (hasInteractiveInput) return true;
   return platform !== "linux";
 }

--- a/apps/desktop/src/wayland-backend.ts
+++ b/apps/desktop/src/wayland-backend.ts
@@ -30,3 +30,18 @@ export function computeEffectiveWaylandBackend(
   // ozone is "" or "auto" — fall back to session-type env vars.
   return xdgSessionType === "wayland" || Boolean(waylandDisplay);
 }
+
+/**
+ * Whether the transparent pet overlay should be allowed to receive input focus.
+ *
+ * Linux compositors, especially native Wayland compositors such as Niri, can
+ * treat the pet as a normal focusable toplevel unless Electron opts it out.
+ * Keep the overlay non-focusable on Linux while preserving the existing
+ * focusable behavior on macOS and Windows.
+ */
+export function shouldPetWindowBeFocusable(
+  platform: NodeJS.Platform | string,
+  _effectiveWaylandBackend: boolean,
+): boolean {
+  return platform !== "linux";
+}

--- a/apps/desktop/tests/pet-window-wayland-predicate.test.ts
+++ b/apps/desktop/tests/pet-window-wayland-predicate.test.ts
@@ -40,13 +40,21 @@ describe("computeEffectiveWaylandBackend (production predicate)", () => {
 });
 
 describe("shouldPetWindowBeFocusable", () => {
-  it("keeps Linux pet windows non-focusable", () => {
+  it("keeps passive Linux pet windows non-focusable", () => {
+    assert.equal(shouldPetWindowBeFocusable("linux", true, false), false);
+    assert.equal(shouldPetWindowBeFocusable("linux", false, false), false);
     assert.equal(shouldPetWindowBeFocusable("linux", true), false);
-    assert.equal(shouldPetWindowBeFocusable("linux", false), false);
+  });
+
+  it("allows Linux pet windows with interactive inputs to receive focus", () => {
+    assert.equal(shouldPetWindowBeFocusable("linux", true, true), true);
+    assert.equal(shouldPetWindowBeFocusable("linux", false, true), true);
   });
 
   it("preserves focusable pet windows on macOS and Windows", () => {
-    assert.equal(shouldPetWindowBeFocusable("darwin", false), true);
-    assert.equal(shouldPetWindowBeFocusable("win32", false), true);
+    assert.equal(shouldPetWindowBeFocusable("darwin", false, false), true);
+    assert.equal(shouldPetWindowBeFocusable("darwin", false, true), true);
+    assert.equal(shouldPetWindowBeFocusable("win32", false, false), true);
+    assert.equal(shouldPetWindowBeFocusable("win32", false, true), true);
   });
 });

--- a/apps/desktop/tests/pet-window-wayland-predicate.test.ts
+++ b/apps/desktop/tests/pet-window-wayland-predicate.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { computeEffectiveWaylandBackend } from "../src/wayland-backend.js";
+import { computeEffectiveWaylandBackend, shouldPetWindowBeFocusable } from "../src/wayland-backend.js";
 
 // ─── real-function predicate tests ───────────────────────────────────────────
 // These exercise the REAL production predicate — the pure, Electron-free core
@@ -36,5 +36,17 @@ describe("computeEffectiveWaylandBackend (production predicate)", () => {
     assert.equal(computeEffectiveWaylandBackend("linux", "", undefined, "/run/user/1000/wayland-0"), true);
     assert.equal(computeEffectiveWaylandBackend("linux", "", undefined, undefined), false);
     assert.equal(computeEffectiveWaylandBackend("linux", "", undefined, ""), false);
+  });
+});
+
+describe("shouldPetWindowBeFocusable", () => {
+  it("keeps Linux pet windows non-focusable", () => {
+    assert.equal(shouldPetWindowBeFocusable("linux", true), false);
+    assert.equal(shouldPetWindowBeFocusable("linux", false), false);
+  });
+
+  it("preserves focusable pet windows on macOS and Windows", () => {
+    assert.equal(shouldPetWindowBeFocusable("darwin", false), true);
+    assert.equal(shouldPetWindowBeFocusable("win32", false), true);
   });
 });

--- a/docs/wayland.md
+++ b/docs/wayland.md
@@ -37,6 +37,13 @@ Speech bubbles and other non-drag UI remain regular client content. Emoji/status
 glyph rendering is handled by the bundled `NotoColorEmoji.ttf`, so fresh Linux
 installs do not depend on system emoji fonts.
 
+Pet windows are created as non-focusable on Linux and are shown inactive, so the
+transparent overlay should not take keyboard focus when it appears or re-assert
+focus during the session. This addresses the focus-stealing class of issues on
+Wayland compositors such as Niri, but it does not change the accepted native
+Wayland limitations around cross-workspace stickiness or compositor-controlled
+window placement.
+
 ## Reproduction and validation notes
 
 The KDE Wayland repro VM lives at:

--- a/docs/wayland.md
+++ b/docs/wayland.md
@@ -37,12 +37,15 @@ Speech bubbles and other non-drag UI remain regular client content. Emoji/status
 glyph rendering is handled by the bundled `NotoColorEmoji.ttf`, so fresh Linux
 installs do not depend on system emoji fonts.
 
-Pet windows are created as non-focusable on Linux and are shown inactive, so the
-transparent overlay should not take keyboard focus when it appears or re-assert
-focus during the session. This addresses the focus-stealing class of issues on
-Wayland compositors such as Niri, but it does not change the accepted native
-Wayland limitations around cross-workspace stickiness or compositor-controlled
-window placement.
+Passive pet windows are created as non-focusable on Linux and are shown inactive,
+so the transparent overlay should not take keyboard focus when it appears or
+re-assert focus during the session. Pet windows temporarily opt back into
+focusability when the rendered plugin bubble includes an inline input/select,
+because those controls need keyboard focus after the user clicks them. This
+addresses the focus-stealing class of issues on Wayland compositors such as Niri,
+without breaking plugin bubbles that need typed input, but it does not change the
+accepted native Wayland limitations around cross-workspace stickiness or
+compositor-controlled window placement.
 
 ## Reproduction and validation notes
 


### PR DESCRIPTION
## Summary

On Linux/Wayland compositors such as Niri, the pet window stole keyboard focus from whatever the user was working in: showing a pet pulled focus away from the terminal/editor. The pet is a passive overlay and should not take focus. This makes passive pet windows non-focusable on Linux so they no longer steal focus, while keeping windows that actually need keyboard input focusable so plugin bubbles still work.

## Why this matters

Issue #32 reports the pet stealing focus on Wayland/Niri, which interrupts typing. The naive fix, making every pet window non-focusable on Linux, trades one bug for another: a plugin bubble with an inline `input`/`select` (`pet:interact`) needs keyboard focus, and a non-focusable BrowserWindow can never receive it, so the user could not type into bubble fields. The focus decision therefore has to depend on whether the window hosts interactive input, not just on the platform.

## Changes

The focusability decision lives in a pure helper, `shouldPetWindowBeFocusable(platform, waylandBackend, hasInteractiveInput)`: on Linux a passive pet is non-focusable, but a pet hosting an interactive bubble stays focusable; macOS and Windows behavior is unchanged. The call sites in `pet-window.ts` and `wayland-backend.ts` pass the `hasInteractiveInput` signal so the policy applies correctly, and `docs/wayland.md` documents the behavior.

## Testing

Extended `apps/desktop/tests/pet-window-wayland-predicate.test.ts` to cover the pure predicate: passive pet on Linux is non-focusable, an interactive-input pet on Linux is focusable, and macOS/Windows are unaffected. The desktop test build passes (8 tests).

Closes #32
