### PR TITLE
feat(virtual-pet): add Show stats panel toggle

### DIFF
--- a/plugins/official/openpets.virtual-pet/index.js
+++ b/plugins/official/openpets.virtual-pet/index.js
@@ -113,6 +113,21 @@ async function playActionSound(ctx) {
 }
 
 export async function updatePinned(ctx, state, now = Date.now()) {
+  let showStats = true;
+  try {
+    const cfg = (await ctx.config.get()) ?? {};
+    if (cfg.showStats === false) showStats = false;
+  } catch {}
+
+  if (!showStats) {
+    const pinned = getPinnedBubble(ctx);
+    if (pinned) {
+      try { await pinned.dismiss(); } catch {}
+      setPinnedBubble(ctx, null);
+    }
+    return;
+  }
+
   const spec = {
     tone: "info",
     sticky: true,

--- a/plugins/official/openpets.virtual-pet/locales/en.json
+++ b/plugins/official/openpets.virtual-pet/locales/en.json
@@ -5,6 +5,8 @@
   "hud.energy": "Energy",
   "hud.play": "Play",
   "hud.bond": "Bond",
+  "config.showStats.label": "Show stats panel",
+  "config.showStats.description": "Show the Food, Energy, Play, and Bond panel next to your pet. Turn off to hide it and free up screen space.",
   "config.sound.label": "Action sound",
   "config.sound.description": "Optionally play a sound for direct care actions like feeding, playing, petting, or resting.",
   

--- a/plugins/official/openpets.virtual-pet/locales/es-419.json
+++ b/plugins/official/openpets.virtual-pet/locales/es-419.json
@@ -5,6 +5,8 @@
   "hud.energy": "Energía",
   "hud.play": "Juego",
   "hud.bond": "Vínculo",
+  "config.showStats.label": "Mostrar panel de estado",
+  "config.showStats.description": "Muestra el panel de Comida, Energía, Juego y Vínculo junto a tu mascota. Desactívalo para ocultarlo y liberar espacio en pantalla.",
   "config.sound.label": "Sonido de acción",
   "config.sound.description": "Opcionalmente reproduce un sonido para acciones directas de cuidado como alimentar, jugar, acariciar o descansar.",
 

--- a/plugins/official/openpets.virtual-pet/locales/ja.json
+++ b/plugins/official/openpets.virtual-pet/locales/ja.json
@@ -5,6 +5,8 @@
   "hud.energy": "元気",
   "hud.play": "遊び",
   "hud.bond": "絆",
+  "config.showStats.label": "ステータスパネルを表示",
+  "config.showStats.description": "ペットの横に「ごはん」「元気」「遊び」「絆」のパネルを表示します。オフにすると非表示になり、画面が広く使えます。",
   "config.sound.label": "アクション音",
   "config.sound.description": "ごはん、遊び、なでる、休むなど直接のお世話で任意の音を鳴らします。",
 

--- a/plugins/official/openpets.virtual-pet/locales/ko.json
+++ b/plugins/official/openpets.virtual-pet/locales/ko.json
@@ -5,6 +5,8 @@
   "hud.energy": "에너지",
   "hud.play": "놀이",
   "hud.bond": "유대감",
+  "config.showStats.label": "상태 패널 표시",
+  "config.showStats.description": "펫 옆에 먹이, 에너지, 놀이, 유대감 패널을 표시합니다. 끄면 숨겨져 화면 공간을 확보할 수 있습니다.",
   "config.sound.label": "동작 소리",
   "config.sound.description": "먹이 주기, 놀기, 쓰다듬기, 쉬기 같은 직접 돌봄 동작에 선택적으로 소리를 재생합니다.",
 

--- a/plugins/official/openpets.virtual-pet/locales/pt-BR.json
+++ b/plugins/official/openpets.virtual-pet/locales/pt-BR.json
@@ -5,6 +5,8 @@
   "hud.energy": "Energia",
   "hud.play": "Brincar",
   "hud.bond": "Vínculo",
+  "config.showStats.label": "Mostrar painel de status",
+  "config.showStats.description": "Mostra o painel de Comida, Energia, Brincar e Vínculo ao lado do seu pet. Desative para ocultá-lo e liberar espaço na tela.",
   "config.sound.label": "Som de ação",
   "config.sound.description": "Opcionalmente reproduz um som para ações diretas de cuidado, como alimentar, brincar, fazer carinho ou descansar.",
 

--- a/plugins/official/openpets.virtual-pet/locales/zh-Hans.json
+++ b/plugins/official/openpets.virtual-pet/locales/zh-Hans.json
@@ -5,6 +5,8 @@
   "hud.energy": "能量",
   "hud.play": "玩耍",
   "hud.bond": "羁绊",
+  "config.showStats.label": "显示状态面板",
+  "config.showStats.description": "在宠物旁边显示食物、能量、玩耍和羁绊面板。关闭后将其隐藏以腾出屏幕空间。",
   "config.sound.label": "动作声音",
   "config.sound.description": "喂食、玩耍、抚摸或休息等直接照顾动作可选择播放声音。",
 

--- a/plugins/official/openpets.virtual-pet/locales/zh-Hant.json
+++ b/plugins/official/openpets.virtual-pet/locales/zh-Hant.json
@@ -5,6 +5,8 @@
   "hud.energy": "能量",
   "hud.play": "玩耍",
   "hud.bond": "羈絆",
+  "config.showStats.label": "顯示狀態面板",
+  "config.showStats.description": "在寵物旁邊顯示食物、能量、玩耍和羈絆面板。關閉後將其隱藏以騰出螢幕空間。",
   "config.sound.label": "動作聲音",
   "config.sound.description": "餵食、玩耍、撫摸或休息等直接照顧動作可選擇播放聲音。",
 

--- a/plugins/official/openpets.virtual-pet/openpets.plugin.json
+++ b/plugins/official/openpets.virtual-pet/openpets.plugin.json
@@ -3,7 +3,7 @@
   "id": "openpets.virtual-pet",
   "name": "$t:plugin.name",
   "description": "$t:plugin.description",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "runtime": "javascript",
   "icon": "heart",
   "sdkVersion": "3.0.0",
@@ -25,6 +25,12 @@
     "events"
   ],
   "configSchema": {
+    "showStats": {
+      "type": "boolean",
+      "default": true,
+      "label": "$t:config.showStats.label",
+      "description": "$t:config.showStats.description"
+    },
     "sound": {
       "type": "sound",
       "label": "$t:config.sound.label",

--- a/plugins/official/openpets.virtual-pet/test.js
+++ b/plugins/official/openpets.virtual-pet/test.js
@@ -124,6 +124,16 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
+// 2b) With showStats disabled, no HUD bubble is pinned
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 100_000_000_000, config: { showStats: false } });
+  activeHarness = h;
+  await h.start();
+  // No pinned status bubble should be created when stats are hidden
+  assert.equal(h.calls.bubbles.length, 0, "Should not create a HUD bubble when showStats is false");
+  h.expectNoErrors();
+}
+
 // 3) Reconcile with wall-clock decay catch-up
 {
   const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 101_000_000_000 });


### PR DESCRIPTION
## Summary

The Virtual Pet plugin always pins a Food / Energy / Play / Bond HUD beside the pet, and there's no way to turn it off. For users who just want the companion on screen, that panel takes up space they'd rather keep clear (see screenshot in #issue / user reports).

This adds a **Show stats panel** toggle to the plugin's settings so the HUD can be hidden.

## Why this is needed

- The HUD is hardcoded into `updatePinned` — always shown whenever the plugin is active, with no opt-out.
- The panel is screen real estate some users don't want; the pet is still fully functional without the visible stats.
- A toggle is the least invasive fix: it reuses the existing `configSchema` mechanism (boolean fields auto-render as a toggle row in the Control Center, next to the existing "Action sound" option).

## Changes

- `openpets.plugin.json`: add a `showStats` boolean config field (`default: true`), bump plugin version to `1.1.0`.
- `index.js` (`updatePinned`): read the config; when `showStats` is `false`, dismiss the pinned bubble and skip rendering the HUD entirely.
- Localized the label + description across all shipped locales (`en`, `es-419`, `ja`, `ko`, `pt-BR`, `zh-Hans`, `zh-Hant`).
- `test.js`: added a case asserting no HUD bubble is created when `showStats` is off.

## Notes

- **Non-breaking:** defaults to on, so existing installs see no change.
- **Platform-agnostic:** no OS-specific code paths touched; behaves the same on macOS / Windows / Linux.
- Plugin locale check and the full plugin test suite pass (`pnpm plugins:locales`, `node scripts/test-plugins.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)