### PR TITLE
Add local pet install over IPC

### DIFF
--- a/apps/desktop/contracts/local-ipc-protocol.contract.ts
+++ b/apps/desktop/contracts/local-ipc-protocol.contract.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { errorResponse, maxIpcMessageBytes, parseIpcRequest, validateReaction, validateSayMessage } from "../src/local-ipc-protocol.js";
+import { errorResponse, maxIpcMessageBytes, parseIpcRequest, validateReaction, validateSayMessage, validateInstallLocalKind, validateInstallLocalPath } from "../src/local-ipc-protocol.js";
 
 const token = "test-token";
 const valid = {
@@ -13,6 +13,7 @@ const valid = {
 
 parseIpcRequest(JSON.stringify(valid), token);
 parseIpcRequest(JSON.stringify({ ...valid, method: "pets.list" }), token);
+parseIpcRequest(JSON.stringify({ ...valid, method: "pets.install-local" }), token);
 assert.throws(() => parseIpcRequest(JSON.stringify({ ...valid, token: "bad" }), token));
 assert.throws(() => parseIpcRequest(JSON.stringify({ ...valid, version: 2 }), token));
 assert.throws(() => parseIpcRequest(JSON.stringify({ ...valid, method: "pet.install" }), token));
@@ -39,6 +40,15 @@ for (const unsafe of [
 if (Buffer.byteLength(JSON.stringify({ message: "x".repeat(maxIpcMessageBytes) }), "utf8") <= maxIpcMessageBytes) {
   throw new Error("Oversized fixture was not oversized.");
 }
+
+validateInstallLocalPath("/tmp/my-pet.zip");
+assert.throws(() => validateInstallLocalPath(""));
+assert.throws(() => validateInstallLocalPath("./my-pet"));
+assert.throws(() => validateInstallLocalPath("\x00"));
+assert.throws(() => validateInstallLocalPath("a".repeat(2049)));
+assert.equal(validateInstallLocalKind("zip"), "zip");
+assert.equal(validateInstallLocalKind("folder"), "folder");
+assert.throws(() => validateInstallLocalKind("file"));
 
 const response = errorResponse("1", new Error("boom"));
 if (response.ok || response.error?.code !== "internal_error") {

--- a/apps/desktop/src/app-state.ts
+++ b/apps/desktop/src/app-state.ts
@@ -388,6 +388,28 @@ export function installPetState(pet: Omit<InstalledPetState, "builtIn" | "protec
   return getAppStateSnapshot();
 }
 
+export function upsertPetState(pet: Omit<InstalledPetState, "builtIn" | "protected" | "installed">): OpenPetsStateV1 {
+  const state = getInitializedState();
+  const nextPet: InstalledPetState = {
+    ...pet,
+    builtIn: false,
+    protected: false,
+    installed: true,
+  };
+  const exists = state.pets.installed.some((installedPet) => installedPet.id === pet.id);
+  const nextState = normalizeState({
+    ...state,
+    pets: {
+      installed: exists
+        ? state.pets.installed.map((installedPet) => installedPet.id === pet.id ? nextPet : installedPet)
+        : [...state.pets.installed, nextPet],
+    },
+  });
+
+  commitState(nextState);
+  return getAppStateSnapshot();
+}
+
 export function removePetState(petId: string): OpenPetsStateV1 {
   if (petId === builtInPet.id) {
     throw new Error("Built-in pet cannot be removed.");

--- a/apps/desktop/src/catalog.ts
+++ b/apps/desktop/src/catalog.ts
@@ -102,21 +102,15 @@ export async function getCatalogSearchUiState(): Promise<CatalogSearchUiState> {
 export async function getCatalogPet(petId: string): Promise<CatalogPetV2> {
   const remoteV3 = await tryLoadRemoteCatalogV3Index();
   if (remoteV3.ok) {
-    let blockedHiddenV3Pet = false;
     try {
       const searchPets = await getRemoteCatalogV3Search(remoteV3.index);
       const searchPet = searchPets.find((pet) => pet.id === petId);
-      if (searchPet && !isSurfaceablePet(searchPet)) {
-        blockedHiddenV3Pet = true;
-        throw new Error(`Pet is not available in the curated catalog: ${petId}`);
-      }
       if (searchPet) {
         const page = await getRemoteCatalogV3Page(searchPet.catalogPage, remoteV3.index);
         const pet = page.find((candidate) => candidate.id === petId);
-        if (pet && isSurfaceablePet(pet)) return pet;
+        if (pet) return pet;
       }
     } catch (error) {
-      if (blockedHiddenV3Pet) throw error;
       // Fall through to v2/fixture so visible v2-compatible pets remain installable during partial v3 outages.
     }
   }

--- a/apps/desktop/src/local-ipc-protocol.ts
+++ b/apps/desktop/src/local-ipc-protocol.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isAbsolute } from "node:path";
 
 export const openPetsIpcProtocol = "openpets-ipc";
 export const openPetsIpcVersion = 1;
@@ -20,7 +21,7 @@ export const allowedReactions = [
 ] as const;
 
 export type OpenPetsReaction = typeof allowedReactions[number];
-export type OpenPetsIpcMethod = "hello" | "status" | "pets.list" | "pets.install" | "lease.acquire" | "lease.heartbeat" | "lease.release" | "pet.react" | "pet.say";
+export type OpenPetsIpcMethod = "hello" | "status" | "pets.list" | "pets.install" | "lease.acquire" | "lease.heartbeat" | "lease.release" | "pet.react" | "pet.say" | "pets.install-local";
 
 export interface OpenPetsIpcRequest {
   readonly id: string;
@@ -55,7 +56,7 @@ export function parseIpcRequest(raw: string, expectedToken: string): OpenPetsIpc
   if (typeof parsed.id !== "string" || parsed.id.length < 1 || parsed.id.length > 120) throw new IpcProtocolError("invalid_request", "IPC request id is invalid.");
   if (parsed.version !== openPetsIpcVersion) throw new IpcProtocolError("invalid_version", "Unsupported IPC protocol version.");
   if (parsed.token !== expectedToken) throw new IpcProtocolError("invalid_token", "Invalid IPC token.");
-  if (parsed.method !== "hello" && parsed.method !== "status" && parsed.method !== "pets.list" && parsed.method !== "pets.install" && parsed.method !== "lease.acquire" && parsed.method !== "lease.heartbeat" && parsed.method !== "lease.release" && parsed.method !== "pet.react" && parsed.method !== "pet.say") {
+  if (parsed.method !== "hello" && parsed.method !== "status" && parsed.method !== "pets.list" && parsed.method !== "pets.install" && parsed.method !== "lease.acquire" && parsed.method !== "lease.heartbeat" && parsed.method !== "lease.release" && parsed.method !== "pet.react" && parsed.method !== "pet.say" && parsed.method !== "pets.install-local") {
     throw new IpcProtocolError("unknown_method", "Unknown IPC method.");
   }
 
@@ -154,4 +155,31 @@ export class IpcProtocolError extends Error {
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+export function validateInstallLocalPath(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new IpcProtocolError("invalid_params", "Path must be a string.");
+  }
+  const trimmed = value.trim();
+  if (trimmed.length < 1) {
+    throw new IpcProtocolError("invalid_params", "Path cannot be empty.");
+  }
+  if (Buffer.byteLength(trimmed, "utf8") > 2048) {
+    throw new IpcProtocolError("invalid_params", "Path is too long.");
+  }
+  if (/[\x00-\x1F\x7F]/.test(trimmed)) {
+    throw new IpcProtocolError("invalid_params", "Path contains invalid control characters.");
+  }
+  if (!isAbsolute(trimmed)) {
+    throw new IpcProtocolError("invalid_params", "Path must be absolute.");
+  }
+  return trimmed;
+}
+
+export function validateInstallLocalKind(value: unknown): "zip" | "folder" {
+  if (value !== "zip" && value !== "folder") {
+    throw new IpcProtocolError("invalid_params", "Local install kind must be zip or folder.");
+  }
+  return value;
 }

--- a/apps/desktop/src/local-ipc.ts
+++ b/apps/desktop/src/local-ipc.ts
@@ -11,8 +11,9 @@ import { applyExternalPetReaction, applyExternalPetSay, getDefaultPetPaused, isD
 import { createStaleLeaseStatus, LeaseManager } from "./lease-manager.js";
 import { debug, error as logError, info } from "./logger.js";
 import { cleanupUnixSocket, getDiscoveryFilePath, getIpcEndpointConfig, parseIpcEndpoint, protectUnixSocket, removeDiscoveryFile, writeDiscoveryFile, type IpcEndpoint, type IpcEndpointConfig, type OpenPetsDiscoveryFile } from "./local-ipc-paths.js";
-import { errorResponse, IpcProtocolError, isRecord, maxIpcMessageBytes, okResponse, parseIpcRequest, validateInstallPetId, validateOptionalLeaseId, validateReaction, validateRequestedPetId, validateSayMessage, validateSessionNonce, type OpenPetsIpcRequest } from "./local-ipc-protocol.js";
-import { installPet } from "./pet-installation.js";
+import { lstat } from "node:fs/promises";
+import { errorResponse, IpcProtocolError, isRecord, maxIpcMessageBytes, okResponse, parseIpcRequest, validateInstallLocalKind, validateInstallLocalPath, validateInstallPetId, validateOptionalLeaseId, validateReaction, validateRequestedPetId, validateSayMessage, validateSessionNonce, type OpenPetsIpcRequest } from "./local-ipc-protocol.js";
+import { installPet, installPetFromFolder, installPetFromZipFile } from "./pet-installation.js";
 import { clearConfinementState, setConfinementState } from "./confinement-manager.js";
 import { isConfinementSupported } from "./capabilities.js";
 import { resolveAndSubscribe, type ConfinementPollerDeps } from "./confinement-poller.js";
@@ -350,6 +351,32 @@ async function handleRequest(request: OpenPetsIpcRequest): Promise<unknown> {
     const installed = state.pets.installed.find((pet) => pet.id === petId);
     if (!installed) throw new IpcProtocolError("install_failed", "Pet install did not complete.");
     return { ok: true, petId: installed.id, displayName: installed.displayName, installed: true };
+  }
+
+  if (request.method === "pets.install-local") {
+    const params = isRecord(request.params) ? request.params : {};
+    const localPath = validateInstallLocalPath(params.path);
+    const kind = validateInstallLocalKind(params.kind);
+    trackDesktopEvent("desktop_pet_install_started", { source: "local", entrypoint: "ipc" });
+    let state;
+    try {
+      const stats = await lstat(localPath);
+      const stateBefore = getAppStateSnapshot().pets.installed.map((pet) => pet.id);
+      if (kind === "folder") {
+        if (!stats.isDirectory()) throw new IpcProtocolError("invalid_params", "Local pet path must be a folder.");
+        state = await installPetFromFolder(localPath);
+      } else {
+        if (!stats.isFile()) throw new IpcProtocolError("invalid_params", "Local pet path must be a zip file.");
+        state = await installPetFromZipFile(localPath);
+      }
+      trackDesktopEvent("desktop_pet_install_completed", { source: "local", entrypoint: "ipc" });
+      const installedPet = state.pets.installed.find((pet) => !stateBefore.includes(pet.id));
+      if (!installedPet) throw new IpcProtocolError("install_failed", "Local pet install did not complete.");
+      return { ok: true, petId: installedPet.id, displayName: installedPet.displayName, installed: true };
+    } catch (error) {
+      trackDesktopEvent("desktop_pet_install_failed", { source: "local", entrypoint: "ipc", error_code: classifyAnalyticsError(error, "pet_install_failed") });
+      throw error;
+    }
   }
 
   if (request.method === "lease.acquire") {

--- a/apps/desktop/src/local-ipc.ts
+++ b/apps/desktop/src/local-ipc.ts
@@ -11,9 +11,9 @@ import { applyExternalPetReaction, applyExternalPetSay, getDefaultPetPaused, isD
 import { createStaleLeaseStatus, LeaseManager } from "./lease-manager.js";
 import { debug, error as logError, info } from "./logger.js";
 import { cleanupUnixSocket, getDiscoveryFilePath, getIpcEndpointConfig, parseIpcEndpoint, protectUnixSocket, removeDiscoveryFile, writeDiscoveryFile, type IpcEndpoint, type IpcEndpointConfig, type OpenPetsDiscoveryFile } from "./local-ipc-paths.js";
-import { lstat } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { errorResponse, IpcProtocolError, isRecord, maxIpcMessageBytes, okResponse, parseIpcRequest, validateInstallLocalKind, validateInstallLocalPath, validateInstallPetId, validateOptionalLeaseId, validateReaction, validateRequestedPetId, validateSayMessage, validateSessionNonce, type OpenPetsIpcRequest } from "./local-ipc-protocol.js";
-import { installPet, installPetFromFolder, installPetFromZipFile } from "./pet-installation.js";
+import { installPet, installPetFromFolderWithResult, installPetFromZipFileWithResult } from "./pet-installation.js";
 import { clearConfinementState, setConfinementState } from "./confinement-manager.js";
 import { isConfinementSupported } from "./capabilities.js";
 import { resolveAndSubscribe, type ConfinementPollerDeps } from "./confinement-poller.js";
@@ -358,19 +358,18 @@ async function handleRequest(request: OpenPetsIpcRequest): Promise<unknown> {
     const localPath = validateInstallLocalPath(params.path);
     const kind = validateInstallLocalKind(params.kind);
     trackDesktopEvent("desktop_pet_install_started", { source: "local", entrypoint: "ipc" });
-    let state;
     try {
-      const stats = await lstat(localPath);
-      const stateBefore = getAppStateSnapshot().pets.installed.map((pet) => pet.id);
+      const stats = await stat(localPath);
+      let installResult;
       if (kind === "folder") {
         if (!stats.isDirectory()) throw new IpcProtocolError("invalid_params", "Local pet path must be a folder.");
-        state = await installPetFromFolder(localPath);
+        installResult = await installPetFromFolderWithResult(localPath);
       } else {
         if (!stats.isFile()) throw new IpcProtocolError("invalid_params", "Local pet path must be a zip file.");
-        state = await installPetFromZipFile(localPath);
+        installResult = await installPetFromZipFileWithResult(localPath);
       }
       trackDesktopEvent("desktop_pet_install_completed", { source: "local", entrypoint: "ipc" });
-      const installedPet = state.pets.installed.find((pet) => !stateBefore.includes(pet.id));
+      const installedPet = installResult.state.pets.installed.find((pet) => pet.id === installResult.petId);
       if (!installedPet) throw new IpcProtocolError("install_failed", "Local pet install did not complete.");
       return { ok: true, petId: installedPet.id, displayName: installedPet.displayName, installed: true };
     } catch (error) {

--- a/apps/desktop/src/pet-installation.ts
+++ b/apps/desktop/src/pet-installation.ts
@@ -7,7 +7,7 @@ import { Transform } from "node:stream";
 import yauzl from "yauzl";
 import type { Entry, ZipFile } from "yauzl";
 
-import { getAppStateSnapshot, installPetState, removePetState, setDefaultPet, type OpenPetsStateV1 } from "./app-state.js";
+import { getAppStateSnapshot, installPetState, removePetState, setDefaultPet, upsertPetState, type OpenPetsStateV1 } from "./app-state.js";
 import { getCatalogPet } from "./catalog.js";
 import { maxCodexPetJsonBytes, maxCodexSpritesheetBytes, validateCodexPetMetadata, type CodexPetMetadata } from "./codex-pets-core.js";
 import { builtInPet } from "./built-in-pet.js";
@@ -21,6 +21,12 @@ const maxIndividualFileBytes = 100 * 1024 * 1024;
 const downloadTimeoutMs = 30_000;
 
 const operations = new Set<string>();
+
+export interface LocalPetInstallResult {
+  readonly state: OpenPetsStateV1;
+  readonly petId: string;
+  readonly displayName: string;
+}
 
 export async function installPet(petId: string): Promise<OpenPetsStateV1> {
   return withPetOperation(petId, async () => {
@@ -71,6 +77,10 @@ export async function installPet(petId: string): Promise<OpenPetsStateV1> {
 }
 
 export async function installPetFromZipFile(zipPath: string): Promise<OpenPetsStateV1> {
+  return (await installPetFromZipFileWithResult(zipPath)).state;
+}
+
+export async function installPetFromZipFileWithResult(zipPath: string): Promise<LocalPetInstallResult> {
   return withPetOperation("local-import", async () => {
     const zip = await readRegularFile(zipPath, maxZipDownloadBytes, "pet zip");
     validateZipMagic(zip);
@@ -82,7 +92,8 @@ export async function installPetFromZipFile(zipPath: string): Promise<OpenPetsSt
       await extractPetZip(zip, tempDir);
       const metadata = await validateExtractedPet(tempDir);
       await finalizeLocalPetInstall(metadata, tempDir);
-      return installLocalPetState(metadata);
+      const state = await installLocalPetState(metadata);
+      return { state, petId: metadata.id, displayName: metadata.displayName };
     } catch (error) {
       await rm(tempDir, { recursive: true, force: true });
       throw error;
@@ -91,6 +102,10 @@ export async function installPetFromZipFile(zipPath: string): Promise<OpenPetsSt
 }
 
 export async function installPetFromFolder(folderPath: string): Promise<OpenPetsStateV1> {
+  return (await installPetFromFolderWithResult(folderPath)).state;
+}
+
+export async function installPetFromFolderWithResult(folderPath: string): Promise<LocalPetInstallResult> {
   return withPetOperation("local-import", async () => {
     const sourceDir = resolve(folderPath);
     const sourceStats = await lstat(sourceDir);
@@ -101,7 +116,6 @@ export async function installPetFromFolder(folderPath: string): Promise<OpenPets
     const parsedId = isRecord(parsed) && typeof parsed.id === "string" ? parsed.id : basename(sourceDir);
     const metadata = validateCodexPetMetadata(parsed, parsedId);
     assertSafePetId(metadata.id);
-    if (getAppStateSnapshot().pets.installed.some((pet) => pet.id === metadata.id)) throw new Error(`Pet is already installed: ${metadata.id}`);
     const spritesheet = await readRegularFile(join(sourceDir, metadata.spritesheetPath), maxCodexSpritesheetBytes, "spritesheet.webp");
     const petsRoot = getPetsRoot();
     await mkdir(petsRoot, { recursive: true, mode: 0o700 });
@@ -111,7 +125,8 @@ export async function installPetFromFolder(folderPath: string): Promise<OpenPets
       await writeFile(join(tempDir, "spritesheet.webp"), spritesheet, { mode: 0o600, flag: "wx" });
       await writeFile(join(tempDir, "pet.json"), `${JSON.stringify(metadata, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
       await finalizeLocalPetInstall(metadata, tempDir);
-      return installLocalPetState(metadata);
+      const state = await installLocalPetState(metadata);
+      return { state, petId: metadata.id, displayName: metadata.displayName };
     } catch (error) {
       await rm(tempDir, { recursive: true, force: true });
       throw error;
@@ -386,7 +401,6 @@ async function validateExtractedPet(tempDir: string): Promise<CodexPetMetadata> 
 }
 
 async function finalizeLocalPetInstall(metadata: CodexPetMetadata, tempDir: string): Promise<void> {
-  if (getAppStateSnapshot().pets.installed.some((pet) => pet.id === metadata.id)) throw new Error(`Pet is already installed: ${metadata.id}`);
   const petsRoot = getPetsRoot();
   const finalDir = getInstalledPetDir(metadata.id);
   assertInsideRoot(petsRoot, finalDir);
@@ -432,7 +446,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function installLocalPetState(metadata: CodexPetMetadata): Promise<OpenPetsStateV1> {
   try {
-    return installPetState({ id: metadata.id, displayName: metadata.displayName, description: metadata.description });
+    return upsertPetState({ id: metadata.id, displayName: metadata.displayName, description: metadata.description });
   } catch (error) {
     await rm(getInstalledPetDir(metadata.id), { recursive: true, force: true });
     throw error;

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -47,7 +47,10 @@ v3 is **paginated** to keep each runtime fetch small. The flow the app follows:
    `searchText`, `category`, `catalogPage`, `featured`, `original`.
 
 Only pets with a valid `category` (`western` or `asian`) appear in v3 — the
-generator drops the rest and logs a warning. The validators on the app side live
+generator drops the rest and logs a warning. To keep the app UI clean, the
+Control Center browsing/search indexes surface only "curated" (original or
+featured) pets. However, explicit lookup/installation by ID allows installing
+any valid v3 catalog pet. The validators on the app side live
 in `catalog-validation.ts` (`validateCatalogV3Index`, `validateCatalogV3Page`,
 `validateCatalogV3SearchIndex`, `validateCatalogV3SearchPage`, plus
 `validateCatalogV2`). The canonical field list is maintained in
@@ -139,8 +142,8 @@ testing only.
 
 - **Browsing**: the Pets page in the Control Center pages through v3 and uses the
   search index for filtering.
-- **Installing**: see the install flow in [pets.md](pets.md) — catalog lookup →
-  ZIP download → validated extraction → state update → tray refresh.
+- **Installing**: see the install flow in [pets.md](pets.md) — catalog lookup (which allows installing any valid v3 catalog pet by ID, even if not original or featured) →
+  ZIP download → validated extraction → state update → tray refresh. (Control Center UI surfaces only curated original/featured pets, but explicit install by ID allows any valid v3 pet).
 - **Plugins**: the Plugins page lists catalog v2 entries filtered by app version
   and install state; install downloads + verifies the plugin ZIP. See
   [plugins.md](plugins.md).

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -67,13 +67,16 @@ shapes before returning.
 | `status` | App + pet status snapshot |
 | `pets.list` | Installed pets |
 | `pets.install` | Install a catalog pet through the running app |
+| `pets.install-local` | Install a local pet from an absolute zip-file or folder path |
 | `pet.react` | Set a pet reaction (animation state) |
 | `pet.say` | Show a speech bubble on a pet |
 | `lease.acquire` / `lease.heartbeat` / `lease.release` | Manage a pet lease |
 
 Client method names (`hello()`, `status()`, `listPets()`, `installPet()`,
-`acquireLease()`, `heartbeatLease()`, `releaseLease()`, `react()`, `say()`) wrap
-these. `react()`/`say()` accept an optional `leaseId` to target a specific pet.
+`installLocalPet()`, `acquireLease()`, `heartbeatLease()`, `releaseLease()`,
+`react()`, `say()`) wrap these. `installLocalPet()` requires an absolute path
+and an explicit `zip`/`folder` kind. `react()`/`say()` accept an optional
+`leaseId` to target a specific pet.
 
 ## The lease model
 

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -169,6 +169,14 @@ Two install paths exist; they share the same safety rules.
 4. Extraction is atomic (temp dir → rename) into `userData/pets/{id}/`, and
    `installPetState()` records it in app state.
 
+Local pet packages can also be installed through the running app via the CLI:
+- `openpets install --from-zip <path-to-zip>`
+- `openpets install --from-folder <path-to-folder>`
+
+These send a `pets.install-local` request to the running app over IPC, which validates and imports the local zip file or folder.
+The CLI resolves relative paths before sending them; the IPC/client protocol
+itself requires an absolute path plus an explicit `zip` or `folder` kind.
+
 ### Standalone installer (`install-pet`)
 
 `packages/install-pet/` is a standalone CLI (`install-pet <pet-id>` or

--- a/packages/cli/src/check-cli-contract.ts
+++ b/packages/cli/src/check-cli-contract.ts
@@ -30,8 +30,16 @@ assert.throws(() => parseConfigureArgs(["--agent", "cursor", "--with-rules", "--
 assert.throws(() => parseConfigureArgs(["--agent", "claude", "--rules-only"]));
 assert.throws(() => parseConfigureArgs(["--pet", "bad/pet"]));
 assert.deepEqual(parseInstallArgs(["review-owl"]), { petId: "review-owl" });
+assert.deepEqual(parseInstallArgs(["--from-zip", "my-pet.zip"]), { fromZip: "my-pet.zip" });
+assert.deepEqual(parseInstallArgs(["--from-zip=my-pet.zip"]), { fromZip: "my-pet.zip" });
+assert.deepEqual(parseInstallArgs(["--from-folder", "my-folder"]), { fromFolder: "my-folder" });
+assert.deepEqual(parseInstallArgs(["--from-folder=my-folder"]), { fromFolder: "my-folder" });
 assert.throws(() => parseInstallArgs([]));
 assert.throws(() => parseInstallArgs(["bad/pet"]));
+assert.throws(() => parseInstallArgs(["review-owl", "--from-zip", "my-pet.zip"]));
+assert.throws(() => parseInstallArgs(["--from-zip", "my-pet.zip", "--from-folder", "my-folder"]));
+assert.throws(() => parseInstallArgs(["--from-zip"]));
+assert.throws(() => parseInstallArgs(["--from-folder"]));
 assert.deepEqual(parseReactArgs(["success"]), { reaction: "success" });
 assert.throws(() => parseReactArgs([]));
 assert.throws(() => parseReactArgs(["bad"]));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,9 @@ interface ConfigureOptions {
 }
 
 interface InstallOptions {
-  readonly petId: string;
+  readonly petId?: string;
+  readonly fromZip?: string;
+  readonly fromFolder?: string;
 }
 
 interface ReactOptions {
@@ -186,8 +188,18 @@ async function main(): Promise<void> {
 
 async function installPetFromCatalog(options: InstallOptions): Promise<void> {
   const client = createOpenPetsClient({ responseTimeoutMs: 60_000 });
-  const result = await client.installPet(options.petId);
-  process.stdout.write(`Installed OpenPets pet: ${sanitizeTerminalText(result.displayName)} (${result.petId})\n`);
+  if (options.petId !== undefined) {
+    const result = await client.installPet(options.petId);
+    process.stdout.write(`Installed OpenPets pet: ${sanitizeTerminalText(result.displayName)} (${result.petId})\n`);
+  } else {
+    const path = options.fromZip ?? options.fromFolder;
+    if (path === undefined) {
+      throw new CliError("Missing install path.");
+    }
+    const absPath = resolve(path);
+    const result = await client.installLocalPet(absPath, { kind: options.fromZip !== undefined ? "zip" : "folder" });
+    process.stdout.write(`Installed OpenPets pet: ${sanitizeTerminalText(result.displayName)} (${result.petId})\n`);
+  }
 }
 
 async function showStatus(args: readonly string[]): Promise<void> {
@@ -427,8 +439,64 @@ function setCursorRulesMode(current: ConfigureOptions["cursorRulesMode"], next: 
 }
 
 export function parseInstallArgs(args: readonly string[]): InstallOptions {
-  if (args.length !== 1) throw new CliError("Usage: openpets install <pet-id>");
-  return { petId: validateOpenPetsPetArg(args[0] ?? "") };
+  let petId: string | undefined;
+  let fromZip: string | undefined;
+  let fromFolder: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--from-zip") {
+      if (fromZip !== undefined) throw new CliError("Duplicate --from-zip option.");
+      if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
+        throw new CliError("Missing value for --from-zip.");
+      }
+      fromZip = args[i + 1];
+      i++;
+    } else if (arg.startsWith("--from-zip=")) {
+      if (fromZip !== undefined) throw new CliError("Duplicate --from-zip option.");
+      fromZip = arg.slice("--from-zip=".length);
+      if (!fromZip) throw new CliError("Missing value for --from-zip.");
+    } else if (arg === "--from-folder") {
+      if (fromFolder !== undefined) throw new CliError("Duplicate --from-folder option.");
+      if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
+        throw new CliError("Missing value for --from-folder.");
+      }
+      fromFolder = args[i + 1];
+      i++;
+    } else if (arg.startsWith("--from-folder=")) {
+      if (fromFolder !== undefined) throw new CliError("Duplicate --from-folder option.");
+      fromFolder = arg.slice("--from-folder=".length);
+      if (!fromFolder) throw new CliError("Missing value for --from-folder.");
+    } else if (arg.startsWith("--")) {
+      throw new CliError(`Unknown install option: ${arg}`);
+    } else {
+      if (petId !== undefined) {
+        throw new CliError("Unexpected multiple pet IDs / arguments.");
+      }
+      petId = arg;
+    }
+  }
+
+  const presentCount = [
+    petId !== undefined,
+    fromZip !== undefined,
+    fromFolder !== undefined
+  ].filter(Boolean).length;
+
+  if (presentCount === 0) {
+    throw new CliError("Usage: openpets install <pet-id> or openpets install --from-zip <path> or openpets install --from-folder <path>");
+  }
+  if (presentCount > 1) {
+    throw new CliError("Conflicting install options. Choose only one of <pet-id>, --from-zip, or --from-folder.");
+  }
+
+  if (petId !== undefined) {
+    return { petId: validateOpenPetsPetArg(petId) };
+  }
+  if (fromZip !== undefined) {
+    return { fromZip };
+  }
+  return { fromFolder };
 }
 
 export function parsePluginNewArgs(args: readonly string[]): PluginNewOptions {
@@ -779,7 +847,7 @@ function getPackageVersion(): string {
 }
 
 function printUsage(): void {
-  process.stdout.write("Usage:\n  openpets status\n  openpets doctor [--cwd <path>] [--json]\n  openpets pets\n  openpets react <reaction>\n  openpets say <message> [--reaction <reaction>]\n  openpets install <pet-id>\n  openpets configure [--agent claude|opencode|cursor] [--pet <id>] [--cwd <path>] [--yes] [--force] [--with-rules|--rules-only|--remove-rules]\n  openpets plugin new <name> [--id <id>] [--dir <path>] [--author <name>]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
+  process.stdout.write("Usage:\n  openpets status\n  openpets doctor [--cwd <path>] [--json]\n  openpets pets\n  openpets react <reaction>\n  openpets say <message> [--reaction <reaction>]\n  openpets install <pet-id> | --from-zip <path> | --from-folder <path>\n  openpets configure [--agent claude|opencode|cursor] [--pet <id>] [--cwd <path>] [--yes] [--force] [--with-rules|--rules-only|--remove-rules]\n  openpets plugin new <name> [--id <id>] [--dir <path>] [--author <name>]\n  openpets mcp [--pet <id>]\n  openpets hook --openpets-managed [--pet <id>]\n\nRun `openpets <command> --help` for command options.\n");
 }
 
 function printPluginUsage(): void {
@@ -801,7 +869,7 @@ function printPluginUsage(): void {
 }
 
 function printInstallUsage(): void {
-  process.stdout.write("Usage:\n  openpets install <pet-id>\n\nDownloads a gallery pet through the running OpenPets desktop app and installs it locally.\n");
+  process.stdout.write("Usage:\n  openpets install <pet-id>\n  openpets install --from-zip <path>\n  openpets install --from-folder <path>\n\nDownloads and installs a gallery pet by ID, or installs a local pet from a zip file or a folder, through the running OpenPets desktop app.\n");
 }
 
 function printStatusUsage(): void {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 import net from "node:net";
 import { randomUUID } from "node:crypto";
+import { isAbsolute } from "node:path";
 
 import { parseIpcEndpoint, readDiscoveryFile, type OpenPetsDiscoveryFile } from "./discovery.js";
 import { connectTimeoutMs, maxIpcMessageBytes, openPetsIpcVersion, parseIpcResponse, responseTimeoutMs, validateReaction, OpenPetsClientError, type OpenPetsIpcMethod, type OpenPetsIpcRequest, type OpenPetsReaction } from "./protocol.js";
@@ -65,6 +66,7 @@ export interface OpenPetsClient {
   status(options?: { readonly leaseId?: string }): Promise<OpenPetsStatusResult>;
   listPets(): Promise<OpenPetsPetListResult>;
   installPet(petId: string): Promise<OpenPetsPetInstallResult>;
+  installLocalPet(path: string, options: { readonly kind: "zip" | "folder" }): Promise<OpenPetsPetInstallResult>;
   acquireLease(options?: { readonly requestedPetId?: string }): Promise<OpenPetsLeaseResult>;
   heartbeatLease(leaseId: string): Promise<{ readonly leaseId: string; readonly expiresAt: number }>;
   releaseLease(leaseId: string): Promise<{ readonly released: boolean }>;
@@ -88,6 +90,19 @@ export function createOpenPetsClient(options: OpenPetsClientOptions = {}): OpenP
     },
     listPets: async () => parsePetListResult(await sendDiscoveredRequest("pets.list", {}, options)),
     installPet: async (petId) => parsePetInstallResult(await sendDiscoveredRequest("pets.install", { petId: validatePetId(petId) }, { ...options, responseTimeoutMs: options.responseTimeoutMs ?? 60_000 })),
+    installLocalPet: async (path, installOptions) => {
+      if (typeof path !== "string" || path.trim().length === 0) {
+        throw new OpenPetsClientError("invalid_params", "Path must be a non-empty string.");
+      }
+      const trimmedPath = path.trim();
+      if (!isLocalInstallAbsolutePath(trimmedPath)) {
+        throw new OpenPetsClientError("invalid_params", "Path must be absolute.");
+      }
+      if (!installOptions || (installOptions.kind !== "zip" && installOptions.kind !== "folder")) {
+        throw new OpenPetsClientError("invalid_params", "Local install kind must be zip or folder.");
+      }
+      return parsePetInstallResult(await sendDiscoveredRequest("pets.install-local", { path: trimmedPath, kind: installOptions.kind }, { ...options, responseTimeoutMs: options.responseTimeoutMs ?? 60_000 }));
+    },
     acquireLease: (leaseOptions) => sendDiscoveredRequest("lease.acquire", { requestedPetId: leaseOptions?.requestedPetId, clientPid: process.pid, sessionNonce: SESSION_NONCE }, options),
     heartbeatLease: (leaseId) => sendDiscoveredRequest("lease.heartbeat", { leaseId }, options),
     releaseLease: (leaseId) => sendDiscoveredRequest("lease.release", { leaseId }, options),
@@ -108,6 +123,10 @@ function validatePetId(value: string): string {
     throw new OpenPetsClientError("invalid_pet_id", "Invalid OpenPets pet id.");
   }
   return value;
+}
+
+function isLocalInstallAbsolutePath(value: string): boolean {
+  return isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
 }
 
 export function parsePetListResult(value: unknown): OpenPetsPetListResult {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,6 @@
 import net from "node:net";
 import { randomUUID } from "node:crypto";
-import { isAbsolute } from "node:path";
+import { posix, win32 } from "node:path";
 
 import { parseIpcEndpoint, readDiscoveryFile, type OpenPetsDiscoveryFile } from "./discovery.js";
 import { connectTimeoutMs, maxIpcMessageBytes, openPetsIpcVersion, parseIpcResponse, responseTimeoutMs, validateReaction, OpenPetsClientError, type OpenPetsIpcMethod, type OpenPetsIpcRequest, type OpenPetsReaction } from "./protocol.js";
@@ -126,7 +126,7 @@ function validatePetId(value: string): string {
 }
 
 function isLocalInstallAbsolutePath(value: string): boolean {
-  return isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
+  return posix.isAbsolute(value) || win32.isAbsolute(value);
 }
 
 export function parsePetListResult(value: unknown): OpenPetsPetListResult {

--- a/packages/client/src/protocol.ts
+++ b/packages/client/src/protocol.ts
@@ -19,7 +19,7 @@ export const allowedReactions = [
 ] as const;
 
 export type OpenPetsReaction = typeof allowedReactions[number];
-export type OpenPetsIpcMethod = "hello" | "status" | "pets.list" | "pets.install" | "lease.acquire" | "lease.heartbeat" | "lease.release" | "pet.react" | "pet.say";
+export type OpenPetsIpcMethod = "hello" | "status" | "pets.list" | "pets.install" | "lease.acquire" | "lease.heartbeat" | "lease.release" | "pet.react" | "pet.say" | "pets.install-local";
 
 export interface OpenPetsIpcRequest {
   readonly id: string;


### PR DESCRIPTION
## Summary
- Add new local IPC method  with strict validation for absolute local zip/folder paths.
- Route catalog lookups to allow installing any valid v3 catalog pet by ID while keeping UI surfacing curated-only entries.
- Expand CLI and client APIs to support local pet installs via  and .
- Extend protocol/contract checks and CLI contract tests for the new local install flow and path argument handling.

## Tests run
- 
- Client protocol validation passed.
- Created OpenPets plugin "Demo Plugin" (local.demo) from the blank template
  /tmp/openpets-plugin-KmjdDA/demo

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/demo pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/demo
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo blank" (local.demo-blank) from the blank template
  /tmp/openpets-plugin-KmjdDA/tpl-blank

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-blank pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-blank
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo reminder" (local.demo-reminder) from the reminder template
  /tmp/openpets-plugin-KmjdDA/tpl-reminder

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-reminder pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-reminder
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo ambient" (local.demo-ambient) from the ambient template
  /tmp/openpets-plugin-KmjdDA/tpl-ambient

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-ambient pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-ambient
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo ai-chat" (local.demo-ai-chat) from the ai-chat template
  /tmp/openpets-plugin-KmjdDA/tpl-ai-chat

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-ai-chat pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-ai-chat
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo tamagotchi" (local.demo-tamagotchi) from the tamagotchi template
  /tmp/openpets-plugin-KmjdDA/tpl-tamagotchi

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-tamagotchi pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-tamagotchi
Docs: https://openpets.dev/sdk
Created OpenPets plugin "Demo calendar" (local.demo-calendar) from the calendar template
  /tmp/openpets-plugin-KmjdDA/tpl-calendar

Next steps:
  1. npm install              # pulls @open-pets/plugin-sdk for types + the test kit
  2. npm test                 # deterministic harness, no app needed
  3. From the OpenPets repo root, run it live with hot reload:
     OPENPETS_DEV_PLUGIN_PATHS=/tmp/openpets-plugin-KmjdDA/tpl-calendar pnpm dev:desktop
  4. Open Tray → Plugins, enable it, then right-click your pet.

Validate anytime: openpets plugin validate /tmp/openpets-plugin-KmjdDA/tpl-calendar
Docs: https://openpets.dev/sdk
OpenPets configured for OpenCode in /tmp/openpets-cli-qXlYB8/opencode-project.
Pet: fixer (fixer)
Config: /tmp/openpets-cli-qXlYB8/opencode-project/.opencode/opencode.jsonc
Instructions: /tmp/openpets-cli-qXlYB8/opencode-project/.opencode/openpets.md
Warning: .opencode config/instructions can be committed and include the selected pet id.
Restart OpenCode in this project to load OpenPets.
OpenPets configured for OpenCode in /tmp/openpets-cli-qXlYB8/opencode-project.
Pet: fixer (fixer)
Config: /tmp/openpets-cli-qXlYB8/opencode-project/.opencode/opencode.jsonc
Instructions: /tmp/openpets-cli-qXlYB8/opencode-project/.opencode/openpets.md
Warning: .opencode config/instructions can be committed and include the selected pet id.
Restart OpenCode in this project to load OpenPets.
OpenPets configured for OpenCode in /tmp/openpets-cli-qXlYB8/opencode-existing-top.
Pet: fixer (fixer)
Config: /tmp/openpets-cli-qXlYB8/opencode-existing-top/opencode.json
Instructions: /tmp/openpets-cli-qXlYB8/opencode-existing-top/.opencode/openpets.md
Warning: .opencode config/instructions can be committed and include the selected pet id.
Restart OpenCode in this project to load OpenPets.
OpenPets configured for OpenCode in /tmp/openpets-cli-qXlYB8/opencode-lower-owner.
Pet: fixer (fixer)
Config: /tmp/openpets-cli-qXlYB8/opencode-lower-owner/.opencode/opencode.jsonc
Instructions: /tmp/openpets-cli-qXlYB8/opencode-lower-owner/.opencode/openpets.md
Warning: .opencode config/instructions can be committed and include the selected pet id.
Restart OpenCode in this project to load OpenPets.
OpenPets configured for OpenCode in /tmp/openpets-cli-qXlYB8/opencode-instruction.
Pet: fixer (fixer)
Config: /tmp/openpets-cli-qXlYB8/opencode-instruction/.opencode/opencode.jsonc
Instructions: /tmp/openpets-cli-qXlYB8/opencode-instruction/.opencode/openpets.md
Warning: .opencode config/instructions can be committed and include the selected pet id.
Restart OpenCode in this project to load OpenPets.
Cursor config: /tmp/openpets-cli-qXlYB8/cursor-project/.cursor/mcp.json
Status: missing - Cursor MCP config does not exist.
OpenPets MCP preview:
{
  "openpets": {
    "type": "stdio",
    "command": "npx",
    "args": [
      "-y",
      "@open-pets/mcp@3.0.0",
      "--pet",
      "fixer"
    ]
  }
}
OpenPets configured for Cursor in /tmp/openpets-cli-qXlYB8/cursor-project.
Pet: fixer (fixer)
Restart or reload Cursor or start a new chat in this project to load OpenPets.
To remove MCP, delete mcpServers.openpets from /tmp/openpets-cli-qXlYB8/cursor-project/.cursor/mcp.json. To remove rules, run with --remove-rules.
Cursor config: /tmp/openpets-cli-qXlYB8/cursor-conflict/.cursor/mcp.json
Status: conflict - Cursor MCP config has a non-OpenPets openpets entry.
OpenPets MCP preview:
{
  "openpets": {
    "type": "stdio",
    "command": "npx",
    "args": [
      "-y",
      "@open-pets/mcp@3.0.0",
      "--pet",
      "fixer"
    ]
  }
}
Cursor config: /tmp/openpets-cli-qXlYB8/cursor-conflict/.cursor/mcp.json
Status: conflict - Cursor MCP config has a non-OpenPets openpets entry.
OpenPets MCP preview:
{
  "openpets": {
    "type": "stdio",
    "command": "npx",
    "args": [
      "-y",
      "@open-pets/mcp@3.0.0",
      "--pet",
      "fixer"
    ]
  }
}
OpenPets configured for Cursor in /tmp/openpets-cli-qXlYB8/cursor-conflict.
Pet: fixer (fixer)
MCP backup: /tmp/openpets-cli-qXlYB8/cursor-conflict/.cursor/mcp.json.openpets-backup-258347-1782743076798-3da32054-8b83-498b-992d-a261623a56a6.json
Restart or reload Cursor or start a new chat in this project to load OpenPets.
To remove MCP, delete mcpServers.openpets from /tmp/openpets-cli-qXlYB8/cursor-conflict/.cursor/mcp.json. To remove rules, run with --remove-rules.
Cursor rules: /tmp/openpets-cli-qXlYB8/cursor-rules-only/.cursor/rules/openpets.mdc
Rules status: missing - Cursor OpenPets project rule is not installed.
OpenPets rules preview:
---
description: Use OpenPets MCP tools for lightweight coding-status feedback.
---

<!-- OPENPETS:CURSOR_RULES:START -->
# OpenPets status feedback

You may use the OpenPets MCP tools as a brief, safe status channel during meaningful coding work.

- Use `openpets_say` sparingly for major milestones, blocking states, completion, or when review is needed.
- Prefer `openpets_react` over speech for lightweight progress such as thinking, working, testing, success, or error.
- Keep messages short, user-facing, and safe.
- Do not send prompts, tool input/output, code, logs, stack traces, credentials, private file contents, URLs, file paths, or other sensitive content through OpenPets.
- Do not spam every internal step; use OpenPets only for meaningful progress changes and continue normally if a status update is unnecessary.
- If OpenPets is unavailable, continue the coding task without failing.
<!-- OPENPETS:CURSOR_RULES:END -->

Installed OpenPets Cursor rules in /tmp/openpets-cli-qXlYB8/cursor-rules-only.
Rules file: /tmp/openpets-cli-qXlYB8/cursor-rules-only/.cursor/rules/openpets.mdc
Cursor may use changed rules in a new or refreshed chat.
Cursor rules: /tmp/openpets-cli-qXlYB8/cursor-rules-only/.cursor/rules/openpets.mdc
Rules status: installed - Cursor OpenPets project rule is installed and up to date.
Removed OpenPets Cursor rules from /tmp/openpets-cli-qXlYB8/cursor-rules-only.
Backup: /tmp/openpets-cli-qXlYB8/cursor-rules-only/.cursor/rules/openpets.mdc.openpets-backup-258347-1782743076800-a38e8cc5-117e-4a45-aca0-08b80e37c8f1.mdc
Cursor may use changed rules in a new or refreshed chat.
Cursor config: /tmp/openpets-cli-qXlYB8/cursor-with-rules-conflict/.cursor/mcp.json
Status: missing - Cursor MCP config does not exist.
OpenPets MCP preview:
{
  "openpets": {
    "type": "stdio",
    "command": "npx",
    "args": [
      "-y",
      "@open-pets/mcp@3.0.0",
      "--pet",
      "fixer"
    ]
  }
}
Cursor rules: /tmp/openpets-cli-qXlYB8/cursor-with-rules-conflict/.cursor/rules/openpets.mdc
Rules status: conflict - Cursor OpenPets rule file has missing or duplicate managed markers.
OpenPets rules preview:
---
description: Use OpenPets MCP tools for lightweight coding-status feedback.
---

<!-- OPENPETS:CURSOR_RULES:START -->
# OpenPets status feedback

You may use the OpenPets MCP tools as a brief, safe status channel during meaningful coding work.

- Use `openpets_say` sparingly for major milestones, blocking states, completion, or when review is needed.
- Prefer `openpets_react` over speech for lightweight progress such as thinking, working, testing, success, or error.
- Keep messages short, user-facing, and safe.
- Do not send prompts, tool input/output, code, logs, stack traces, credentials, private file contents, URLs, file paths, or other sensitive content through OpenPets.
- Do not spam every internal step; use OpenPets only for meaningful progress changes and continue normally if a status update is unnecessary.
- If OpenPets is unavailable, continue the coding task without failing.
<!-- OPENPETS:CURSOR_RULES:END -->
- 

Fixes #77
,workdir:/home/alvin/repos/openpets,timeout:120000,