### PR TITLE
fix(claude): prefer installed app's bundled CLI for hooks instead of npx (fixes #78)

### DIFF
--- a/packages/claude/src/check-claude-hooks.ts
+++ b/packages/claude/src/check-claude-hooks.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { addOpenPetsHooks, claudeHookEvents, createOpenPetsHookCommand, createOpenPetsHookSettingsPreview, doctorClaudeHooks, getBundledClaudeCliPath, getLocalClaudeCliPath, installClaudeHooks, openPetsHookMarker, removeOpenPetsHooks, uninstallClaudeHooks } from "./hook-settings.js";
+import { addOpenPetsHooks, assertInstalledClaudeCliPath, claudeHookEvents, createOpenPetsHookCommand, createOpenPetsHookSettingsPreview, doctorClaudeHooks, findInstalledOpenPetsClaudeCli, getBundledClaudeCliPath, getLocalClaudeCliPath, installClaudeHooks, openPetsHookMarker, removeOpenPetsHooks, uninstallClaudeHooks } from "./hook-settings.js";
 import { hookSpeechPools } from "./hook-messages.js";
 import { handleClaudeHookPayload, hasProjectLocalOpenPetsHook, mapClaudeHookEvent, validateHookSpeech } from "./hooks.js";
 
@@ -38,6 +38,7 @@ const client = {
   status: async () => ({ ok: true, appRunning: true }),
   listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
   installPet: async () => { throw new Error("unused"); },
+  installLocalPet: async () => { throw new Error("unused"); },
   acquireLease: async (options?: { readonly requestedPetId?: string }) => {
     calls.push({ kind: "lease", value: "acquire", requestedPetId: options?.requestedPetId });
     return { leaseId: "lease-fixer", requestedPetId: options?.requestedPetId, targetKind: "explicit" as const, actualTargetPetId: options?.requestedPetId ?? "builtin", actualTargetPetName: "Fixer", usingDefaultPet: false, expiresAt: Date.now() + 15_000, leaseActive: true };
@@ -162,6 +163,41 @@ assert.equal(missingPetHook.status, 1);
 const malformedHook = spawnSync(process.execPath, [new URL("./cli.js", import.meta.url).pathname, "hook", "--openpets-managed"], { input: "not json", encoding: "utf8", env: isolatedEnv });
 assert.equal(malformedHook.status, 0);
 assert.equal(malformedHook.stdout, "");
+
+// Explicit installed-CLI path: hooks run as `node <abs-path> hook ...`, and the
+// resolved command must round-trip cleanly through install -> doctor (status
+// stays "installed", not "needs_update").
+const fakeAppCliDir = join(dir, "OpenPets.app", "Contents", "Resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist");
+mkdirSync(fakeAppCliDir, { recursive: true });
+const fakeAppCliPath = join(fakeAppCliDir, "cli.js");
+writeFileSync(fakeAppCliPath, "// bundled cli", "utf8");
+assertInstalledClaudeCliPath(fakeAppCliPath);
+const installedCliCommand = createOpenPetsHookCommand("published", undefined, "node", fakeAppCliPath);
+assert.ok(installedCliCommand.startsWith(`node ${fakeAppCliPath} hook ${openPetsHookMarker}`), "explicit installed CLI path must produce a node + absolute-path hook command");
+assert.ok(!installedCliCommand.includes("npx"), "explicit installed CLI path must not fall back to npx");
+const installedCliPreview = createOpenPetsHookSettingsPreview("published", undefined, "node", fakeAppCliPath);
+const installedCliHook = (((installedCliPreview.hooks as Record<string, unknown>).Stop as Array<{ hooks: Array<{ command: string }> }>)[0]?.hooks[0]);
+assert.equal(installedCliHook?.command, installedCliCommand);
+const explicitSettingsPath = join(dir, "explicit-cli-settings.json");
+writeFileSync(explicitSettingsPath, JSON.stringify(settings), "utf8");
+assert.equal(installClaudeHooks(explicitSettingsPath, "published", undefined, "node", fakeAppCliPath).status, "installed");
+assert.equal(doctorClaudeHooks(explicitSettingsPath, "published", undefined, "node", fakeAppCliPath).status, "installed");
+// A published-mode doctor sees the explicit-path hooks as stale (npx command differs).
+assert.equal(doctorClaudeHooks(explicitSettingsPath).status, "needs_update");
+
+// findInstalledOpenPetsClaudeCli returns the first valid candidate and skips
+// missing / malformed ones; returns null when nothing valid is present.
+assert.equal(findInstalledOpenPetsClaudeCli([join(dir, "nope", "cli.js"), fakeAppCliPath]), fakeAppCliPath);
+assert.equal(findInstalledOpenPetsClaudeCli([join(dir, "absent", "@open-pets", "claude", "dist", "cli.js")]), null);
+
+// Path validation rejects unsafe / wrong-shaped CLI paths.
+assert.throws(() => assertInstalledClaudeCliPath("relative/cli.js"));
+assert.throws(() => assertInstalledClaudeCliPath(join(dir, "OpenPets.app", "Contents", "Resources", "app.asar", "node_modules", "@open-pets", "claude", "dist", "cli.js")));
+assert.throws(() => assertInstalledClaudeCliPath(join(fakeAppCliDir, "index.js")));
+const symlinkedCliPath = join(dir, "linked-cli.js-target", "@open-pets", "claude", "dist", "cli.js");
+mkdirSync(join(dir, "linked-cli.js-target", "@open-pets", "claude", "dist"), { recursive: true });
+symlinkSync(fakeAppCliPath, symlinkedCliPath);
+assert.throws(() => assertInstalledClaudeCliPath(symlinkedCliPath));
 
 } finally {
   rmSync(dir, { recursive: true, force: true });

--- a/packages/claude/src/cli.ts
+++ b/packages/claude/src/cli.ts
@@ -11,7 +11,10 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "doctor-hooks") {
-    process.stderr.write(`${JSON.stringify(doctorClaudeHooks(readPathArg(args), undefined, readPetArg(args)), null, 2)}\n`);
+    // Resolve the same bundled-CLI path install-hooks would use, so a correct
+    // bundled install reports "installed" rather than a false "needs_update".
+    const installedCliPath = resolveInstalledClaudeCliPath(args);
+    process.stderr.write(`${JSON.stringify(doctorClaudeHooks(readPathArg(args), undefined, readPetArg(args), "node", installedCliPath ?? undefined), null, 2)}\n`);
     return;
   }
   if (command === "install-hooks") {
@@ -19,7 +22,7 @@ async function main(): Promise<void> {
     // `node <abs-path> hook ...`, paying no package-manager resolution cost per
     // firing. Fall back to the `npx -y @open-pets/claude` published command when
     // no install is found or the user opts out with --prefer-npx.
-    const installedCliPath = args.includes("--prefer-npx") ? null : findInstalledOpenPetsClaudeCli();
+    const installedCliPath = resolveInstalledClaudeCliPath(args);
     process.stderr.write(`${JSON.stringify(installClaudeHooks(readPathArg(args), undefined, readPetArg(args), "node", installedCliPath ?? undefined), null, 2)}\n`);
     return;
   }
@@ -48,6 +51,15 @@ function readPetArg(args: readonly string[]): string | undefined {
 
 function hasProjectLocalArg(args: readonly string[]): boolean {
   return args.includes("--project-local");
+}
+
+// install-hooks and doctor-hooks must resolve the hook command identically:
+// prefer an installed OpenPets app's bundled CLI unless --prefer-npx is passed
+// or no app is found. Resolving asymmetrically makes doctor-hooks report a
+// correct bundled install as needs_update.
+function resolveInstalledClaudeCliPath(args: readonly string[]): string | null {
+  if (args.includes("--prefer-npx")) return null;
+  return findInstalledOpenPetsClaudeCli();
 }
 
 main().catch((error: unknown) => {

--- a/packages/claude/src/cli.ts
+++ b/packages/claude/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { runClaudeHookFromStdin } from "./hooks.js";
-import { doctorClaudeHooks, installClaudeHooks, uninstallClaudeHooks } from "./hook-settings.js";
+import { doctorClaudeHooks, findInstalledOpenPetsClaudeCli, installClaudeHooks, uninstallClaudeHooks } from "./hook-settings.js";
 import { validateOpenPetsPetArg } from "./claude-code.js";
 
 async function main(): Promise<void> {
@@ -15,14 +15,19 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "install-hooks") {
-    process.stderr.write(`${JSON.stringify(installClaudeHooks(readPathArg(args), undefined, readPetArg(args)), null, 2)}\n`);
+    // Prefer the bundled CLI inside an installed OpenPets app: hooks then run as
+    // `node <abs-path> hook ...`, paying no package-manager resolution cost per
+    // firing. Fall back to the `npx -y @open-pets/claude` published command when
+    // no install is found or the user opts out with --prefer-npx.
+    const installedCliPath = args.includes("--prefer-npx") ? null : findInstalledOpenPetsClaudeCli();
+    process.stderr.write(`${JSON.stringify(installClaudeHooks(readPathArg(args), undefined, readPetArg(args), "node", installedCliPath ?? undefined), null, 2)}\n`);
     return;
   }
   if (command === "uninstall-hooks") {
     process.stderr.write(`${JSON.stringify(uninstallClaudeHooks(readPathArg(args)), null, 2)}\n`);
     return;
   }
-  process.stderr.write("Usage: open-pets-claude <hook|doctor-hooks|install-hooks|uninstall-hooks> [--settings <path>] [--pet <id>]\n");
+  process.stderr.write("Usage: open-pets-claude <hook|doctor-hooks|install-hooks|uninstall-hooks> [--settings <path>] [--pet <id>] [--prefer-npx]\n");
   process.exitCode = 1;
 }
 

--- a/packages/claude/src/hook-settings.ts
+++ b/packages/claude/src/hook-settings.ts
@@ -29,14 +29,80 @@ export function getClaudeUserSettingsPath(): string {
   return join(homedir(), ".claude", "settings.json");
 }
 
-export function createOpenPetsHookCommand(commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node"): string {
+export function createOpenPetsHookCommand(commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): string {
   const petArgs = selectedPetId === undefined ? "" : ` --pet ${shellQuote(validateOpenPetsPetArg(selectedPetId))}`;
+  // An explicitly resolved CLI path (e.g. the bundled CLI inside an installed
+  // OpenPets app, discovered by the external install-hooks command) always wins
+  // over the package-relative bundled/local paths and the npx fallback.
+  if (explicitCliPath !== undefined) {
+    assertInstalledClaudeCliPath(explicitCliPath);
+    return `${shellQuote(nodeCommand)} ${shellQuote(explicitCliPath)} hook ${openPetsHookMarker}${petArgs}`;
+  }
   if (commandMode === "local" || commandMode === "bundled") {
     const cliPath = commandMode === "bundled" ? getBundledClaudeCliPath() : getLocalClaudeCliPath();
     commandMode === "bundled" ? assertBundledClaudeCliPath() : assertLocalClaudeCliPath();
     return `${shellQuote(nodeCommand)} ${shellQuote(cliPath)} hook ${openPetsHookMarker}${petArgs}`;
   }
   return `npx -y @open-pets/claude hook ${openPetsHookMarker}${petArgs}`;
+}
+
+// Candidate locations of an installed OpenPets desktop app's bundled
+// `@open-pets/claude` CLI, by platform. The bundled CLI runs through `node`
+// against an absolute path, which avoids the per-invocation package-manager
+// resolution cost (`npx -y ...`) that the published fallback pays on every hook
+// firing. Order is most-specific/most-common first.
+function installedClaudeCliCandidates(): readonly string[] {
+  const rel = join("Contents", "Resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
+  const linuxRel = join("resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
+  const winRel = join("resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
+  if (process.platform === "darwin") {
+    return [
+      join("/Applications", "OpenPets.app", rel),
+      join(homedir(), "Applications", "OpenPets.app", rel),
+    ];
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    const programFiles = process.env.PROGRAMFILES;
+    return [
+      ...(localAppData ? [join(localAppData, "Programs", "openpets", winRel)] : []),
+      ...(programFiles ? [join(programFiles, "OpenPets", winRel)] : []),
+    ];
+  }
+  // Linux deb/rpm installs unpack here; AppImage mounts at runtime and is not
+  // discoverable, so those users keep the published fallback.
+  return [
+    join("/opt", "OpenPets", linuxRel),
+    join("/usr", "lib", "openpets", linuxRel),
+  ];
+}
+
+// Returns the absolute path to an installed OpenPets app's bundled Claude CLI,
+// or null when no valid install is found (the caller then keeps the npx
+// published fallback). Each candidate is validated the same way the bundled
+// command path is, minus the package-relative root check (the app lives outside
+// this package).
+export function findInstalledOpenPetsClaudeCli(candidates: readonly string[] = installedClaudeCliCandidates()): string | null {
+  for (const candidate of candidates) {
+    try {
+      assertInstalledClaudeCliPath(candidate);
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+export function assertInstalledClaudeCliPath(path: string): void {
+  if (!isAbsolute(path)) throw new Error("Installed Claude hook CLI path must be absolute.");
+  if (path.includes("\n") || path.includes("\r") || path.includes("\0")) throw new Error("Installed Claude hook CLI path contains unsupported characters.");
+  if (isTrueAsarPath(path)) throw new Error("Installed Claude hook CLI path must be unpacked outside app.asar.");
+  const cliDir = join("@open-pets", "claude", "dist");
+  if (!path.endsWith(join(cliDir, "cli.js"))) throw new Error("Installed Claude hook CLI path must point at @open-pets/claude/dist/cli.js.");
+  if (lstatSync(path).isSymbolicLink()) throw new Error("Installed Claude hook CLI path must not be a symlink.");
+  const stat = statSync(path);
+  if (!stat.isFile()) throw new Error("Installed Claude hook CLI path is not a regular file.");
 }
 
 export function getLocalClaudeCliPath(): string {
@@ -72,20 +138,20 @@ function isTrueAsarPath(path: string): boolean {
   return /app\.asar(?:$|[\\/])/.test(path) && !/app\.asar\.unpacked(?:$|[\\/])/.test(path);
 }
 
-export function createOpenPetsHookSettingsPreview(commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node"): Record<string, unknown> {
+export function createOpenPetsHookSettingsPreview(commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): Record<string, unknown> {
   const hooks: Record<string, unknown> = {};
   for (const event of claudeHookEvents) {
-    hooks[event] = [{ hooks: [createHookCommandEntry(commandMode, selectedPetId, nodeCommand)] }];
+    hooks[event] = [{ hooks: [createHookCommandEntry(commandMode, selectedPetId, nodeCommand, explicitCliPath)] }];
   }
   return { hooks };
 }
 
-export function doctorClaudeHooks(settingsPath = getClaudeUserSettingsPath(), commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node"): ClaudeHookDoctorResult {
-  const preview = createOpenPetsHookSettingsPreview(commandMode, selectedPetId, nodeCommand);
+export function doctorClaudeHooks(settingsPath = getClaudeUserSettingsPath(), commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): ClaudeHookDoctorResult {
+  const preview = createOpenPetsHookSettingsPreview(commandMode, selectedPetId, nodeCommand, explicitCliPath);
   const asyncSupported = isClaudeHookAsyncSupported();
   try {
     const settings = readClaudeSettings(settingsPath);
-    const status = getHookInstallStatus(settings, commandMode, selectedPetId, nodeCommand);
+    const status = getHookInstallStatus(settings, commandMode, selectedPetId, nodeCommand, explicitCliPath);
     return {
       status,
       settingsPath,
@@ -100,15 +166,15 @@ export function doctorClaudeHooks(settingsPath = getClaudeUserSettingsPath(), co
   }
 }
 
-export function installClaudeHooks(settingsPath = getClaudeUserSettingsPath(), commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node"): ClaudeHookWriteResult {
+export function installClaudeHooks(settingsPath = getClaudeUserSettingsPath(), commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): ClaudeHookWriteResult {
   if (!isClaudeHookAsyncSupported()) throw new Error("Claude async hook support is not enabled for this OpenPets build.");
   const settings = readClaudeSettings(settingsPath);
-  const status = getHookInstallStatus(settings, commandMode, selectedPetId, nodeCommand);
-  if (status === "installed") return { ...doctorClaudeHooks(settingsPath, commandMode, selectedPetId, nodeCommand), changed: false };
+  const status = getHookInstallStatus(settings, commandMode, selectedPetId, nodeCommand, explicitCliPath);
+  if (status === "installed") return { ...doctorClaudeHooks(settingsPath, commandMode, selectedPetId, nodeCommand, explicitCliPath), changed: false };
   const backupPath = backupSettings(settingsPath);
-  const next = addOpenPetsHooks(removeOpenPetsHooks(settings), commandMode, selectedPetId, nodeCommand);
+  const next = addOpenPetsHooks(removeOpenPetsHooks(settings), commandMode, selectedPetId, nodeCommand, explicitCliPath);
   writeClaudeSettings(settingsPath, next);
-  return { ...doctorClaudeHooks(settingsPath, commandMode, selectedPetId, nodeCommand), backupPath, changed: true };
+  return { ...doctorClaudeHooks(settingsPath, commandMode, selectedPetId, nodeCommand, explicitCliPath), backupPath, changed: true };
 }
 
 export function uninstallClaudeHooks(settingsPath = getClaudeUserSettingsPath(), commandMode: OpenPetsCommandMode = "published"): ClaudeHookWriteResult {
@@ -121,13 +187,13 @@ export function uninstallClaudeHooks(settingsPath = getClaudeUserSettingsPath(),
   return { ...doctorClaudeHooks(settingsPath, commandMode), backupPath, changed: true };
 }
 
-export function addOpenPetsHooks(settings: Record<string, unknown>, commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node"): Record<string, unknown> {
+export function addOpenPetsHooks(settings: Record<string, unknown>, commandMode: OpenPetsCommandMode = "published", selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): Record<string, unknown> {
   const next = structuredClone(settings) as Record<string, unknown>;
   assertSelectedHookEventsAreArrays(next);
   const hooks = isRecord(next.hooks) ? { ...next.hooks } : {};
   for (const event of claudeHookEvents) {
     const existing = Array.isArray(hooks[event]) ? hooks[event].filter((entry) => !containsOpenPetsHook(entry)) : [];
-    hooks[event] = [...existing, { hooks: [createHookCommandEntry(commandMode, selectedPetId, nodeCommand)] }];
+    hooks[event] = [...existing, { hooks: [createHookCommandEntry(commandMode, selectedPetId, nodeCommand, explicitCliPath)] }];
   }
   next.hooks = hooks;
   return next;
@@ -149,7 +215,7 @@ export function removeOpenPetsHooks(settings: Record<string, unknown>): Record<s
   return next;
 }
 
-function getHookInstallStatus(settings: Record<string, unknown>, commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node"): ClaudeHookInstallStatus {
+function getHookInstallStatus(settings: Record<string, unknown>, commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): ClaudeHookInstallStatus {
   if (settings.hooks !== undefined && !isRecord(settings.hooks)) throw new Error("Claude settings hooks field is not an object.");
   const hooks = isRecord(settings.hooks) ? settings.hooks : {};
   let foundAny = false;
@@ -157,7 +223,7 @@ function getHookInstallStatus(settings: Record<string, unknown>, commandMode: Op
   for (const event of claudeHookEvents) {
     const entries = hooks[event];
     if (!Array.isArray(entries)) return foundAny ? "needs_update" : "not_installed";
-    const currentCount = entries.filter((entry) => containsCurrentOpenPetsHook(entry, commandMode, selectedPetId, nodeCommand)).length;
+    const currentCount = entries.filter((entry) => containsCurrentOpenPetsHook(entry, commandMode, selectedPetId, nodeCommand, explicitCliPath)).length;
     const managedCount = entries.filter((entry) => containsOpenPetsHook(entry)).length;
     const hasCurrent = currentCount === 1;
     if (managedCount > 0) foundAny = true;
@@ -168,13 +234,13 @@ function getHookInstallStatus(settings: Record<string, unknown>, commandMode: Op
   return staleManaged ? "needs_update" : "installed";
 }
 
-function createHookCommandEntry(commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node"): Record<string, unknown> {
-  return { type: "command", command: createOpenPetsHookCommand(commandMode, selectedPetId, nodeCommand), timeout: 3, async: true, asyncRewake: false };
+function createHookCommandEntry(commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): Record<string, unknown> {
+  return { type: "command", command: createOpenPetsHookCommand(commandMode, selectedPetId, nodeCommand, explicitCliPath), timeout: 3, async: true, asyncRewake: false };
 }
 
-function containsCurrentOpenPetsHook(value: unknown, commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node"): boolean {
+function containsCurrentOpenPetsHook(value: unknown, commandMode: OpenPetsCommandMode, selectedPetId?: string, nodeCommand = "node", explicitCliPath?: string): boolean {
   if (!isRecord(value) || !Array.isArray(value.hooks)) return false;
-  const command = createOpenPetsHookCommand(commandMode, selectedPetId, nodeCommand);
+  const command = createOpenPetsHookCommand(commandMode, selectedPetId, nodeCommand, explicitCliPath);
   return value.hooks.some((hook) => isRecord(hook) && hook.type === "command" && hook.command === command && hook.timeout === 3 && hook.async === true && hook.asyncRewake === false);
 }
 

--- a/packages/claude/src/hook-settings.ts
+++ b/packages/claude/src/hook-settings.ts
@@ -52,28 +52,31 @@ export function createOpenPetsHookCommand(commandMode: OpenPetsCommandMode = "pu
 // resolution cost (`npx -y ...`) that the published fallback pays on every hook
 // firing. Order is most-specific/most-common first.
 function installedClaudeCliCandidates(): readonly string[] {
-  const rel = join("Contents", "Resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
-  const linuxRel = join("resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
-  const winRel = join("resources", "app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
+  // Path from the app's resources dir down to the bundled CLI. macOS nests
+  // resources under Contents/Resources; Windows and Linux use a top-level
+  // resources/ dir (identical from there on).
+  const cliFromResources = join("app.asar.unpacked", "node_modules", "@open-pets", "claude", "dist", "cli.js");
+  const macRel = join("Contents", "Resources", cliFromResources);
+  const resourcesRel = join("resources", cliFromResources);
   if (process.platform === "darwin") {
     return [
-      join("/Applications", "OpenPets.app", rel),
-      join(homedir(), "Applications", "OpenPets.app", rel),
+      join("/Applications", "OpenPets.app", macRel),
+      join(homedir(), "Applications", "OpenPets.app", macRel),
     ];
   }
   if (process.platform === "win32") {
     const localAppData = process.env.LOCALAPPDATA;
     const programFiles = process.env.PROGRAMFILES;
     return [
-      ...(localAppData ? [join(localAppData, "Programs", "openpets", winRel)] : []),
-      ...(programFiles ? [join(programFiles, "OpenPets", winRel)] : []),
+      ...(localAppData ? [join(localAppData, "Programs", "openpets", resourcesRel)] : []),
+      ...(programFiles ? [join(programFiles, "OpenPets", resourcesRel)] : []),
     ];
   }
   // Linux deb/rpm installs unpack here; AppImage mounts at runtime and is not
   // discoverable, so those users keep the published fallback.
   return [
-    join("/opt", "OpenPets", linuxRel),
-    join("/usr", "lib", "openpets", linuxRel),
+    join("/opt", "OpenPets", resourcesRel),
+    join("/usr", "lib", "openpets", resourcesRel),
   ];
 }
 
@@ -282,7 +285,7 @@ function isClaudeHookAsyncSupported(): boolean {
 
 function shellQuote(value: string): string {
   if (/^[a-zA-Z0-9_@%+=:,./-]+$/.test(value)) return value;
-  if (/[\r\n"]/.test(value) || value.includes("\0")) throw new Error("Local Claude hook path contains unsupported shell characters.");
+  if (/[\r\n"]/.test(value) || value.includes("\0")) throw new Error("Claude hook path contains unsupported shell characters.");
   return `"${value.replaceAll("\\", "\\\\").replaceAll("$", "\\$").replaceAll("`", "\\`")}"`;
 }
 


### PR DESCRIPTION
## Summary

Fixes #78. The external `@open-pets/claude install-hooks` command writes hook commands that shell out to `npx -y @open-pets/claude hook --openpets-managed`. Because these hooks fire on every Claude Code event (`UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `Notification`, `Stop`, `StopFailure`) and are configured `async: true, asyncRewake: false` with a 3s timeout, npm's package-resolution cold start (~1-3s per invocation) causes firings to overlap and stack during tool-call bursts.

On an otherwise idle machine I observed **12+ concurrent `npm exec @open-pets/claude hook` processes, each at 60-120% CPU**, enough to make the whole system sluggish.

## Root cause

The in-app setup flow already avoids this. It installs hooks in `"bundled"` command mode and writes:

```
node <app>/Contents/Resources/app.asar.unpacked/node_modules/@open-pets/claude/dist/cli.js hook --openpets-managed
```

That command runs `node` directly against an absolute path and pays **no** package-manager resolution cost per firing.

The external CLI never reaches this fast path: its `"bundled"` resolution (`getBundledClaudeCliPath()`) is relative to where the `@open-pets/claude` package is *running from* (the `npx`/`bunx` cache when invoked externally), not the installed app. So the only mode available to the external CLI was `"published"` → `npx`.

Measured cold-start on the reporting machine:

| Hook command | Cold start |
| --- | --- |
| `npx -y @open-pets/claude hook` (current default) | ~2.2s |
| `node <installed-app>/.../cli.js hook` (this PR) | ~0.5s |

## What this PR does

Makes `install-hooks` discover an installed OpenPets app and prefer its bundled CLI, falling back to the existing `npx` command when no app is found.

- **`findInstalledOpenPetsClaudeCli()`** — checks platform-standard install locations (macOS `/Applications` + `~/Applications`; Windows `LOCALAPPDATA`/`PROGRAMFILES`; Linux `/opt` + `/usr/lib`) and returns the first path that passes validation, else `null`. AppImage (mounted at runtime, not discoverable) keeps the published fallback.
- **`assertInstalledClaudeCliPath()`** — validates a discovered path: absolute, unpacked (not inside `app.asar`), correct `@open-pets/claude/dist/cli.js` shape, regular file, not a symlink.
- **`createOpenPetsHookCommand()`** (and the `install` / `doctor` / status chain) take an optional explicit CLI path. When set, the hook command is `node <abs-path> hook ...`. The path is threaded through both the command writer and the status comparison so `install` → `doctor` stays consistent (no spurious `needs_update`).
- **`install-hooks`** uses the discovered path when present; falls back to `npx` when no app is found or `--prefer-npx` is passed.

Behaviour is unchanged when no OpenPets app is installed.

## Drive-by fix

`packages/claude/src/check-claude-hooks.ts` mock client was missing the `installLocalPet` method that the `OpenPetsClient` interface gained in #79, which broke `tsc` for this package on `main`. Added the missing mock method so the package typechecks again.

## Testing

- `pnpm --filter @open-pets/claude typecheck` — clean
- `pnpm --filter @open-pets/claude build` — clean
- `pnpm --filter @open-pets/claude test` — passes, including new assertions for explicit-path command generation, install→doctor round-trip consistency, `findInstalledOpenPetsClaudeCli` candidate selection, and path validation (rejects relative paths, `app.asar` paths, wrong filenames, and symlinks).
- Verified end-to-end against a real installed `OpenPets.app` (macOS Intel): discovery resolves the bundled CLI and produces the `node <abs-path>` command with no `npx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)