### PR TITLE
Recover mouse interop on macOS when forwarded events stop (stuck pet)

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -61,6 +61,7 @@ const behaviorTests = [
   ".test-dist/tests/preference-patch.test.js",
   ".test-dist/tests/plugin-agent-activity.test.js",
   ".test-dist/tests/pet-window-wayland-predicate.test.js",
+  ".test-dist/tests/pet-window-mouse-forwarding-predicate.test.js",
 ];
 const contractTests = [
   ".test-dist/contracts/local-ipc-protocol.contract.js",

--- a/apps/desktop/src/mouse-forwarding.ts
+++ b/apps/desktop/src/mouse-forwarding.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure, dependency-free mouse-forwarding decision logic.
+ *
+ * This logic is extracted out of `pet-window.ts` (which imports Electron and so
+ * cannot be loaded by the plain-Node `node:test` runner) so the exact production
+ * predicates can be unit-tested directly instead of through a hand-rolled copy.
+ * `pet-window.ts` reads the live platform and delegates here, guaranteeing the
+ * tests and production never drift.
+ */
+
+/**
+ * Whether a click-through pet window can still receive *forwarded* mouse events
+ * (`setIgnoreMouseEvents(true, { forward: true })`).
+ *
+ * On Linux, Electron does not forward mouse events to ignored windows at all, so
+ * pet windows there are kept interactive instead (see `setPassthrough`).
+ */
+export function canForwardMouseEvents(platform: NodeJS.Platform | string): boolean {
+  return platform === "darwin" || platform === "win32";
+}
+
+/**
+ * Whether the cursor-probe watchdog should run for a click-through pet window.
+ *
+ * Forwarded mouse events are the *only* way a click-through pet learns that the
+ * cursor is over it, and the compositor can silently stop delivering them:
+ *   - Windows: Chromium's forwarded mouse tracking goes stale after rapid pet
+ *     HTML reloads and fullscreen sweeps.
+ *   - macOS: the WindowServer stops delivering forwarded moves after Space
+ *     switches, display sleep, and fullscreen transitions.
+ *
+ * When that happens the renderer's hit-test never fires, passthrough is never
+ * lifted, and the pet becomes permanently unclickable and undraggable until the
+ * app restarts. The watchdog re-arms forwarding from the main process using
+ * `screen.getCursorScreenPoint()`, which keeps working even when event
+ * forwarding is dead.
+ *
+ * The watchdog therefore has to cover *every* platform that depends on forwarded
+ * events — it is exactly `canForwardMouseEvents`. Guarding it on Windows alone
+ * leaves macOS pets stuck.
+ */
+export function shouldWatchForwardedMouseEvents(platform: NodeJS.Platform | string): boolean {
+  return canForwardMouseEvents(platform);
+}

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -17,6 +17,7 @@ import type { ActiveBubble } from "./plugin-bubble-arbiter.js";
 import type { PluginBubbleIndicator, PluginCommandForm, PluginBubbleHud, PluginBubbleHudItem } from "./plugin-sdk-bridge.js";
 import { defaultPetSprite, motionToSpriteState, resolveReactionSpriteState, type PetMotionState, type UniversalSpriteState } from "./reaction-animation-mapping.js";
 import { isFocusActionAvailable } from "./capabilities.js";
+import { canForwardMouseEvents as platformCanForwardMouseEvents, shouldWatchForwardedMouseEvents } from "./mouse-forwarding.js";
 import { computeEffectiveWaylandBackend, shouldPetWindowBeFocusable } from "./wayland-backend.js";
 
 export interface PetWindowInteractionHooks {
@@ -332,7 +333,7 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
   let forwardingWatchTimer: NodeJS.Timeout | null = null;
   const rearmTimers = new Set<NodeJS.Timeout>();
   const webContents = window.webContents;
-  const canForwardMouseEvents = process.platform === "darwin" || process.platform === "win32";
+  const canForwardMouseEvents = platformCanForwardMouseEvents(process.platform);
 
   const scheduleMouseInteropRecovery = (reason: string): void => {
     if (window.isDestroyed()) return;
@@ -375,7 +376,7 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     rearmTimers.clear();
   };
 
-  const clearWindowsForwardingWatch = (): void => {
+  const clearForwardingWatch = (): void => {
     if (!forwardingWatchTimer) return;
     clearTimeout(forwardingWatchTimer);
     forwardingWatchTimer = null;
@@ -403,13 +404,13 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     webContents.send("openpets:pet-probe-hit-test", { clientX: probe.clientX, clientY: probe.clientY, reason });
   };
 
-  const rearmWindowsMouseForwarding = (reason: string, logRearm = true): void => {
+  const rearmMouseForwarding = (reason: string, logRearm = true): void => {
     if (window.isDestroyed()) return;
     if (dragging || lastInteractive) {
-      if (logRearm) debug("pet.window", "windows mouse forwarding rearm skipped", { windowId, reason, dragging: Boolean(dragging), interactive: lastInteractive });
+      if (logRearm) debug("pet.window", "mouse forwarding rearm skipped", { windowId, reason, dragging: Boolean(dragging), interactive: lastInteractive });
       return;
     }
-    if (logRearm) debug("pet.window", "windows mouse forwarding rearm", { windowId, reason });
+    if (logRearm) debug("pet.window", "mouse forwarding rearm", { windowId, reason });
     window.setIgnoreMouseEvents(false);
     window.setIgnoreMouseEvents(true, { forward: true });
     requestCursorHitTestProbe(reason, logRearm);
@@ -418,18 +419,18 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
   const scheduleWindowsMouseForwardingRearm = (reason: string, delayMs: number): void => {
     const timer = setTimeout(() => {
       rearmTimers.delete(timer);
-      rearmWindowsMouseForwarding(reason);
+      rearmMouseForwarding(reason);
     }, delayMs);
     rearmTimers.add(timer);
   };
 
-  const scheduleWindowsForwardingWatch = (reason: string): void => {
-    if (process.platform !== "win32" || forwardingWatchTimer || dragging || lastInteractive || window.isDestroyed()) return;
+  const scheduleForwardingWatch = (reason: string): void => {
+    if (!shouldWatchForwardedMouseEvents(process.platform) || forwardingWatchTimer || dragging || lastInteractive || window.isDestroyed()) return;
     forwardingWatchTimer = setTimeout(() => {
       forwardingWatchTimer = null;
       if (window.isDestroyed() || dragging || lastInteractive) return;
-      if (getCursorProbe().inside) rearmWindowsMouseForwarding(reason, false);
-      scheduleWindowsForwardingWatch(reason);
+      if (getCursorProbe().inside) rearmMouseForwarding(reason, false);
+      scheduleForwardingWatch(reason);
     }, 750);
     forwardingWatchTimer.unref?.();
   };
@@ -438,6 +439,14 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     if (window.isDestroyed()) return;
     if (process.platform !== "win32") {
       setPassthrough(true);
+      // macOS also depends on forwarded mouse events, and the WindowServer can
+      // stop delivering them across Space switches / display sleep. Probe the
+      // cursor now and keep the watchdog armed so the pet cannot get stuck
+      // click-through with no way back to interactive.
+      if (canForwardMouseEvents) {
+        requestCursorHitTestProbe(reason);
+        scheduleForwardingWatch(reason);
+      }
       return;
     }
 
@@ -446,7 +455,7 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     // Toggle immediately, probe the current cursor hit target, then repeat the
     // toggle shortly after load because Windows sometimes re-registers mouse
     // forwarding after Chromium finishes late compositing work.
-    rearmWindowsMouseForwarding(reason);
+    rearmMouseForwarding(reason);
     scheduleWindowsMouseForwardingRearm(`${reason}+75ms`, 75);
     scheduleWindowsMouseForwardingRearm(`${reason}+175ms`, 175);
   };
@@ -462,14 +471,15 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     const sourceName = typeof source === "string" ? source : undefined;
     if (sourceName !== "idle-forwarding-watch" || lastInteractive) debug("pet.window", "hit test", { windowId, interactive: lastInteractive, dragging, source: sourceName });
     setPassthrough(!lastInteractive && !dragging);
-    if (lastInteractive || dragging) clearWindowsForwardingWatch();
-    else scheduleWindowsForwardingWatch("idle-forwarding-watch");
+    if (lastInteractive || dragging) clearForwardingWatch();
+    else scheduleForwardingWatch("idle-forwarding-watch");
   };
 
   const handleReady = (event: IpcMainEvent): void => {
     if (!isFromWindow(event)) return;
     rendererReady = true;
     setPassthrough(true);
+    scheduleForwardingWatch("ready-forwarding-watch");
   };
 
   const handleDragStart = (event: IpcMainEvent, point: unknown): void => {
@@ -482,7 +492,7 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     dragging = { startScreenX: point.screenX, startScreenY: point.screenY, startWindowX: startBounds.x, startWindowY: startBounds.y, width: startBounds.width, height: startBounds.height };
     petWindowDragging.set(window, true);
     debug("pet.window", "drag start", { windowId, point, startBounds });
-    clearWindowsForwardingWatch();
+    clearForwardingWatch();
     setPassthrough(false);
     onPetEvent?.("pet:dragStart", {});
   };
@@ -586,7 +596,7 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     ipcMain.off("openpets:bubble-submit", handleBubbleSubmit);
     ipcMain.off("openpets:pet-event", handlePetEvent);
     clearRearmTimers();
-    clearWindowsForwardingWatch();
+    clearForwardingWatch();
     petMouseInteropRecovery.delete(window);
     petWindowDragging.delete(window);
     if (!webContents.isDestroyed()) {

--- a/apps/desktop/tests/pet-window-mouse-forwarding-predicate.test.ts
+++ b/apps/desktop/tests/pet-window-mouse-forwarding-predicate.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { canForwardMouseEvents, shouldWatchForwardedMouseEvents } from "../src/mouse-forwarding.js";
+
+// ─── real-function predicate tests ───────────────────────────────────────────
+// These exercise the REAL production predicates — the pure, Electron-free core
+// that pet-window.ts delegates to for its passthrough/watchdog decisions — so
+// the test and production logic cannot drift. The Electron-bound runtime wiring
+// (setIgnoreMouseEvents, the 750ms cursor probe, the timer bookkeeping) lives in
+// pet-window.ts's installMousePassthroughAndDrag().
+
+describe("canForwardMouseEvents", () => {
+  it("reports forwarding support on the platforms Electron forwards on", () => {
+    assert.equal(canForwardMouseEvents("darwin"), true);
+    assert.equal(canForwardMouseEvents("win32"), true);
+  });
+
+  it("reports no forwarding support on Linux, where ignored windows get no events", () => {
+    assert.equal(canForwardMouseEvents("linux"), false);
+  });
+});
+
+describe("shouldWatchForwardedMouseEvents", () => {
+  // Regression guard: the watchdog used to be win32-only while forwarding was
+  // used on darwin too. When macOS's WindowServer stopped delivering forwarded
+  // mousemove events (Space switch, display sleep, fullscreen transition), the
+  // renderer hit-test never fired, passthrough was never lifted, and the pet
+  // stayed unclickable and undraggable until the app restarted.
+  it("watches macOS, where the WindowServer can silently stop forwarding events", () => {
+    assert.equal(shouldWatchForwardedMouseEvents("darwin"), true);
+  });
+
+  it("keeps watching Windows, where forwarded mouse tracking goes stale", () => {
+    assert.equal(shouldWatchForwardedMouseEvents("win32"), true);
+  });
+
+  it("does not watch Linux, where pet windows stay interactive instead", () => {
+    assert.equal(shouldWatchForwardedMouseEvents("linux"), false);
+  });
+
+  it("watches exactly the platforms that depend on forwarded mouse events", () => {
+    // The invariant the fix restores: a platform that relies on forwarded events
+    // to detect hover MUST have a recovery path when those events stop arriving.
+    for (const platform of ["darwin", "win32", "linux", "freebsd"]) {
+      assert.equal(shouldWatchForwardedMouseEvents(platform), canForwardMouseEvents(platform), platform);
+    }
+  });
+});

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -50,6 +50,17 @@ Two distinct window roles, two controllers:
 Both are created by `pet-window.ts` as transparent, frameless, always-on-top
 windows, driven through `pet-preload.cjs` for drag and click-through behavior.
 
+While a pet is click-through it only learns that the cursor is over it through
+*forwarded* mouse events (`setIgnoreMouseEvents(true, { forward: true })`), which
+Electron delivers on macOS and Windows but not on Linux (Linux pet windows are
+kept interactive instead). Both compositors can silently stop forwarding — macOS
+across Space switches, display sleep, and fullscreen transitions; Windows after
+rapid pet reloads and fullscreen sweeps — which would leave the pet stuck
+click-through and impossible to grab. A cursor-probe watchdog in `pet-window.ts`
+re-arms forwarding from the main process (`screen.getCursorScreenPoint()`), which
+keeps working even when forwarding is dead. The platform predicates live in
+`mouse-forwarding.ts`.
+
 ## Reactions → animations → speech
 
 A **reaction** is a categorical pet state (thinking, editing, testing, waiting


### PR DESCRIPTION
## The bug

On macOS a pet can become permanently ungrabbable — it keeps animating, but clicks pass straight through it and it can't be dragged or right-clicked. The only way out is restarting the app.

While a pet window is click-through, it only learns the cursor is over it through **forwarded** mouse events (`setIgnoreMouseEvents(true, { forward: true })`). The macOS WindowServer silently stops delivering those forwarded moves after certain window-server transitions. When that happens:

1. The renderer's hit-test never fires.
2. `openpets:pet-hit-test` never reaches the main process.
3. Passthrough is never lifted.
4. The pet stays click-through forever, with no path back to interactive.

### Repro

1. Run OpenPets on macOS with a pet on screen.
2. Trigger a window-server transition that kills forwarded events — any of these does it:
   - switch to another Space (or into/out of a fullscreen app) and come back;
   - let the display sleep, then wake it;
   - plug/unplug an external display.
3. Move the cursor over the pet and try to click or drag it.

**Expected:** the pet becomes interactive under the cursor.
**Actual:** the pet is inert. The cursor hits whatever is behind it. `pet.window hit test` debug lines stop appearing entirely — the main process is no longer being told the cursor is over the pet. Restarting the app is the only recovery.

It's environmental, so it doesn't reproduce on every machine on the first try — the Space-switch and display-sleep paths are the most reliable triggers.

## The fix

The codebase already solves this exact failure mode on Windows. `scheduleWindowsForwardingWatch` is a 750ms cursor-probe watchdog that re-arms mouse forwarding from the **main** process via `screen.getCursorScreenPoint()` — so it keeps working even when event forwarding is dead. It only probes while the cursor is inside the window bounds, and the timer is `unref`'d.

That watchdog was gated on `win32`, while forwarding is used on `darwin` **and** `win32` (`canForwardMouseEvents`). macOS therefore had the failure mode but not the recovery. This PR runs the watchdog on every platform that depends on forwarded events, and arms it on the ready/rearm paths.

No new mechanism, no new timers on Linux (which never forwards and keeps its windows interactive), and no behavior change on Windows.

### Shape of the change

- **New `apps/desktop/src/mouse-forwarding.ts`** — the platform decision as pure, Electron-free predicates (`canForwardMouseEvents`, `shouldWatchForwardedMouseEvents`), so it can be unit-tested by the plain-Node `node:test` runner. This mirrors the existing `wayland-backend.ts` split, and encodes the invariant that caused the bug: *the watchdog must cover exactly the platforms that rely on forwarded events.*
- **`pet-window.ts`** — delegates to those predicates, and arms the watchdog on `rearmPassthrough` and `handleReady`.
- **Renames** — `scheduleWindowsForwardingWatch` → `scheduleForwardingWatch`, `rearmWindowsMouseForwarding` → `rearmMouseForwarding`, `clearWindowsForwardingWatch` → `clearForwardingWatch`. The `Windows` prefix is what hid the bug: these now run on both platforms. `scheduleWindowsMouseForwardingRearm` is genuinely win32-only and keeps its name.
- **`docs/pets.md`** — documents the forwarded-event contract and the watchdog, per `AGENTS.md`.

## Tests

`apps/desktop/tests/pet-window-mouse-forwarding-predicate.test.ts` (registered in `run-tests.mjs`) pins the invariant. It fails against the old win32-only behavior and passes with the fix:

```
# without the fix (watchdog gated on win32 only)
not ok 2 - shouldWatchForwardedMouseEvents
# tests 6  # pass 4  # fail 2

# with the fix
# tests 6  # pass 6  # fail 0
```

`pnpm --filter @open-pets/desktop typecheck` and `build` are clean, and every behavior + contract test passes.

Two checks fail identically on a clean `main` checkout on my machine, unrelated to this change (I left both alone):
- `pet-motion-engine-nan-guard.test.js` — one case is cancelled with *"Promise resolution is still pending but the event loop has already resolved"*.
- `check-packaging-contract.js` — wants `web/app/plugins/posthog.client.js`, which isn't in a fresh clone.
