### PR TITLE
Add multi-pet LAN coordinator foundation

### DIFF
--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -18,12 +18,21 @@ export type LanClientRecord = {
   readonly host: string;
   readonly lastSeen: number;
   readonly position?: LanPoint;
+  readonly petId?: string;
+};
+
+export type LanPetRecord = {
+  readonly ownerHost: string;
+  readonly petId: string;
+  readonly currentHost: string;
+  readonly position?: LanPoint;
 };
 
 export type LanState = {
   readonly enabled: true;
   readonly currentHost: string | null;
   readonly clients: readonly LanClientRecord[];
+  readonly pets?: readonly LanPetRecord[];
   readonly updatedAt: number;
 };
 
@@ -36,6 +45,8 @@ export interface LanCoordinatorOptions {
 export class LanCoordinator {
   readonly #staleClientMs: number;
   readonly #clients = new Map<string, LanClientRecord>();
+  readonly #pets = new Map<string, LanPetRecord>();
+  readonly #petEdgeArmed = new Set<string>();
   readonly #topology: LanTopology;
   #currentHost: string | null = null;
   #preferredHost: string | null = null;
@@ -55,8 +66,17 @@ export class LanCoordinator {
     }
   }
 
-  register(host: string, position: LanPoint | undefined, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  register(host: string, position: LanPoint | undefined, now: number, petId?: string): LanState {
+    this.#clients.set(host, { host, lastSeen: now, position, petId });
+    if (petId) {
+      const existingPet = this.#pets.get(host);
+      this.#pets.set(host, {
+        ownerHost: host,
+        petId,
+        currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
+        position: existingPet?.position ?? position,
+      });
+    }
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -76,8 +96,10 @@ export class LanCoordinator {
     return this.snapshot(now);
   }
 
-  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number, ownerHost?: string): LanState {
+    const existingClient = this.#clients.get(host);
+    this.#clients.set(host, { host, lastSeen: now, position, petId: existingClient?.petId });
+    if (ownerHost) this.#updatePetPosition(host, ownerHost, position, edge);
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -104,6 +126,7 @@ export class LanCoordinator {
       enabled: true,
       currentHost: this.#currentHost,
       clients: [...this.#clients.values()].sort((a, b) => a.host.localeCompare(b.host)),
+      pets: [...this.#pets.values()].filter((pet) => this.#clients.has(pet.ownerHost) && this.#clients.has(pet.currentHost)).sort((a, b) => a.ownerHost.localeCompare(b.ownerHost)),
       updatedAt: now,
     };
   }
@@ -112,10 +135,40 @@ export class LanCoordinator {
     for (const [host, record] of this.#clients) {
       if (now - record.lastSeen > this.#staleClientMs) this.#clients.delete(host);
     }
+    for (const [ownerHost, pet] of this.#pets) {
+      if (!this.#clients.has(ownerHost)) {
+        this.#pets.delete(ownerHost);
+        this.#petEdgeArmed.delete(ownerHost);
+      } else if (!this.#clients.has(pet.currentHost)) {
+        this.#pets.set(ownerHost, { ...pet, currentHost: ownerHost });
+      }
+    }
     if (this.#currentHost && !this.#clients.has(this.#currentHost)) {
       this.#currentHost = this.#clients.keys().next().value ?? null;
       this.#edgeArmed = false;
     }
+  }
+
+  #updatePetPosition(host: string, ownerHost: string, position: LanPoint | undefined, edge: LanEdge | null): void {
+    const pet = this.#pets.get(ownerHost);
+    if (!pet || pet.currentHost !== host) return;
+    let currentHost = pet.currentHost;
+    if (!edge) this.#petEdgeArmed.add(ownerHost);
+    else if (position && this.#petEdgeArmed.has(ownerHost)) {
+      currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
+      this.#petEdgeArmed.delete(ownerHost);
+    }
+    this.#pets.set(ownerHost, { ...pet, currentHost, position });
+  }
+
+  #getPetNeighbor(currentHost: string, edge: LanEdge): string | null {
+    const configured = this.#topology[currentHost]?.[edge];
+    if (configured && this.#clients.has(configured)) return configured;
+    const hosts = [...this.#clients.keys()].sort();
+    if (hosts.length < 2) return null;
+    const index = hosts.indexOf(currentHost);
+    if (index < 0) return null;
+    return edge === "right" || edge === "down" ? hosts[(index + 1) % hosts.length] : hosts[(index - 1 + hosts.length) % hosts.length];
   }
 
   #migrate(edge: LanEdge): void {
@@ -157,6 +210,10 @@ export function normalizeLanPoint(value: unknown): LanPoint | undefined {
 
 export function normalizeLanEdge(value: unknown): LanEdge | null {
   return value === "left" || value === "right" || value === "up" || value === "down" ? value : null;
+}
+
+export function normalizeLanPetId(value: unknown): string | null {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value) ? value : null;
 }
 
 export function normalizeLanTopology(value: unknown): LanTopology {

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -67,15 +67,19 @@ export class LanCoordinator {
   }
 
   register(host: string, position: LanPoint | undefined, now: number, petId?: string): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position, petId });
-    if (petId) {
+    const normalizedPetId = normalizeLanPetId(petId) ?? undefined;
+    this.#clients.set(host, { host, lastSeen: now, position, petId: normalizedPetId });
+    if (normalizedPetId) {
       const existingPet = this.#pets.get(host);
       this.#pets.set(host, {
         ownerHost: host,
-        petId,
+        petId: normalizedPetId,
         currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
         position: existingPet?.position ?? position,
       });
+    } else {
+      this.#pets.delete(host);
+      this.#petEdgeArmed.delete(host);
     }
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
@@ -141,6 +145,7 @@ export class LanCoordinator {
         this.#petEdgeArmed.delete(ownerHost);
       } else if (!this.#clients.has(pet.currentHost)) {
         this.#pets.set(ownerHost, { ...pet, currentHost: ownerHost });
+        this.#petEdgeArmed.delete(ownerHost);
       }
     }
     if (this.#currentHost && !this.#clients.has(this.#currentHost)) {
@@ -154,9 +159,9 @@ export class LanCoordinator {
     if (!pet || pet.currentHost !== host) return;
     let currentHost = pet.currentHost;
     if (!edge) this.#petEdgeArmed.add(ownerHost);
-    else if (position && this.#petEdgeArmed.has(ownerHost)) {
-      currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
+    else if (this.#petEdgeArmed.has(ownerHost)) {
       this.#petEdgeArmed.delete(ownerHost);
+      if (position) currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
     }
     this.#pets.set(ownerHost, { ...pet, currentHost, position });
   }

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
+import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
 
 const coordinator = new LanCoordinator({ staleClientMs: 1_000 });
 
@@ -68,6 +68,22 @@ offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 120, y: 1
 offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 6_300);
 assert.equal(offlineState.currentHost, "beta", "offline configured neighbor should fall back to sorted cycling");
 
+// Multi-pet foundation: each host contributes an independently movable pet,
+// allowing two pets to occupy the same host without changing legacy behavior.
+const multiPetCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let multiPetState = multiPetCoordinator.register("alpha", { x: 100, y: 100 }, 7_000, "cat");
+multiPetState = multiPetCoordinator.register("beta", { x: 200, y: 100 }, 7_100, "dog");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
+  ["alpha", "cat", "alpha"],
+  ["beta", "dog", "beta"],
+], "each LAN host should register its own independently hosted pet");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 7_200, "alpha");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 7_300, "alpha");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
+  ["alpha", "beta"],
+  ["beta", "beta"],
+], "one LAN pet should migrate onto a host that already has another pet");
+
 
 const topologyDiagnostics = normalizeLanTopology({
   alpha: { right: "beta", left: "alpha" },
@@ -90,5 +106,7 @@ assert.deepEqual(normalizeLanPoint({ x: 12.7, y: "9" }), { x: 13, y: 9 });
 assert.equal(normalizeLanPoint({ x: Number.NaN, y: 1 }), undefined);
 assert.equal(normalizeLanEdge("left"), "left");
 assert.equal(normalizeLanEdge("diagonal"), null);
+assert.equal(normalizeLanPetId("pixel-cat"), "pixel-cat");
+assert.equal(normalizeLanPetId("../cat"), null);
 
 console.log("LAN coordinator validation passed.");

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -84,6 +84,42 @@ assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHos
   ["beta", "beta"],
 ], "one LAN pet should migrate onto a host that already has another pet");
 
+// Registration is the coordinator trust boundary: unsafe IDs must never enter
+// snapshots, and a host that no longer selects a pet must remove its old record.
+const registrationCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_000, "../cat");
+assert.equal(registrationState.clients[0]?.petId, undefined, "invalid pet IDs should be discarded at registration");
+assert.deepEqual(registrationState.pets, [], "invalid pet IDs should not create coordinator pet records");
+registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_100, "cat");
+assert.equal(registrationState.pets?.[0]?.petId, "cat", "a valid selection should create the owner's pet record");
+registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_200);
+assert.equal(registrationState.clients[0]?.petId, undefined, "deselection should clear the client selection");
+assert.deepEqual(registrationState.pets, [], "deselection should remove the owner's previous pet record");
+
+// An interrupted crossing consumes the arm. Reconnecting another host while
+// the pet remains at the edge must not cause a delayed, surprise handoff.
+const interruptedHandoffCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let interruptedState = interruptedHandoffCoordinator.register("alpha", { x: 100, y: 100 }, 9_000, "cat");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 9_100, "alpha");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", undefined, "right", 9_200, "alpha");
+interruptedState = interruptedHandoffCoordinator.register("beta", { x: 200, y: 100 }, 9_300, "dog");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 9_400, "alpha");
+assert.equal(interruptedState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "an interrupted handoff should require moving away from the edge before retrying");
+
+// If a destination disappears, recovery returns the pet to its owner and
+// clears the old host's arm so a reconnect cannot immediately bounce it away.
+const hostLossCoordinator = new LanCoordinator({ staleClientMs: 1_000 });
+let hostLossState = hostLossCoordinator.register("alpha", { x: 100, y: 100 }, 10_000, "cat");
+hostLossState = hostLossCoordinator.register("beta", { x: 200, y: 100 }, 10_100, "dog");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 10_200, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 10_300, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("beta", { x: 220, y: 100 }, null, 10_400, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 100, y: 100 }, null, 11_500);
+assert.equal(hostLossState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "host loss should return a visiting pet to its connected owner");
+hostLossState = hostLossCoordinator.register("beta", { x: 200, y: 100 }, 11_600, "dog");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 11_700, "alpha");
+assert.equal(hostLossState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "host-loss recovery should require a fresh interior position before another handoff");
+
 
 const topologyDiagnostics = normalizeLanTopology({
   alpha: { right: "beta", left: "alpha" },

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -10,6 +10,10 @@ The coordinator state can also represent one independently traveling pet per
 connected host. Each record keeps the pet's owner host, selected pet ID, current
 host, and latest position. This foundation allows two pets to occupy the same
 host while preserving the existing single-pet fields and behavior.
+Pet IDs are normalized at registration, and clearing a host's selection removes
+its coordinator record. Every edge-crossing attempt consumes its arm; returning
+a pet to its owner after host loss also requires a fresh move away from the edge
+before another handoff.
 
 Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
 and Control Center setup are intentionally deferred to later phases of

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -4,6 +4,19 @@ This experimental mode makes one OpenPets default pet shared across PCs on a LAN
 Only the current owner machine shows the pet. Dragging the pet to a screen edge
 hands ownership to the next/previous connected host.
 
+## Experimental multi-pet foundation
+
+The coordinator state can also represent one independently traveling pet per
+connected host. Each record keeps the pet's owner host, selected pet ID, current
+host, and latest position. This foundation allows two pets to occupy the same
+host while preserving the existing single-pet fields and behavior.
+
+Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
+and Control Center setup are intentionally deferred to later phases of
+[issue #93](https://github.com/alvinunreal/openpets/issues/93). Multi-machine GUI
+validation is pending while the second test system is unavailable, so this work
+remains experimental.
+
 ## Server PC
 
 PowerShell:


### PR DESCRIPTION
## Summary

Adds the coordinator-state foundation for experimental multi-pet LAN mode from #93.

- represents one independently traveling pet per connected host
- tracks each pet's owner host, selected pet ID, current host, and latest position
- allows two pets to occupy the same host without replacing the existing single-pet fields
- validates pet IDs before they can enter the LAN state model
- prunes pets whose owner disconnects and returns pets when their current host disappears

This PR intentionally does not add rendering, MCP signals, meeting dialogue, animations, or Control Center configuration. Those remain separate follow-up phases after the state model is reviewed.

## Experimental status

This remains experimental. Real two-machine GUI testing is pending because the second test system is currently under repair. I plan to validate migration and reconnect behavior on two physical machines in the next few days and report the results before building the rendering phase.

## Validation

- `pnpm --filter @open-pets/desktop test:build`
- `node apps/desktop/.test-dist/tests/lan-state.test.js`
- `pnpm --filter @open-pets/desktop typecheck`

The automated coordinator regression verifies that two host-owned pets can independently end up on the same LAN host while the existing single-pet tests continue to pass.

Closes no issue; follows #93.
