### PR TITLE
feat(opencode): add excludeReactions plugin option for reaction filtering

### DIFF
--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -127,7 +127,9 @@ Ships both a config manager and a runtime plugin.
 - **Runtime** (`opencode-plugin-runtime.ts`, plugin id `open-pets-opencode`):
   hooks `event`, `chat.message`, `tool.execute.before/after`, classifies them to
   reactions/speech, manages a lease (renew with a 2s buffer), and applies the
-  same throttle windows as Claude.
+  same throttle windows as Claude. The optional `excludeReactions` plugin option is an
+  array of reactions to suppress before IPC or throttling. It can be used without a
+  `pet` target: `["@open-pets/opencode", { "excludeReactions": ["success", "thinking"] }]`.
 
 ## Cursor — `@open-pets/cursor`
 

--- a/packages/opencode/src/check-opencode-foundation.ts
+++ b/packages/opencode/src/check-opencode-foundation.ts
@@ -41,7 +41,7 @@ try {
   assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer" }), ["@open-pets/opencode", { pet: "fixer" }]);
   assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer", packageVersion: "0.0.0" }), ["@open-pets/opencode@0.0.0", { pet: "fixer" }]);
   assert.deepEqual(buildOpenCodePluginPreview({}), "@open-pets/opencode");
-  assert.deepEqual(buildOpenCodePluginPreview({ excludeReactions: ["success", "thinking"] }), ["@open-pets/opencode", { excludeReactions: ["success", "thinking"] }]);
+  assert.deepEqual(buildOpenCodePluginPreview({ excludeReactions: ["success", "thinking", "not-a-reaction"] }), ["@open-pets/opencode", { excludeReactions: ["success", "thinking"] }], "config previews must not persist unrecognized exclusions");
   assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer", excludeReactions: ["success"] }), ["@open-pets/opencode", { pet: "fixer", excludeReactions: ["success"] }]);
 
   const jsonc = `{
@@ -140,8 +140,9 @@ try {
   assert.equal(doctorOpenCodeGlobalSetup(globalDir).status, "not_installed");
 
   const globalExclusionsOnly = join(root, "global-exclusions-only");
-  writePreparedOpenCodeGlobalSetup(prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["success", "thinking"] }));
-  assert.doesNotThrow(() => prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["thinking", "success"] }), "exclusions-only setup should recognize its existing plugin entry");
+  writePreparedOpenCodeGlobalSetup(prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["success", "thinking", "not-a-reaction"] }));
+  assert.doesNotMatch(readFileSync(join(globalExclusionsOnly, "opencode.jsonc"), "utf8"), /not-a-reaction/, "setup must not persist unrecognized exclusions");
+  assert.doesNotThrow(() => prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["thinking", "success", "not-a-reaction"] }), "exclusions-only setup should recognize its existing plugin entry");
 
   const globalLower = join(root, "global-lower");
   mkdirSync(globalLower);

--- a/packages/opencode/src/check-opencode-foundation.ts
+++ b/packages/opencode/src/check-opencode-foundation.ts
@@ -92,6 +92,8 @@ try {
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "fixer", extra: true }]] }], "fixer", "0.0.0").status, "custom");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "fixer", excludeReactions: ["success"] }]] }], "fixer", "0.0.0").status, "needs_update", "plugin with excludeReactions but no matching expected spec should need update");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "helper", excludeReactions: ["success"] }]] }], "fixer", "0.0.0").status, "needs_update", "plugin with excludeReactions but wrong pet is managed-but-outdated");
+  assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { excludeReactions: ["success", "thinking"] }]] }], undefined, "0.0.0", ["thinking", "success"]).status, "installed", "exclusions-only plugin options round-trip without a pet regardless of ordering");
+  assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { excludeReactions: ["success", 1] }]] }], undefined, "0.0.0", ["success"]).status, "custom", "invalid exclusions remain custom rather than managed");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: ["./openpets-custom-plugin.js"] }], "fixer").status, "custom");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode", { pet: "fixer" }], "./openpets-custom-plugin.js"] }], "fixer").status, "conflict");
 
@@ -136,6 +138,10 @@ try {
   const globalRemove = prepareOpenCodeGlobalRemove(globalDir);
   writePreparedOpenCodeGlobalRemove(globalRemove);
   assert.equal(doctorOpenCodeGlobalSetup(globalDir).status, "not_installed");
+
+  const globalExclusionsOnly = join(root, "global-exclusions-only");
+  writePreparedOpenCodeGlobalSetup(prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["success", "thinking"] }));
+  assert.doesNotThrow(() => prepareOpenCodeGlobalSetup({ configDir: globalExclusionsOnly, cliVersion: "0.0.0", excludeReactions: ["thinking", "success"] }), "exclusions-only setup should recognize its existing plugin entry");
 
   const globalLower = join(root, "global-lower");
   mkdirSync(globalLower);

--- a/packages/opencode/src/check-opencode-foundation.ts
+++ b/packages/opencode/src/check-opencode-foundation.ts
@@ -38,8 +38,11 @@ try {
   assert.throws(() => buildOpenCodeMcpEntry({ cliVersion: "0.0.0", petId: "bad/pet" }));
   assert.equal(buildOpenCodeInstructionPath("project"), ".opencode/openpets.md");
   assert.equal(buildOpenCodeInstructionPath("global", join(root, "global")), join(root, "global", "openpets.md"));
-  assert.deepEqual(buildOpenCodePluginPreview("fixer"), ["@open-pets/opencode", { pet: "fixer" }]);
-  assert.deepEqual(buildOpenCodePluginPreview("fixer", "0.0.0"), ["@open-pets/opencode@0.0.0", { pet: "fixer" }]);
+  assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer" }), ["@open-pets/opencode", { pet: "fixer" }]);
+  assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer", packageVersion: "0.0.0" }), ["@open-pets/opencode@0.0.0", { pet: "fixer" }]);
+  assert.deepEqual(buildOpenCodePluginPreview({}), "@open-pets/opencode");
+  assert.deepEqual(buildOpenCodePluginPreview({ excludeReactions: ["success", "thinking"] }), ["@open-pets/opencode", { excludeReactions: ["success", "thinking"] }]);
+  assert.deepEqual(buildOpenCodePluginPreview({ petId: "fixer", excludeReactions: ["success"] }), ["@open-pets/opencode", { pet: "fixer", excludeReactions: ["success"] }]);
 
   const jsonc = `{
     // keep this comment
@@ -87,6 +90,8 @@ try {
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", {}]] }], "fixer", "0.0.0").status, "custom");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "fixer" }, "extra"]] }], "fixer", "0.0.0").status, "custom");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "fixer", extra: true }]] }], "fixer", "0.0.0").status, "custom");
+  assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "fixer", excludeReactions: ["success"] }]] }], "fixer", "0.0.0").status, "needs_update", "plugin with excludeReactions but no matching expected spec should need update");
+  assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode@0.0.0", { pet: "helper", excludeReactions: ["success"] }]] }], "fixer", "0.0.0").status, "needs_update", "plugin with excludeReactions but wrong pet is managed-but-outdated");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: ["./openpets-custom-plugin.js"] }], "fixer").status, "custom");
   assert.equal(classifyOpenCodePluginStatus([{ plugin: [["@open-pets/opencode", { pet: "fixer" }], "./openpets-custom-plugin.js"] }], "fixer").status, "conflict");
 

--- a/packages/opencode/src/check-opencode-plugin.ts
+++ b/packages/opencode/src/check-opencode-plugin.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import type { OpenPetsClient, OpenPetsReaction } from "@open-pets/client";
 
 import plugin, { openPetsOpenCodePluginId } from "./plugin.js";
-import { classifyOpenCodeBusEvent, classifyOpenCodeToolReaction, createOpenPetsOpenCodeHooks, getDefaultOpenCodeThrottlePath, shouldIgnoreOpenPetsTool } from "./opencode-plugin-runtime.js";
+import { classifyOpenCodeBusEvent, classifyOpenCodeToolReaction, createOpenPetsOpenCodeHooks, getDefaultOpenCodeThrottlePath, isReactionExcluded, shouldIgnoreOpenPetsTool } from "./opencode-plugin-runtime.js";
 
 assert.equal(plugin.id, openPetsOpenCodePluginId);
 assert.equal(typeof plugin.server, "function");
@@ -120,5 +120,120 @@ const loaded = await plugin.server({}, { pet: "fixer" });
 assert.equal(typeof loaded.event, "function");
 assert.equal(typeof loaded["chat.message"], "function");
 assert.equal(typeof loaded["tool.execute.before"], "function");
+
+// --- excludeReactions tests ---
+
+// isReactionExcluded: basic Set check
+assert.equal(isReactionExcluded("success", new Set(["success", "thinking"])), true);
+assert.equal(isReactionExcluded("error", new Set(["success", "thinking"])), false);
+assert.equal(isReactionExcluded("success", new Set()), false);
+
+// Excluded reaction (success) is NOT sent to client when session.status: idle fires
+{
+  const dir2 = mkdtempSync(join(tmpdir(), "openpets-opencode-exclude-"));
+  try {
+    const excludeCalls: string[] = [];
+    const excludeClient: OpenPetsClient = {
+      hello: async () => ({}),
+      status: async () => ({ ok: true, appRunning: true }),
+      listPets: async () => ({ ok: true, pets: [], defaultPetId: "builtin" }),
+      installPet: async () => { throw new Error("unused"); },
+      installLocalPet: async () => { throw new Error("unused"); },
+      acquireLease: async () => ({ leaseId: "lease-ex", targetKind: "explicit", actualTargetPetId: "fixer", actualTargetPetName: "Fixer", usingDefaultPet: false, expiresAt: Date.now() + 15_000, leaseActive: true }),
+      heartbeatLease: async () => ({ leaseId: "lease-ex", expiresAt: Date.now() + 15_000 }),
+      releaseLease: async () => ({ released: true }),
+      react: async (reaction: OpenPetsReaction) => { excludeCalls.push(reaction); },
+      say: async (message: string) => { excludeCalls.push(`say:${message}`); },
+      showMedia: async () => ({ ok: true, shown: true }),
+    };
+    const scheduled2: Array<() => Promise<void>> = [];
+    const hooks2 = createOpenPetsOpenCodeHooks({
+      pet: "fixer",
+      excludeReactions: ["success", "thinking"],
+      clientFactory: () => excludeClient,
+      schedule: (work) => { scheduled2.push(work); },
+      throttlePath: join(dir2, "throttle.json"),
+      now: () => 300_000,
+    });
+
+    // session.status idle → success → should be excluded, nothing scheduled
+    hooks2.event({ event: { type: "session.status", properties: { status: { type: "idle" } } } });
+    assert.equal(scheduled2.length, 0, "excluded success reaction must not schedule any work");
+
+    // chat.message → thinking → should be excluded
+    hooks2["chat.message"]({}, {});
+    assert.equal(scheduled2.length, 0, "excluded thinking reaction must not schedule any work");
+
+    // session.error → error → NOT excluded, should schedule (with speech)
+    hooks2.event({ event: { type: "session.error" } });
+    assert.equal(scheduled2.length, 1, "non-excluded error reaction should schedule");
+    await scheduled2.shift()?.();
+    assert.ok(excludeCalls.at(-1)?.startsWith("say:"), "non-excluded error reaction should reach client via say");
+
+    // tool.execute.before with edit → editing → NOT excluded, should schedule
+    hooks2["tool.execute.before"]({ tool: "edit" }, { args: {} });
+    assert.equal(scheduled2.length, 1, "non-excluded editing reaction should schedule");
+    await scheduled2.shift()?.();
+    assert.equal(excludeCalls.at(-1), "editing", "non-excluded editing reaction should reach client");
+
+    assert.equal(excludeCalls.includes("success"), false, "success must never have been sent");
+    assert.equal(excludeCalls.includes("thinking"), false, "thinking must never have been sent");
+  } finally {
+    rmSync(dir2, { recursive: true, force: true });
+  }
+}
+
+// Empty excludeReactions array has no effect (current behavior preserved)
+{
+  const dir3 = mkdtempSync(join(tmpdir(), "openpets-opencode-empty-exclude-"));
+  try {
+    const emptyExcludeCalls: string[] = [];
+    const emptyExcludeClient: OpenPetsClient = {
+      hello: async () => ({}),
+      status: async () => ({ ok: true, appRunning: true }),
+      listPets: async () => ({ ok: true, pets: [], defaultPetId: "builtin" }),
+      installPet: async () => { throw new Error("unused"); },
+      installLocalPet: async () => { throw new Error("unused"); },
+      acquireLease: async () => ({ leaseId: "lease-empty", targetKind: "explicit", actualTargetPetId: "fixer", actualTargetPetName: "Fixer", usingDefaultPet: false, expiresAt: Date.now() + 15_000, leaseActive: true }),
+      heartbeatLease: async () => ({ leaseId: "lease-empty", expiresAt: Date.now() + 15_000 }),
+      releaseLease: async () => ({ released: true }),
+      react: async (reaction: OpenPetsReaction) => { emptyExcludeCalls.push(reaction); },
+      say: async () => {},
+      showMedia: async () => ({ ok: true, shown: true }),
+    };
+    const scheduled3: Array<() => Promise<void>> = [];
+    const hooks3 = createOpenPetsOpenCodeHooks({
+      pet: "fixer",
+      excludeReactions: [],
+      clientFactory: () => emptyExcludeClient,
+      schedule: (work) => { scheduled3.push(work); },
+      throttlePath: join(dir3, "throttle.json"),
+      now: () => 400_000,
+    });
+    hooks3.event({ event: { type: "session.status", properties: { status: { type: "idle" } } } });
+    assert.equal(scheduled3.length, 1, "empty excludeReactions should not block success");
+    await scheduled3.shift()?.();
+    assert.equal(emptyExcludeCalls.at(-1), "success");
+  } finally {
+    rmSync(dir3, { recursive: true, force: true });
+  }
+}
+
+// Invalid reaction strings in excludeReactions are silently ignored
+{
+  const validSet = new Set<string>();
+  assert.equal(isReactionExcluded("success", validSet), false, "empty set should not exclude anything");
+  // Invalid reaction names are ignored by buildExcludedReactionsSet (tested implicitly: no crash on invalid input)
+  const hooks4 = createOpenPetsOpenCodeHooks({
+    excludeReactions: ["not-a-real-reaction" as OpenPetsReaction, 42 as unknown as OpenPetsReaction],
+    throttlePath: join(dir, "invalid-throttle.json"),
+    now: () => 500_000,
+  });
+  assert.equal(typeof hooks4.event, "function", "invalid excludeReactions should not crash hook creation");
+}
+
+// Classification is unaffected by filter (filter is in run(), not classify*)
+assert.deepEqual(classifyOpenCodeBusEvent({ type: "session.status", properties: { status: { type: "idle" } } }), { reaction: "success" });
+assert.deepEqual(classifyOpenCodeToolReaction("edit", {}), "editing");
 
 console.error("OpenCode plugin validation passed.");

--- a/packages/opencode/src/check-opencode-plugin.ts
+++ b/packages/opencode/src/check-opencode-plugin.ts
@@ -219,17 +219,17 @@ assert.equal(isReactionExcluded("success", new Set()), false);
   }
 }
 
-// Invalid reaction strings in excludeReactions are silently ignored
+// Invalid reaction strings are ignored without discarding recognized exclusions.
 {
-  const validSet = new Set<string>();
-  assert.equal(isReactionExcluded("success", validSet), false, "empty set should not exclude anything");
-  // Invalid reaction names are ignored by buildExcludedReactionsSet (tested implicitly: no crash on invalid input)
+  const scheduled4: Array<() => Promise<void>> = [];
   const hooks4 = createOpenPetsOpenCodeHooks({
-    excludeReactions: ["not-a-real-reaction" as OpenPetsReaction, 42 as unknown as OpenPetsReaction],
+    excludeReactions: ["success", "not-a-real-reaction" as OpenPetsReaction, 42 as unknown as OpenPetsReaction],
+    schedule: (work) => { scheduled4.push(work); },
     throttlePath: join(dir, "invalid-throttle.json"),
     now: () => 500_000,
   });
-  assert.equal(typeof hooks4.event, "function", "invalid excludeReactions should not crash hook creation");
+  hooks4.event({ event: { type: "session.status", properties: { status: { type: "idle" } } } });
+  assert.equal(scheduled4.length, 0, "recognized exclusions remain active when invalid values are present");
 }
 
 // Classification is unaffected by filter (filter is in run(), not classify*)

--- a/packages/opencode/src/opencode-global-setup.ts
+++ b/packages/opencode/src/opencode-global-setup.ts
@@ -58,7 +58,7 @@ export function prepareOpenCodeGlobalSetup(options: PrepareOpenCodeGlobalSetupOp
   const instructionContent = existsSync(instructionPath) ? readSafeInstructionFile(instructionPath) : "";
   const mcpStatus = classifyOpenCodeMcpStatus(configs, { cliVersion: options.cliVersion, petId, commandMode: options.commandMode, cliEntryPath: options.cliEntryPath });
   const instructionStatus = classifyOpenCodeInstructionsStatus(configs, "global", options.configDir, { [instructionPath]: instructionContent });
-  const pluginStatus = classifyOpenCodePluginStatus(configs, petId, options.pluginVersion ?? options.cliVersion);
+  const pluginStatus = classifyOpenCodePluginStatus(configs, petId, options.pluginVersion ?? options.cliVersion, options.excludeReactions);
   for (const status of [mcpStatus, instructionStatus, pluginStatus]) {
     if (status.status === "custom" || status.status === "conflict" || status.status === "error") throw new Error(`${status.message} Edit or remove the custom OpenPets OpenCode entry, then rerun setup.`);
   }

--- a/packages/opencode/src/opencode-global-setup.ts
+++ b/packages/opencode/src/opencode-global-setup.ts
@@ -14,6 +14,7 @@ export interface PrepareOpenCodeGlobalSetupOptions {
   readonly pluginVersion?: string;
   readonly commandMode?: OpenCodeCommandMode;
   readonly cliEntryPath?: string;
+  readonly excludeReactions?: readonly string[];
 }
 
 export interface PreparedOpenCodeGlobalSetup {
@@ -138,7 +139,7 @@ function buildNextGlobalConfig(config: Record<string, unknown>, petId: string | 
   mcp.openpets = buildOpenCodeMcpEntry({ cliVersion: options.cliVersion, petId, commandMode: options.commandMode, cliEntryPath: options.cliEntryPath });
   const instructionPath = buildOpenCodeInstructionPath("global", options.configDir);
   const instructions = [...new Set([...(Array.isArray(config.instructions) ? config.instructions.filter((entry): entry is string => typeof entry === "string") : []), instructionPath])];
-  const plugin = [...(Array.isArray(config.plugin) ? config.plugin.filter((entry) => !isManagedOpenPetsPluginEntry(entry)) : []), buildOpenCodePluginPreview(petId, options.pluginVersion ?? options.cliVersion)];
+  const plugin = [...(Array.isArray(config.plugin) ? config.plugin.filter((entry) => !isManagedOpenPetsPluginEntry(entry)) : []), buildOpenCodePluginPreview({ petId, packageVersion: options.pluginVersion ?? options.cliVersion, excludeReactions: options.excludeReactions })];
   return { mcp, instructions, plugin };
 }
 

--- a/packages/opencode/src/opencode-plugin-runtime.ts
+++ b/packages/opencode/src/opencode-plugin-runtime.ts
@@ -5,7 +5,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { createOpenPetsClient, type OpenPetsClient, type OpenPetsReaction } from "@open-pets/client";
 import { pickHookSpeech, type HookSpeechCategory, validateHookSpeech } from "@open-pets/agent-events";
 
-import { validateOpenPetsPetArg } from "./opencode-previews.js";
+import { sanitizeOpenCodeExcludedReactions, validateOpenPetsPetArg } from "./opencode-previews.js";
 
 export interface OpenCodePluginOptions {
   readonly pet?: string;
@@ -162,20 +162,11 @@ function shouldSendThrottleKey(key: string, cooldown: number, now: number, path:
 }
 
 function buildExcludedReactionsSet(excludeReactions?: readonly OpenPetsReaction[]): ReadonlySet<string> {
-  if (!excludeReactions || excludeReactions.length === 0) return emptySet;
-  const valid = new Set<string>();
-  for (const r of excludeReactions) {
-    if (typeof r === "string" && allowedReactionStrings.has(r)) valid.add(r);
-  }
-  return valid.size > 0 ? valid : emptySet;
+  const valid = sanitizeOpenCodeExcludedReactions(excludeReactions);
+  return valid.length > 0 ? new Set(valid) : emptySet;
 }
 
 const emptySet: ReadonlySet<string> = new Set();
-
-const allowedReactionStrings: ReadonlySet<string> = new Set([
-  "idle", "thinking", "working", "editing", "running", "testing",
-  "waiting", "waving", "success", "error", "celebrating",
-]);
 
 function isTestLikeToolArgs(args: unknown): boolean {
   const command = isRecord(args) && typeof args.command === "string" ? args.command.slice(0, 300) : "";

--- a/packages/opencode/src/opencode-plugin-runtime.ts
+++ b/packages/opencode/src/opencode-plugin-runtime.ts
@@ -10,6 +10,8 @@ import { validateOpenPetsPetArg } from "./opencode-previews.js";
 export interface OpenCodePluginOptions {
   readonly pet?: string;
   readonly debug?: boolean;
+  /** Reactions the user wants suppressed. Excluded reactions are silently dropped before any IPC or throttle work. */
+  readonly excludeReactions?: readonly OpenPetsReaction[];
 }
 
 export interface OpenCodePluginRuntimeOptions extends OpenCodePluginOptions {
@@ -37,17 +39,23 @@ const speechCooldownMs = 20_000;
 const permissionCooldownMs = 3_000;
 const reactionCooldownMs = 10_000;
 
+export function isReactionExcluded(reaction: OpenPetsReaction, excludedSet: ReadonlySet<string>): boolean {
+  return excludedSet.has(reaction);
+}
+
 export function createOpenPetsOpenCodeHooks(options: OpenCodePluginRuntimeOptions = {}): OpenCodeHooks {
   const pet = options.pet === undefined ? undefined : validateOpenPetsPetArg(options.pet);
   const clientFactory = options.clientFactory ?? (() => createOpenPetsClient({ connectTimeoutMs: 500, responseTimeoutMs: 500 }));
   const schedule = options.schedule ?? defaultSchedule;
   const debug = options.debug === true || process.env.OPENPETS_DEBUG === "1";
   const debugLog = options.debugLog ?? ((message) => { if (debug) process.stderr.write(`${message}\n`); });
+  const excludedReactions = buildExcludedReactionsSet(options.excludeReactions);
   let client: OpenPetsClient | undefined;
   let lease: { readonly leaseId: string; readonly expiresAt?: number } | undefined;
 
   const run = (decision: OpenCodePluginDecision | undefined): void => {
     if (!decision?.reaction) return;
+    if (isReactionExcluded(decision.reaction, excludedReactions)) return;
     const reaction = decision.reaction;
     try {
       schedule(async () => {
@@ -152,6 +160,22 @@ function shouldSendThrottleKey(key: string, cooldown: number, now: number, path:
   writeThrottleState(path, state);
   return true;
 }
+
+function buildExcludedReactionsSet(excludeReactions?: readonly OpenPetsReaction[]): ReadonlySet<string> {
+  if (!excludeReactions || excludeReactions.length === 0) return emptySet;
+  const valid = new Set<string>();
+  for (const r of excludeReactions) {
+    if (typeof r === "string" && allowedReactionStrings.has(r)) valid.add(r);
+  }
+  return valid.size > 0 ? valid : emptySet;
+}
+
+const emptySet: ReadonlySet<string> = new Set();
+
+const allowedReactionStrings: ReadonlySet<string> = new Set([
+  "idle", "thinking", "working", "editing", "running", "testing",
+  "waiting", "waving", "success", "error", "celebrating",
+]);
 
 function isTestLikeToolArgs(args: unknown): boolean {
   const command = isRecord(args) && typeof args.command === "string" ? args.command.slice(0, 300) : "";

--- a/packages/opencode/src/opencode-previews.ts
+++ b/packages/opencode/src/opencode-previews.ts
@@ -1,5 +1,7 @@
 import { isAbsolute, join } from "node:path";
 
+import { allowedReactions, type OpenPetsReaction } from "@open-pets/client";
+
 export const openCodeMcpServerName = "openpets";
 export const openPetsCliPackageName = "@open-pets/cli";
 export type OpenCodeCommandMode = "published" | "local" | "bundled";
@@ -56,14 +58,20 @@ export interface BuildOpenCodePluginPreviewOptions {
   readonly excludeReactions?: readonly string[];
 }
 
+export function sanitizeOpenCodeExcludedReactions(excludeReactions?: readonly string[]): readonly OpenPetsReaction[] {
+  if (!excludeReactions) return [];
+  return [...new Set(excludeReactions.filter((reaction): reaction is OpenPetsReaction => typeof reaction === "string" && allowedReactions.includes(reaction as OpenPetsReaction)))];
+}
+
 export function buildOpenCodePluginPreview(options?: BuildOpenCodePluginPreviewOptions): OpenCodePluginSpec {
   const spec = options?.packageVersion ? `@open-pets/opencode@${options.packageVersion}` : "@open-pets/opencode";
   const hasPet = options?.petId !== undefined;
-  const hasExclusions = Array.isArray(options?.excludeReactions) && options.excludeReactions!.length > 0;
+  const excludeReactions = sanitizeOpenCodeExcludedReactions(options?.excludeReactions);
+  const hasExclusions = excludeReactions.length > 0;
   if (!hasPet && !hasExclusions) return spec;
   return [spec, {
     ...(hasPet ? { pet: validateOpenPetsPetArg(options!.petId!) } : {}),
-    ...(hasExclusions ? { excludeReactions: options!.excludeReactions! } : {}),
+    ...(hasExclusions ? { excludeReactions } : {}),
   }];
 }
 

--- a/packages/opencode/src/opencode-previews.ts
+++ b/packages/opencode/src/opencode-previews.ts
@@ -43,11 +43,28 @@ export function buildOpenCodeInstructionPath(scope: "project" | "global", config
   return join(configDir, "openpets.md");
 }
 
-export type OpenCodePluginSpec = string | readonly [string, { readonly pet?: string }];
+export type OpenCodePluginSpecOptions = {
+  readonly pet?: string;
+  readonly excludeReactions?: readonly string[];
+};
 
-export function buildOpenCodePluginPreview(petId?: string, packageVersion?: string): OpenCodePluginSpec {
-  const spec = packageVersion ? `@open-pets/opencode@${packageVersion}` : "@open-pets/opencode";
-  return petId === undefined ? spec : [spec, { pet: validateOpenPetsPetArg(petId) }];
+export type OpenCodePluginSpec = string | readonly [string, OpenCodePluginSpecOptions];
+
+export interface BuildOpenCodePluginPreviewOptions {
+  readonly petId?: string;
+  readonly packageVersion?: string;
+  readonly excludeReactions?: readonly string[];
+}
+
+export function buildOpenCodePluginPreview(options?: BuildOpenCodePluginPreviewOptions): OpenCodePluginSpec {
+  const spec = options?.packageVersion ? `@open-pets/opencode@${options.packageVersion}` : "@open-pets/opencode";
+  const hasPet = options?.petId !== undefined;
+  const hasExclusions = Array.isArray(options?.excludeReactions) && options.excludeReactions!.length > 0;
+  if (!hasPet && !hasExclusions) return spec;
+  return [spec, {
+    ...(hasPet ? { pet: validateOpenPetsPetArg(options!.petId!) } : {}),
+    ...(hasExclusions ? { excludeReactions: options!.excludeReactions! } : {}),
+  }];
 }
 
 export function formatOpenCodeMcpConfig(options: OpenCodePreviewOptions): Record<string, unknown> {

--- a/packages/opencode/src/opencode-project-setup.ts
+++ b/packages/opencode/src/opencode-project-setup.ts
@@ -52,7 +52,7 @@ export function prepareOpenCodeProjectSetup(options: PrepareOpenCodeProjectSetup
   const instructionContent = existsSync(instructionPath) ? readSafeInstructionFile(instructionPath) : "";
   const mcpStatus = classifyOpenCodeMcpStatus(configs, { cliVersion: options.cliVersion, petId, commandMode: options.commandMode, cliEntryPath: options.cliEntryPath });
   const instructionStatus = classifyOpenCodeInstructionsStatus(configs, "project", undefined, { [instructionRelPath]: instructionContent });
-  const pluginStatus = classifyOpenCodePluginStatus(configs, petId, options.cliVersion);
+  const pluginStatus = classifyOpenCodePluginStatus(configs, petId, options.cliVersion, options.excludeReactions);
   for (const status of [mcpStatus, instructionStatus, pluginStatus]) {
     if (status.status === "custom" || status.status === "conflict" || status.status === "error") throw new Error(`${status.message} Edit or remove the custom OpenPets OpenCode entry, then rerun setup.`);
   }

--- a/packages/opencode/src/opencode-project-setup.ts
+++ b/packages/opencode/src/opencode-project-setup.ts
@@ -12,6 +12,7 @@ export interface PrepareOpenCodeProjectSetupOptions {
   readonly cliVersion: string;
   readonly commandMode?: OpenCodeCommandMode;
   readonly cliEntryPath?: string;
+  readonly excludeReactions?: readonly string[];
 }
 
 export interface PreparedOpenCodeProjectSetup {
@@ -87,7 +88,7 @@ function buildNextConfig(config: Record<string, unknown>, petId: string, options
   mcp.openpets = buildOpenCodeMcpEntry({ cliVersion: options.cliVersion, petId, commandMode: options.commandMode, cliEntryPath: options.cliEntryPath });
   const instructionPath = buildOpenCodeInstructionPath("project");
   const instructions = [...new Set([...(Array.isArray(config.instructions) ? config.instructions.filter((entry): entry is string => typeof entry === "string") : []), instructionPath])];
-  const pluginSpec = buildOpenCodePluginPreview(petId, options.cliVersion);
+  const pluginSpec = buildOpenCodePluginPreview({ petId, packageVersion: options.cliVersion, excludeReactions: options.excludeReactions });
   const plugin = [...(Array.isArray(config.plugin) ? config.plugin.filter((entry) => !isManagedOpenPetsPluginEntry(entry)) : []), pluginSpec];
   return { mcp, instructions, plugin };
 }

--- a/packages/opencode/src/opencode-status.ts
+++ b/packages/opencode/src/opencode-status.ts
@@ -109,9 +109,12 @@ function isPetPluginOptions(value: unknown): value is { readonly pet?: string; r
   const keys = Object.keys(value).sort();
   const hasPet = keys.includes("pet");
   const hasExclusions = keys.includes("excludeReactions");
-  if ((!hasPet && !hasExclusions) || keys.length !== Number(hasPet) + Number(hasExclusions)) return false;
+  if (!hasPet && !hasExclusions) return false;
+  const expectedKeyCount = (hasPet ? 1 : 0) + (hasExclusions ? 1 : 0);
+  if (keys.length !== expectedKeyCount) return false;
   if (hasPet && (typeof value.pet !== "string" || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet))) return false;
-  return !hasExclusions || Array.isArray(value.excludeReactions) && value.excludeReactions.length > 0 && value.excludeReactions.every((reaction: unknown) => typeof reaction === "string");
+  if (!hasExclusions) return true;
+  return Array.isArray(value.excludeReactions) && value.excludeReactions.length > 0 && value.excludeReactions.every((reaction: unknown) => typeof reaction === "string");
 }
 
 function isSameMcpEntry(value: unknown, expected: { readonly type: "local"; readonly command: readonly string[]; readonly enabled: true }): boolean {

--- a/packages/opencode/src/opencode-status.ts
+++ b/packages/opencode/src/opencode-status.ts
@@ -35,8 +35,8 @@ export function classifyOpenCodeInstructionsStatus(configs: readonly Record<stri
   return { status: "custom", message: "OpenCode has custom OpenPets-like instruction entries.", matches: customEntries.map((entry) => entry.source) };
 }
 
-export function classifyOpenCodePluginStatus(configs: readonly Record<string, unknown>[], petId?: string, packageVersion?: string): OpenCodeStatusResult {
-  const expected = buildOpenCodePluginPreview({ petId, packageVersion });
+export function classifyOpenCodePluginStatus(configs: readonly Record<string, unknown>[], petId?: string, packageVersion?: string, excludeReactions?: readonly string[]): OpenCodeStatusResult {
+  const expected = buildOpenCodePluginPreview({ petId, packageVersion, excludeReactions });
   const pluginEntries = configs.flatMap((config, index) => Array.isArray(config.plugin) ? config.plugin.map((entry) => ({ source: String(index), entry })) : []);
   const current = pluginEntries.filter(({ entry }) => isExpectedPlugin(entry, expected));
   const recognizable = pluginEntries.filter(({ entry }) => isManagedOpenPetsPluginEntry(entry));
@@ -104,16 +104,14 @@ export function isOpenPetsLikePluginEntry(value: unknown): boolean {
   return false;
 }
 
-function isPetPluginOptions(value: unknown): boolean {
+function isPetPluginOptions(value: unknown): value is { readonly pet?: string; readonly excludeReactions?: readonly string[] } {
   if (!isRecord(value)) return false;
   const keys = Object.keys(value).sort();
-  if (keys.length === 1) return keys[0] === "pet" && typeof value.pet === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet);
-  if (keys.length === 2) {
-    if (keys[0] !== "excludeReactions" || keys[1] !== "pet") return false;
-    if (typeof value.pet !== "string" || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet)) return false;
-    return Array.isArray(value.excludeReactions) && value.excludeReactions.every((r: unknown) => typeof r === "string");
-  }
-  return false;
+  const hasPet = keys.includes("pet");
+  const hasExclusions = keys.includes("excludeReactions");
+  if ((!hasPet && !hasExclusions) || keys.length !== Number(hasPet) + Number(hasExclusions)) return false;
+  if (hasPet && (typeof value.pet !== "string" || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet))) return false;
+  return !hasExclusions || Array.isArray(value.excludeReactions) && value.excludeReactions.length > 0 && value.excludeReactions.every((reaction: unknown) => typeof reaction === "string");
 }
 
 function isSameMcpEntry(value: unknown, expected: { readonly type: "local"; readonly command: readonly string[]; readonly enabled: true }): boolean {
@@ -135,12 +133,11 @@ function hasValidMcpEnvironment(value: unknown): boolean {
 }
 
 function isSamePluginOptions(value: unknown, expected: { readonly pet?: string; readonly excludeReactions?: readonly string[] }): boolean {
-  if (!isRecord(value)) return Object.keys(expected).length === 0;
+  if (!isPetPluginOptions(value)) return false;
   if (value.pet !== expected.pet) return false;
-  const expectedExclusions = Array.isArray(expected.excludeReactions) ? expected.excludeReactions : [];
-  const actualExclusions = Array.isArray(value.excludeReactions) ? value.excludeReactions : [];
-  if (expectedExclusions.length !== actualExclusions.length) return false;
-  return expectedExclusions.every((r, i) => r === actualExclusions[i]);
+  const expectedExclusions = new Set(expected.excludeReactions ?? []);
+  const actualExclusions = new Set(value.excludeReactions ?? []);
+  return expectedExclusions.size === actualExclusions.size && [...expectedExclusions].every((reaction) => actualExclusions.has(reaction));
 }
 
 function isOpenPetsLikeInstruction(value: string): boolean {

--- a/packages/opencode/src/opencode-status.ts
+++ b/packages/opencode/src/opencode-status.ts
@@ -36,7 +36,7 @@ export function classifyOpenCodeInstructionsStatus(configs: readonly Record<stri
 }
 
 export function classifyOpenCodePluginStatus(configs: readonly Record<string, unknown>[], petId?: string, packageVersion?: string): OpenCodeStatusResult {
-  const expected = buildOpenCodePluginPreview(petId, packageVersion);
+  const expected = buildOpenCodePluginPreview({ petId, packageVersion });
   const pluginEntries = configs.flatMap((config, index) => Array.isArray(config.plugin) ? config.plugin.map((entry) => ({ source: String(index), entry })) : []);
   const current = pluginEntries.filter(({ entry }) => isExpectedPlugin(entry, expected));
   const recognizable = pluginEntries.filter(({ entry }) => isManagedOpenPetsPluginEntry(entry));
@@ -88,7 +88,7 @@ function isSameCommand(command: readonly string[], expected: readonly string[]):
   return command.length === expected.length && command.every((part, index) => part === expected[index]);
 }
 
-function isExpectedPlugin(value: unknown, expected: string | readonly [string, { readonly pet?: string }]): boolean {
+function isExpectedPlugin(value: unknown, expected: string | readonly [string, { readonly pet?: string; readonly excludeReactions?: readonly string[] }]): boolean {
   if (typeof expected === "string") return value === expected;
   return Array.isArray(value) && value.length === 2 && value[0] === expected[0] && isSamePluginOptions(value[1], expected[1]);
 }
@@ -106,8 +106,14 @@ export function isOpenPetsLikePluginEntry(value: unknown): boolean {
 
 function isPetPluginOptions(value: unknown): boolean {
   if (!isRecord(value)) return false;
-  const keys = Object.keys(value);
-  return keys.length === 1 && keys[0] === "pet" && typeof value.pet === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet);
+  const keys = Object.keys(value).sort();
+  if (keys.length === 1) return keys[0] === "pet" && typeof value.pet === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet);
+  if (keys.length === 2) {
+    if (keys[0] !== "excludeReactions" || keys[1] !== "pet") return false;
+    if (typeof value.pet !== "string" || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(value.pet)) return false;
+    return Array.isArray(value.excludeReactions) && value.excludeReactions.every((r: unknown) => typeof r === "string");
+  }
+  return false;
 }
 
 function isSameMcpEntry(value: unknown, expected: { readonly type: "local"; readonly command: readonly string[]; readonly enabled: true }): boolean {
@@ -128,10 +134,13 @@ function hasValidMcpEnvironment(value: unknown): boolean {
   return Object.entries(value).every(([key, envValue]) => /^[A-Z_][A-Z0-9_]*$/.test(key) && typeof envValue === "string");
 }
 
-function isSamePluginOptions(value: unknown, expected: { readonly pet?: string }): boolean {
+function isSamePluginOptions(value: unknown, expected: { readonly pet?: string; readonly excludeReactions?: readonly string[] }): boolean {
   if (!isRecord(value)) return Object.keys(expected).length === 0;
-  const keys = Object.keys(value);
-  return keys.length === Object.keys(expected).length && value.pet === expected.pet;
+  if (value.pet !== expected.pet) return false;
+  const expectedExclusions = Array.isArray(expected.excludeReactions) ? expected.excludeReactions : [];
+  const actualExclusions = Array.isArray(value.excludeReactions) ? value.excludeReactions : [];
+  if (expectedExclusions.length !== actualExclusions.length) return false;
+  return expectedExclusions.every((r, i) => r === actualExclusions[i]);
 }
 
 function isOpenPetsLikeInstruction(value: string): boolean {


### PR DESCRIPTION
## Summary

Add user-configurable reaction filtering to the OpenCode plugin so users can suppress spammy reactions (e.g. `success` on every turn, `thinking` on every message).

## Problem

The OpenCode plugin fires pet reactions on every agent lifecycle event with no user control. The `success` reaction fires on **every** `session.status: idle` event (end of every turn), and `thinking` fires on **every`chat.message`. The only mitigation today is time-based cooldowns (10s reaction, 20s speech), not actual user preference.

## Solution

Add an `excludeReactions` option to the OpenCode plugin config. Excluded reactions are silently dropped before any IPC or throttle work via an O(1) `Set.has()` check.

### Usage

```jsonc
// .opencode/opencode.jsonc
{
  "plugin": ["@open-pets/opencode@<version>", {
    "pet": "bitty",
    "excludeReactions": ["success", "thinking"]
  }]
}
```

### Available reactions

`idle | thinking | working | editing | running | testing | waiting | waving | success | error | celebrating`

## Changes

| File | Change |
|---|---|
| `opencode-plugin-runtime.ts` | Add `excludeReactions` option, `isReactionExcluded()` helper, filter in `run()` |
| `opencode-previews.ts` | Update `buildOpenCodePluginPreview()` to serialize `excludeReactions` in plugin spec |
| `opencode-status.ts` | Update plugin status detection to recognize `excludeReactions` in managed entries |
| `opencode-project-setup.ts` | Thread `excludeReactions` through project setup options |
| `opencode-global-setup.ts` | Thread `excludeReactions` through global setup options |
| `check-opencode-plugin.ts` | Tests: exclusion, non-exclusion, empty array, invalid input |
| `check-opencode-foundation.ts` | Tests: preview builder, status classification with exclusions |

## What this does NOT change

- Claude hooks (separate mechanism, would need its own follow-up)
- Desktop-side IPC filtering
- Reaction animation mapping
- MCP tools (`openpets_react` / `openpets_say`)