### PR TITLE
Render visiting pets in multi-pet LAN mode

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -16,6 +16,7 @@ const behaviorTests = [
   ".test-dist/tests/lease-manager.test.js",
   ".test-dist/tests/lease-manager-fixes.test.js",
   ".test-dist/tests/lan-state.test.js",
+  ".test-dist/tests/lan-pet-presence.test.js",
   ".test-dist/tests/lan-auth.test.js",
   ".test-dist/tests/lan-controller.test.js",
   ".test-dist/tests/lan-client-retry.test.js",

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -48,6 +48,15 @@ local-ipc.ts → parseIpcRequest() → handleRequest()
 
 **Pet Display Flow**:
 ```
+
+**LAN visiting-pet flow**: with `OPENPETS_LAN_PETS=multi`, each client
+registers its selected default pet through `lan-http-controller.ts`.
+`lan-controller.ts` reports positions for every pet currently hosted locally
+and reconciles coordinator snapshots through `lan-pet-controller.ts`.
+Visiting windows are keyed by owner host, use `lan-pet-presence.ts` for pure
+show/close and asset-availability decisions, and stay isolated from agent
+leases. The bundled pet can render explicitly for fresh-profile LAN testing;
+missing or broken catalog assets are skipped without stopping LAN polling.
 pet-window.ts
 ├── createDefaultPetWindow() / createAgentPetWindow()
 ├── loadDefaultPetContent() / loadExplicitPetContent()

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -12,6 +12,7 @@ import { PetBubbleArbiter, type ActiveBubble, type PetBubbleSink } from "./plugi
 import { publishPluginPetEvent } from "./plugin-events-source.js";
 import { reclampAgentPetWindows } from "./agent-pet-controller.js";
 import { reclampPluginPetWindows } from "./plugin-pet-registry.js";
+import { reclampLanVisitingPetWindows } from "./lan-pet-controller.js";
 
 let defaultPetWindow: BrowserWindow | null = null;
 let paused = false;
@@ -497,6 +498,7 @@ function reclampDefaultPetWindow(reason: DisplayChangeReason, changedDisplay?: D
 function reclampAllLivePetWindows(reason: DisplayChangeReason, changedDisplay?: Display): void {
   reclampDefaultPetWindow(reason, changedDisplay);
   reclampAgentPetWindows();
+  reclampLanVisitingPetWindows();
   reclampPluginPetWindows();
 }
 

--- a/apps/desktop/src/lan-controller.ts
+++ b/apps/desktop/src/lan-controller.ts
@@ -4,11 +4,13 @@ import { hostname } from "node:os";
 import { URL } from "node:url";
 
 import { defaultPetWindowSize } from "./display.js";
+import { getAppStateSnapshot } from "./app-state.js";
 import { getDefaultPetLanPosition, hideDefaultPetForLan, showDefaultPetForLan } from "./default-pet-controller.js";
 import { resolveLanAuthConfig, type LanAuthSource } from "./lan-auth.js";
 import { defaultLanRetryOptions, getLanRetryDelayMs, shouldHideLanPetAfterMisses, shouldLogLanPollFailure } from "./lan-client-retry.js";
 import { createLanRequestHandler } from "./lan-http-controller.js";
 import { readPersistedLanState, writePersistedLanState } from "./lan-persistence.js";
+import { getLanVisitingPetPosition, syncLanVisitingPets } from "./lan-pet-controller.js";
 import { LanCoordinator, countLanTopologyLinks, normalizeLanHost, normalizeLanTopology, validateLanTopology, type LanEdge, type LanPoint, type LanState, type LanTopology, type LanTopologyIssue } from "./lan-state.js";
 import { info, warn, error as logError } from "./logger.js";
 
@@ -46,6 +48,8 @@ let serverStarted = false;
 let serverStarting = false;
 let missedPolls = 0;
 let lastPollWarningAt = 0;
+let multiPetEnabled = false;
+let lastLanState: LanState | null = null;
 
 export function startLanController(): void {
   const mode = normalizeMode(process.env.OPENPETS_LAN_MODE);
@@ -57,6 +61,7 @@ export function startLanController(): void {
   const auth = resolveLanAuthConfig(app.getPath("userData"), process.env, { serverMode: mode === "server" });
   const token = auth.token;
   const topology = parseLanTopology(process.env.OPENPETS_LAN_TOPOLOGY);
+  multiPetEnabled = process.env.OPENPETS_LAN_PETS === "multi";
   const topologyIssues = validateLanTopology(topology);
   coordinator = new LanCoordinator({ staleClientMs, topology });
   for (const issue of topologyIssues) warn("app", "lan topology issue", issue);
@@ -126,13 +131,20 @@ function startLanClient(serverUrl: string, localHost: string, token: string | nu
 async function registerLanClient(serverUrl: string, localHost: string, token: string | null): Promise<void> {
   try {
     const position = getDefaultPetLanPosition();
-    const state = await postJson<LanState>(`${serverUrl}/register`, { host: localHost, position }, token);
+    const state = await postJson<LanState>(`${serverUrl}/register`, {
+      host: localHost,
+      position,
+      ...(multiPetEnabled ? { petId: getAppStateSnapshot().preferences.defaultPetId } : {}),
+    }, token);
     missedPolls = 0;
     applyLanState(state, localHost);
   } catch (registerError) {
     missedPolls += 1;
     warn("app", "lan register failed", { error: registerError instanceof Error ? registerError.message : String(registerError), missedPolls });
-    if (shouldHideLanPetAfterMisses(missedPolls)) hideDefaultPetForLan();
+    if (shouldHideLanPetAfterMisses(missedPolls)) {
+      hideDefaultPetForLan();
+      if (multiPetEnabled) syncLanVisitingPets(localHost, []);
+    }
   }
 }
 
@@ -146,10 +158,30 @@ function scheduleLanPoll(serverUrl: string, localHost: string, token: string | n
   pollTimer.unref?.();
 }
 async function pollLanServer(serverUrl: string, localHost: string, token: string | null): Promise<void> {
-  const position = getDefaultPetLanPosition();
-  const edge = position ? detectEdge(position) : null;
   try {
-    const state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token);
+    let state: LanState;
+    if (multiPetEnabled && lastLanState?.pets) {
+      state = await postJson<LanState>(`${serverUrl}/position`, {
+        host: localHost,
+        position: getDefaultPetLanPosition(),
+        edge: null,
+      }, token);
+      for (const pet of lastLanState.pets) {
+        if (pet.currentHost !== localHost) continue;
+        const position = pet.ownerHost === localHost ? getDefaultPetLanPosition() : getLanVisitingPetPosition(pet.ownerHost);
+        if (!position) continue;
+        state = await postJson<LanState>(`${serverUrl}/position`, {
+          host: localHost,
+          ownerHost: pet.ownerHost,
+          position,
+          edge: detectEdge(position),
+        }, token);
+      }
+    } else {
+      const position = getDefaultPetLanPosition();
+      const edge = position ? detectEdge(position) : null;
+      state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token);
+    }
     missedPolls = 0;
     applyLanState(state, localHost);
   } catch (pollError) {
@@ -159,11 +191,22 @@ async function pollLanServer(serverUrl: string, localHost: string, token: string
       lastPollWarningAt = now;
       warn("app", "lan poll failed", { error: pollError instanceof Error ? pollError.message : String(pollError), missedPolls, nextPollMs: getLanRetryDelayMs(missedPolls) });
     }
-    if (shouldHideLanPetAfterMisses(missedPolls)) hideDefaultPetForLan();
+    if (shouldHideLanPetAfterMisses(missedPolls)) {
+      hideDefaultPetForLan();
+      if (multiPetEnabled) syncLanVisitingPets(localHost, []);
+    }
   }
 }
 
 function applyLanState(state: LanState, localHost: string): void {
+  lastLanState = state;
+  if (multiPetEnabled && state.pets) {
+    const localPet = state.pets.find((pet) => pet.ownerHost === localHost);
+    if (localPet?.currentHost === localHost) showDefaultPetForLan();
+    else hideDefaultPetForLan();
+    syncLanVisitingPets(localHost, state.pets);
+    return;
+  }
   if (state.currentHost === localHost) showDefaultPetForLan();
   else hideDefaultPetForLan();
 }

--- a/apps/desktop/src/lan-http-controller.ts
+++ b/apps/desktop/src/lan-http-controller.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { URL } from "node:url";
 
-import { LanCoordinator, normalizeLanEdge, normalizeLanHost, normalizeLanPoint, type LanState } from "./lan-state.js";
+import { LanCoordinator, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, type LanState } from "./lan-state.js";
 
 const maxLanRequestBodyBytes = 16 * 1024;
 
@@ -50,8 +50,13 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       writeJson(res, 400, { error: "missing_host" });
       return;
     }
+    const petId = normalizeLanPetId(body.petId);
+    if (body.petId !== undefined && !petId) {
+      writeJson(res, 400, { error: "invalid_pet_id" });
+      return;
+    }
     const previousHost = lanCoordinator.currentHost();
-    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), now());
+    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), now(), petId ?? undefined);
     writeJson(res, 200, state);
     notifyStateChangeIfOwnerChanged(previousHost, state, options);
     return;
@@ -79,7 +84,8 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       return;
     }
     const previousHost = lanCoordinator.currentHost();
-    const state = lanCoordinator.updatePosition(host, normalizeLanPoint(body.position), normalizeLanEdge(body.edge), now());
+    const ownerHost = normalizeLanHost(body.ownerHost) ?? undefined;
+    const state = lanCoordinator.updatePosition(host, normalizeLanPoint(body.position), normalizeLanEdge(body.edge), now(), ownerHost);
     writeJson(res, 200, state);
     notifyStateChangeIfOwnerChanged(previousHost, state, options);
     return;

--- a/apps/desktop/src/lan-pet-controller.ts
+++ b/apps/desktop/src/lan-pet-controller.ts
@@ -1,0 +1,130 @@
+import { BrowserWindow } from "electron";
+
+import { getAppStateSnapshot, type PetScaleValue } from "./app-state.js";
+import { clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosition } from "./display.js";
+import { debug, info, warn } from "./logger.js";
+import { planLanPetPresence, resolveRenderableLanPetId } from "./lan-pet-presence.js";
+import type { LanPetRecord, LanPoint } from "./lan-state.js";
+import { createAgentPetWindow, readWindowPosition } from "./pet-window.js";
+import { registerRoamingPet, unregisterRoamingPet } from "./pet-roaming-controller.js";
+
+type VisitingPetWindow = {
+  readonly ownerHost: string;
+  readonly requestedPetId: string;
+  readonly renderedPetId: string;
+  readonly motionHandleId: string;
+  readonly window: BrowserWindow;
+};
+
+const visitingPetWindows = new Map<string, VisitingPetWindow>();
+const dismissedOwnerHosts = new Set<string>();
+const unavailablePetWarnings = new Set<string>();
+
+export function syncLanVisitingPets(localHost: string, pets: readonly LanPetRecord[]): void {
+  const plan = planLanPetPresence(localHost, pets, [...visitingPetWindows.keys()]);
+  const desiredOwners = new Set(plan.show.map((pet) => pet.ownerHost));
+  for (const ownerHost of [...dismissedOwnerHosts]) {
+    if (!desiredOwners.has(ownerHost)) dismissedOwnerHosts.delete(ownerHost);
+  }
+  for (const ownerHost of [...unavailablePetWarnings]) {
+    if (!desiredOwners.has(ownerHost)) unavailablePetWarnings.delete(ownerHost);
+  }
+  for (const ownerHost of plan.closeOwnerHosts) {
+    closeLanVisitingPet(ownerHost);
+  }
+  for (const pet of plan.show) showLanVisitingPet(pet);
+}
+
+export function getLanVisitingPetPosition(ownerHost: string): LanPoint | null {
+  const entry = visitingPetWindows.get(ownerHost);
+  if (!entry || entry.window.isDestroyed() || !entry.window.isVisible()) return null;
+  return readWindowPosition(entry.window);
+}
+
+export function closeAllLanVisitingPets(): void {
+  for (const ownerHost of [...visitingPetWindows.keys()]) closeLanVisitingPet(ownerHost);
+  dismissedOwnerHosts.clear();
+  unavailablePetWarnings.clear();
+}
+
+export function reclampLanVisitingPetWindows(): void {
+  for (const entry of visitingPetWindows.values()) {
+    if (entry.window.isDestroyed()) continue;
+    const safe = readWindowPosition(entry.window);
+    const [x, y] = entry.window.getPosition();
+    if (safe.x !== x || safe.y !== y) entry.window.setPosition(safe.x, safe.y, false);
+  }
+}
+
+function showLanVisitingPet(pet: LanPetRecord): void {
+  if (dismissedOwnerHosts.has(pet.ownerHost)) return;
+  const state = getAppStateSnapshot();
+  const renderedPetId = resolveRenderableLanPetId(pet.petId, state.pets.installed);
+  if (!renderedPetId) {
+    if (!unavailablePetWarnings.has(pet.ownerHost)) {
+      unavailablePetWarnings.add(pet.ownerHost);
+      warn("pet.agent", "lan visiting pet unavailable", { ownerHost: pet.ownerHost, petId: pet.petId });
+    }
+    closeLanVisitingPet(pet.ownerHost);
+    return;
+  }
+  unavailablePetWarnings.delete(pet.ownerHost);
+
+  const existing = visitingPetWindows.get(pet.ownerHost);
+  if (existing && !existing.window.isDestroyed() && existing.renderedPetId === renderedPetId) {
+    existing.window.showInactive();
+    return;
+  }
+  if (existing) closeLanVisitingPet(pet.ownerHost);
+
+  const installed = state.pets.installed.find((candidate) => candidate.id === renderedPetId);
+  if (!installed) return;
+  const offset = visitingPetWindows.size + 1;
+  const base = getDefaultPetInitialPosition(defaultPetWindowSize);
+  const position = clampToVisibleWorkArea({ x: base.x - offset * 48, y: base.y - offset * 28 }, defaultPetWindowSize);
+  const motionHandleId = `lan:${pet.ownerHost}`;
+  const window = createAgentPetWindow({
+    petId: renderedPetId,
+    displayName: `${installed.displayName} — ${pet.ownerHost}`,
+    scale: state.preferences.petScale as PetScaleValue,
+    position,
+    display: null,
+    badge: null,
+    plainContextMenu: true,
+    onCloseRequested: () => {
+      dismissedOwnerHosts.add(pet.ownerHost);
+      closeLanVisitingPet(pet.ownerHost);
+    },
+  });
+  const entry: VisitingPetWindow = {
+    ownerHost: pet.ownerHost,
+    requestedPetId: pet.petId,
+    renderedPetId,
+    motionHandleId,
+    window,
+  };
+  visitingPetWindows.set(pet.ownerHost, entry);
+  window.once("closed", () => {
+    const current = visitingPetWindows.get(pet.ownerHost);
+    if (current?.window !== window) return;
+    unregisterRoamingPet(motionHandleId);
+    visitingPetWindows.delete(pet.ownerHost);
+  });
+  window.showInactive();
+  registerRoamingPet(motionHandleId, () => {
+    const current = visitingPetWindows.get(pet.ownerHost);
+    return current?.window && !current.window.isDestroyed() ? current.window : null;
+  });
+  info("pet.agent", "lan visiting pet shown", { ownerHost: pet.ownerHost, requestedPetId: pet.petId, renderedPetId, windowId: window.id });
+}
+
+function closeLanVisitingPet(ownerHost: string): void {
+  const entry = visitingPetWindows.get(ownerHost);
+  if (!entry) return;
+  visitingPetWindows.delete(ownerHost);
+  unregisterRoamingPet(entry.motionHandleId);
+  if (!entry.window.isDestroyed()) {
+    debug("pet.agent", "lan visiting pet close", { ownerHost, petId: entry.renderedPetId, windowId: entry.window.id });
+    entry.window.destroy();
+  }
+}

--- a/apps/desktop/src/lan-pet-presence.ts
+++ b/apps/desktop/src/lan-pet-presence.ts
@@ -1,0 +1,25 @@
+import type { LanPetRecord } from "./lan-state.js";
+
+export type LanPetPresencePlan = {
+  readonly show: readonly LanPetRecord[];
+  readonly closeOwnerHosts: readonly string[];
+};
+
+export function planLanPetPresence(localHost: string, pets: readonly LanPetRecord[], activeOwnerHosts: readonly string[]): LanPetPresencePlan {
+  const show = pets
+    .filter((pet) => pet.ownerHost !== localHost && pet.currentHost === localHost)
+    .sort((a, b) => a.ownerHost.localeCompare(b.ownerHost));
+  const desiredOwners = new Set(show.map((pet) => pet.ownerHost));
+  return {
+    show,
+    closeOwnerHosts: activeOwnerHosts.filter((ownerHost) => !desiredOwners.has(ownerHost)).sort(),
+  };
+}
+
+export function resolveRenderableLanPetId(
+  requestedPetId: string,
+  installedPets: readonly { readonly id: string; readonly broken?: boolean; readonly builtIn?: boolean }[],
+): string | null {
+  const pet = installedPets.find((candidate) => candidate.id === requestedPetId);
+  return pet && !pet.broken ? pet.id : null;
+}

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -18,12 +18,21 @@ export type LanClientRecord = {
   readonly host: string;
   readonly lastSeen: number;
   readonly position?: LanPoint;
+  readonly petId?: string;
+};
+
+export type LanPetRecord = {
+  readonly ownerHost: string;
+  readonly petId: string;
+  readonly currentHost: string;
+  readonly position?: LanPoint;
 };
 
 export type LanState = {
   readonly enabled: true;
   readonly currentHost: string | null;
   readonly clients: readonly LanClientRecord[];
+  readonly pets?: readonly LanPetRecord[];
   readonly updatedAt: number;
 };
 
@@ -36,6 +45,8 @@ export interface LanCoordinatorOptions {
 export class LanCoordinator {
   readonly #staleClientMs: number;
   readonly #clients = new Map<string, LanClientRecord>();
+  readonly #pets = new Map<string, LanPetRecord>();
+  readonly #petEdgeArmed = new Set<string>();
   readonly #topology: LanTopology;
   #currentHost: string | null = null;
   #preferredHost: string | null = null;
@@ -55,8 +66,17 @@ export class LanCoordinator {
     }
   }
 
-  register(host: string, position: LanPoint | undefined, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  register(host: string, position: LanPoint | undefined, now: number, petId?: string): LanState {
+    this.#clients.set(host, { host, lastSeen: now, position, petId });
+    if (petId) {
+      const existingPet = this.#pets.get(host);
+      this.#pets.set(host, {
+        ownerHost: host,
+        petId,
+        currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
+        position: existingPet?.position ?? position,
+      });
+    }
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -76,8 +96,10 @@ export class LanCoordinator {
     return this.snapshot(now);
   }
 
-  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number, ownerHost?: string): LanState {
+    const existingClient = this.#clients.get(host);
+    this.#clients.set(host, { host, lastSeen: now, position, petId: existingClient?.petId });
+    if (ownerHost) this.#updatePetPosition(host, ownerHost, position, edge);
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -104,6 +126,7 @@ export class LanCoordinator {
       enabled: true,
       currentHost: this.#currentHost,
       clients: [...this.#clients.values()].sort((a, b) => a.host.localeCompare(b.host)),
+      pets: [...this.#pets.values()].filter((pet) => this.#clients.has(pet.ownerHost) && this.#clients.has(pet.currentHost)).sort((a, b) => a.ownerHost.localeCompare(b.ownerHost)),
       updatedAt: now,
     };
   }
@@ -112,10 +135,40 @@ export class LanCoordinator {
     for (const [host, record] of this.#clients) {
       if (now - record.lastSeen > this.#staleClientMs) this.#clients.delete(host);
     }
+    for (const [ownerHost, pet] of this.#pets) {
+      if (!this.#clients.has(ownerHost)) {
+        this.#pets.delete(ownerHost);
+        this.#petEdgeArmed.delete(ownerHost);
+      } else if (!this.#clients.has(pet.currentHost)) {
+        this.#pets.set(ownerHost, { ...pet, currentHost: ownerHost });
+      }
+    }
     if (this.#currentHost && !this.#clients.has(this.#currentHost)) {
       this.#currentHost = this.#clients.keys().next().value ?? null;
       this.#edgeArmed = false;
     }
+  }
+
+  #updatePetPosition(host: string, ownerHost: string, position: LanPoint | undefined, edge: LanEdge | null): void {
+    const pet = this.#pets.get(ownerHost);
+    if (!pet || pet.currentHost !== host) return;
+    let currentHost = pet.currentHost;
+    if (!edge) this.#petEdgeArmed.add(ownerHost);
+    else if (position && this.#petEdgeArmed.has(ownerHost)) {
+      currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
+      this.#petEdgeArmed.delete(ownerHost);
+    }
+    this.#pets.set(ownerHost, { ...pet, currentHost, position });
+  }
+
+  #getPetNeighbor(currentHost: string, edge: LanEdge): string | null {
+    const configured = this.#topology[currentHost]?.[edge];
+    if (configured && this.#clients.has(configured)) return configured;
+    const hosts = [...this.#clients.keys()].sort();
+    if (hosts.length < 2) return null;
+    const index = hosts.indexOf(currentHost);
+    if (index < 0) return null;
+    return edge === "right" || edge === "down" ? hosts[(index + 1) % hosts.length] : hosts[(index - 1 + hosts.length) % hosts.length];
   }
 
   #migrate(edge: LanEdge): void {
@@ -157,6 +210,10 @@ export function normalizeLanPoint(value: unknown): LanPoint | undefined {
 
 export function normalizeLanEdge(value: unknown): LanEdge | null {
   return value === "left" || value === "right" || value === "up" || value === "down" ? value : null;
+}
+
+export function normalizeLanPetId(value: unknown): string | null {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value) ? value : null;
 }
 
 export function normalizeLanTopology(value: unknown): LanTopology {

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -5,6 +5,7 @@ import { shutdownDesktopAnalytics } from "./analytics.js";
 import { destroyDefaultPet } from "./default-pet-controller.js";
 import { info } from "./logger.js";
 import { stopLocalIpcServer } from "./local-ipc.js";
+import { closeAllLanVisitingPets } from "./lan-pet-controller.js";
 import { stopPluginService } from "./plugin-service.js";
 import { focusOpenTaskWindows } from "./windows.js";
 
@@ -36,6 +37,7 @@ export function installAppLifecycle(): void {
     scheduleHardExitFallback("before-quit");
     stopPluginService();
     stopLocalIpcServer();
+    closeAllLanVisitingPets();
     closeAllAgentPets();
     destroyDefaultPet();
     shutdownDesktopAnalytics();

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -761,12 +761,14 @@ export async function loadExplicitPetContent(window: BrowserWindow, petId: strin
     applyPetWindowFocusPolicy(window, petPluginBubblesHaveInteractiveInput(pluginBubbles));
     const state = getAppStateSnapshot();
     const pet = state.pets.installed.find((candidate) => candidate.id === petId);
-    if (!pet || pet.broken || pet.id === builtInPet.id) {
+    if (!pet || pet.broken) {
       throw new Error(`Cannot render explicit pet: ${petId}`);
     }
     debug("pet.window", "explicit content render begin", { windowId: window.id, sequence, petId, displayName: pet.displayName, hasDisplay: Boolean(display), reaction: display?.reaction, hasMessage: Boolean(display?.message), badge });
     const scale = scaleOverride ?? state.preferences.petScale as PetScaleValue;
-    const render = await createInstalledPetRender(pet.id, pet.displayName, false, display, scale, badge, `explicit:${pet.id}`, dismissToken, pluginBubbles);
+    const render = pet.id === builtInPet.id
+      ? createBuiltInPetRender(false, display, badge, scale, `explicit:${pet.id}`, dismissToken, pluginBubbles)
+      : await createInstalledPetRender(pet.id, pet.displayName, false, display, scale, badge, `explicit:${pet.id}`, dismissToken, pluginBubbles);
     applyLinuxPetWindowShape(window, scale, Boolean(display?.message || display?.reactionMessage || display?.reaction || display?.mediaPath || badge || pluginBubbles?.transient || pluginBubbles?.pinned));
     if (tryUpdateLoadedPetContent(window, render, `explicit-${pet.id}`, sequence)) return;
     await loadPetHtmlFile(window, render.html, `explicit-${pet.id}`, sequence);
@@ -933,15 +935,19 @@ async function createDefaultPetRender(paused: boolean, display: PetTransientDisp
     return installedPetRender;
   }
 
+  const scale = getAppStateSnapshot().preferences.petScale as PetScaleValue;
+  return createBuiltInPetRender(paused, display, badge, scale, "default:builtin", dismissToken, pluginBubbles);
+}
+
+function createBuiltInPetRender(paused: boolean, display: PetTransientDisplay | null, badge: PetStatusBadgeReaction | null, scale: PetScaleValue, cachePrefix: string, dismissToken?: string, pluginBubbles: PetPluginBubbles | null = null): PetContentRender {
   const spriteUrl = pathToFileURL(join(app.getAppPath(), "assets", defaultPetSprite.fileName)).toString();
   const hasPinned = Boolean(pluginBubbles?.pinned);
   const bodyHtml = createPetBodyMarkup("OpenPets default pet", createBubbleMarkup(display, paused, badge, dismissToken, pluginBubbles), `<div class="sprite" role="img" aria-label="Claude animated default pet"></div>`, createPinnedBubbleMarkup(pluginBubbles), hasPinned);
   const reactionState = getReactionSpriteState(display?.reaction);
   const stateRows = defaultPetSprite.states;
-  const scale = getAppStateSnapshot().preferences.petScale as PetScaleValue;
 
   return {
-    cacheKey: `default:builtin:${paused}:${scale}:${getActiveLocale()}`,
+    cacheKey: `${cachePrefix}:${paused}:${scale}:${getActiveLocale()}`,
     bodyHtml,
     reactionState,
     html: `<!doctype html>

--- a/apps/desktop/tests/lan-controller.test.ts
+++ b/apps/desktop/tests/lan-controller.test.ts
@@ -39,6 +39,20 @@ try {
   assert.equal(betaRegister.body.currentHost, "alpha", "second register should not steal current ownership");
   assert.deepEqual(betaRegister.body.clients.map((client) => client.host), ["alpha", "beta"]);
 
+  const alphaPetRegister = await requestJson<LanState>("POST", "/register", { host: "alpha", petId: "cat", position: { x: 10, y: 20 } }, token);
+  const betaPetRegister = await requestJson<LanState>("POST", "/register", { host: "beta", petId: "cat", position: { x: 400, y: 20 } }, token);
+  assert.deepEqual(betaPetRegister.body.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
+    ["alpha", "cat", "alpha"],
+    ["beta", "cat", "beta"],
+  ], "HTTP registration should preserve separate owners even when both choose the same pet ID");
+  const armBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 200, y: 20 }, edge: null }, token);
+  assert.equal(armBetaPet.status, 200);
+  const moveBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 5, y: 20 }, edge: "left" }, token);
+  assert.deepEqual(moveBetaPet.body.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
+    ["alpha", "alpha"],
+    ["beta", "alpha"],
+  ], "HTTP position updates should allow two pets to meet on one host");
+
   now += 100;
   const moveAway = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 200, y: 20 }, edge: null }, token);
   assert.equal(moveAway.body.currentHost, "alpha", "moving away from the edge arms handoff without migrating");
@@ -56,6 +70,8 @@ try {
 
   const missingHostRegister = await requestJson("POST", "/register", {}, token);
   assert.equal(missingHostRegister.status, 400, "register should reject requests without a host");
+  const invalidPetRegister = await requestJson("POST", "/register", { host: "alpha", petId: "../cat" }, token);
+  assert.equal(invalidPetRegister.status, 400, "register should reject unsafe pet IDs instead of silently downgrading to legacy state");
 
   now += 11_000;
   const staleOwnerPrune = await requestJson<LanState>("POST", "/position", { host: "beta", position: { x: 420, y: 20 }, edge: null }, token);

--- a/apps/desktop/tests/lan-pet-presence.test.ts
+++ b/apps/desktop/tests/lan-pet-presence.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import { planLanPetPresence, resolveRenderableLanPetId } from "../src/lan-pet-presence.js";
+
+const pets = [
+  { ownerHost: "alpha", petId: "cat", currentHost: "beta" },
+  { ownerHost: "beta", petId: "dog", currentHost: "beta" },
+  { ownerHost: "gamma", petId: "cat", currentHost: "beta" },
+];
+
+const plan = planLanPetPresence("beta", pets, ["alpha", "departed"]);
+assert.deepEqual(plan.show.map((pet) => pet.ownerHost), ["alpha", "gamma"], "all remote pets hosted locally should render, including duplicate pet IDs");
+assert.deepEqual(plan.closeOwnerHosts, ["departed"], "windows whose owners moved away should close");
+assert.equal(plan.show.some((pet) => pet.ownerHost === "beta"), false, "the local owner's default pet must not be duplicated as a visiting window");
+
+assert.equal(resolveRenderableLanPetId("cat", [{ id: "cat" }]), "cat", "an installed healthy pet should render");
+assert.equal(resolveRenderableLanPetId("cat", [{ id: "cat", broken: true }]), null, "a broken pet should not open a blank visiting window");
+assert.equal(resolveRenderableLanPetId("builtin", [{ id: "builtin", builtIn: true }]), "builtin", "the bundled pet should support fresh-profile LAN testing");
+assert.equal(resolveRenderableLanPetId("missing", [{ id: "cat" }]), null, "a missing remote asset should degrade safely");
+
+console.log("LAN visiting pet presence validation passed.");

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
+import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
 
 const coordinator = new LanCoordinator({ staleClientMs: 1_000 });
 
@@ -68,6 +68,22 @@ offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 120, y: 1
 offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 6_300);
 assert.equal(offlineState.currentHost, "beta", "offline configured neighbor should fall back to sorted cycling");
 
+// Multi-pet foundation: each host contributes an independently movable pet,
+// allowing two pets to occupy the same host without changing legacy behavior.
+const multiPetCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let multiPetState = multiPetCoordinator.register("alpha", { x: 100, y: 100 }, 7_000, "cat");
+multiPetState = multiPetCoordinator.register("beta", { x: 200, y: 100 }, 7_100, "dog");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
+  ["alpha", "cat", "alpha"],
+  ["beta", "dog", "beta"],
+], "each LAN host should register its own independently hosted pet");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 7_200, "alpha");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 7_300, "alpha");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
+  ["alpha", "beta"],
+  ["beta", "beta"],
+], "one LAN pet should migrate onto a host that already has another pet");
+
 
 const topologyDiagnostics = normalizeLanTopology({
   alpha: { right: "beta", left: "alpha" },
@@ -90,5 +106,7 @@ assert.deepEqual(normalizeLanPoint({ x: 12.7, y: "9" }), { x: 13, y: 9 });
 assert.equal(normalizeLanPoint({ x: Number.NaN, y: 1 }), undefined);
 assert.equal(normalizeLanEdge("left"), "left");
 assert.equal(normalizeLanEdge("diagonal"), null);
+assert.equal(normalizeLanPetId("pixel-cat"), "pixel-cat");
+assert.equal(normalizeLanPetId("../cat"), null);
 
 console.log("LAN coordinator validation passed.");

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -11,11 +11,33 @@ connected host. Each record keeps the pet's owner host, selected pet ID, current
 host, and latest position. This foundation allows two pets to occupy the same
 host while preserving the existing single-pet fields and behavior.
 
-Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
-and Control Center setup are intentionally deferred to later phases of
+Meeting interactions, privacy-preserving MCP work signals, and Control Center
+setup are intentionally deferred to later phases of
 [issue #93](https://github.com/alvinunreal/openpets/issues/93). Multi-machine GUI
 validation is pending while the second test system is unavailable, so this work
 remains experimental.
+
+### Experimental visiting-pet rendering
+
+Set `OPENPETS_LAN_PETS=multi` on every participating host to exercise the next
+experimental phase. Each host registers its selected default pet. When that pet
+migrates away, its default window hides; the destination opens a dedicated
+visiting-pet window keyed by owner host. Owner identity—not pet package ID—is
+the window key, so two people may select the same pet without colliding.
+
+The destination must have the selected pet installed and healthy. The bundled
+built-in pet works without extra setup. Missing or broken catalog assets are
+skipped with a scoped diagnostic;
+the local pet and LAN polling continue normally. Visiting windows close when
+their pet leaves, their owner disconnects, or LAN polling exceeds its failure
+threshold. This phase contains no meeting dialogue, MCP relay, or social
+animation.
+
+This rendering phase has been exercised with two isolated Electron profiles on
+one computer. The test covered both handoff directions, two independently
+draggable built-in pets on one host, return cleanup, and stale-client pruning
+after one instance disconnected. Validation across two physical machines is
+still pending.
 
 ## Server PC
 

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -4,6 +4,19 @@ This experimental mode makes one OpenPets default pet shared across PCs on a LAN
 Only the current owner machine shows the pet. Dragging the pet to a screen edge
 hands ownership to the next/previous connected host.
 
+## Experimental multi-pet foundation
+
+The coordinator state can also represent one independently traveling pet per
+connected host. Each record keeps the pet's owner host, selected pet ID, current
+host, and latest position. This foundation allows two pets to occupy the same
+host while preserving the existing single-pet fields and behavior.
+
+Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
+and Control Center setup are intentionally deferred to later phases of
+[issue #93](https://github.com/alvinunreal/openpets/issues/93). Multi-machine GUI
+validation is pending while the second test system is unavailable, so this work
+remains experimental.
+
 ## Server PC
 
 PowerShell:

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -50,6 +50,11 @@ Two distinct window roles, two controllers:
 Both are created by `pet-window.ts` as transparent, frameless, always-on-top
 windows, driven through `pet-preload.cjs` for drag and click-through behavior.
 
+Experimental multi-pet LAN mode adds a third, isolated controller for visiting
+pets. Windows are keyed by LAN owner host rather than pet ID, so they do not
+collide with lease-managed agent pets or with another visitor using the same
+pet package. Unavailable remote assets are logged and skipped safely.
+
 While a pet is click-through it only learns that the cursor is over it through
 *forwarded* mouse events (`setIgnoreMouseEvents(true, { forward: true })`), which
 Electron delivers on macOS and Windows but not on Linux (Linux pet windows are


### PR DESCRIPTION
## Depends on

- #94 — multi-pet LAN coordinator foundation
- #93 — feature discussion and phased plan

This is the experimental Phase 2 follow-up. Until #94 merges, GitHub will show
both the Phase 1 foundation and this rendering change in the comparison.

## What changed

- register each opted-in host's selected default pet with the LAN coordinator
- render remote pets hosted locally in dedicated windows keyed by owner host
- report visiting-pet positions so either pet can continue travelling
- support the bundled pet in explicit windows for fresh-profile testing
- safely skip missing or broken remote pet assets
- close visiting windows when pets leave, owners disconnect, polling fails, or
  the app exits
- reclamp visiting windows after display changes
- add behavior-focused presence and HTTP tests
- document the experimental runtime flag and current limitations

## Why

The coordinator added in #94 can represent independently travelling pets, but
users cannot yet see two pets meet. This phase connects that state to isolated
pet windows without sharing MCP message contents or adding meeting dialogue.

Enable it on each participant with:

```text
OPENPETS_LAN_PETS=multi
```

## Validation

- `pnpm --filter @open-pets/desktop test:build`
- `node apps/desktop/.test-dist/tests/lan-state.test.js`
- `node apps/desktop/.test-dist/tests/lan-pet-presence.test.js`
- `node apps/desktop/.test-dist/tests/lan-controller.test.js`
- `pnpm --filter @open-pets/desktop typecheck`
- `pnpm --filter @open-pets/desktop build`

Two isolated Electron instances on one computer were also used to verify:

- handoff in both directions
- two independently draggable built-in pets on one host
- cleanup when a pet returns
- stale-client pruning after one instance disconnects

Testing across two physical machines is still pending because the second system
is under repair. The feature remains experimental.

## Deferred

- privacy-preserving MCP work signals
- pet-to-pet dialogue and social animations
- Sonic-style return-to-work animation
- Control Center setup
