### PR TITLE
Fix MCP startup lease cleanup race

### DIFF
--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -102,12 +102,12 @@ A standalone stdio MCP server (`open-pets-mcp`) for any MCP-capable agent. It
 registers exactly three tools — `openpets_status`, `openpets_react`,
 `openpets_say` — with Zod-validated input and read-only/idempotent annotations.
 On startup it acquires a lease, heartbeats every ~5s, and releases on transport
-close or SIGINT/SIGTERM. Shutdown waits for any in-flight startup acquisition
-before releasing, so an agent that replaces an MCP process during startup
-cannot leave a temporary second pool pet behind. Errors are sanitized so IPC
-paths/tokens/sockets never leak into tool output. It is spawned by the CLI
-(`runMcp()`) which forwards stdio and signals. `--pet <id>` targets a specific
-pet.
+close or SIGINT/SIGTERM. Shutdown waits for in-flight startup and recovery
+acquisitions before releasing, so an agent that replaces an MCP process cannot
+leave a temporary second pool pet behind—even if replacement overlaps a
+heartbeat-recovery retry. Errors are sanitized so IPC paths/tokens/sockets never
+leak into tool output. It is spawned by the CLI (`runMcp()`) which forwards
+stdio and signals. `--pet <id>` targets a specific pet.
 
 > **Window confinement requires an installed pet.** Passing `--pet <id>` only
 > activates window confinement when the requested pet is actually installed. If

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -104,12 +104,15 @@ registers exactly three tools — `openpets_status`, `openpets_react`,
 On startup it acquires a lease, heartbeats every ~5s, and releases on transport
 close or SIGINT/SIGTERM. Shutdown marks the shared lease context as closing,
 stops timers, waits for in-flight startup and single-flight recovery from either
-the heartbeat timer or a reaction/say tool, then releases the current lease
-before closing the server and exiting. No new recovery acquisition starts after
-teardown begins, so an agent that replaces an MCP process cannot leave a
-temporary second pool pet behind. Errors are sanitized so IPC paths/tokens/
-sockets never leak into tool output. It is spawned by the CLI (`runMcp()`) which
-forwards stdio and signals. `--pet <id>` targets a specific pet.
+the heartbeat timer or a reaction/say tool, then best-effort releases every
+retained lease ID exactly once before closing the server and exiting. A heartbeat
+failure that arrives after closing begins cannot erase the active lease needed
+for teardown; a failure just before closing retains its stale ID alongside any
+eventual recovery lease. No new recovery acquisition starts after teardown
+begins, so an agent that replaces an MCP process cannot leave a temporary second
+pool pet behind. Errors are sanitized so IPC paths/tokens/sockets never leak
+into tool output. It is spawned by the CLI (`runMcp()`) which forwards stdio and
+signals. `--pet <id>` targets a specific pet.
 
 > **Window confinement requires an installed pet.** Passing `--pet <id>` only
 > activates window confinement when the requested pet is actually installed. If

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -101,10 +101,13 @@ are what the Control Center Integrations page and the CLI call.
 A standalone stdio MCP server (`open-pets-mcp`) for any MCP-capable agent. It
 registers exactly three tools — `openpets_status`, `openpets_react`,
 `openpets_say` — with Zod-validated input and read-only/idempotent annotations.
-On startup it acquires a lease, heartbeats every ~5s, and releases on
-SIGINT/SIGTERM. Errors are sanitized so IPC paths/tokens/sockets never leak into
-tool output. It is spawned by the CLI (`runMcp()`) which forwards stdio and
-signals. `--pet <id>` targets a specific pet.
+On startup it acquires a lease, heartbeats every ~5s, and releases on transport
+close or SIGINT/SIGTERM. Shutdown waits for any in-flight startup acquisition
+before releasing, so an agent that replaces an MCP process during startup
+cannot leave a temporary second pool pet behind. Errors are sanitized so IPC
+paths/tokens/sockets never leak into tool output. It is spawned by the CLI
+(`runMcp()`) which forwards stdio and signals. `--pet <id>` targets a specific
+pet.
 
 > **Window confinement requires an installed pet.** Passing `--pet <id>` only
 > activates window confinement when the requested pet is actually installed. If

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -102,12 +102,14 @@ A standalone stdio MCP server (`open-pets-mcp`) for any MCP-capable agent. It
 registers exactly three tools — `openpets_status`, `openpets_react`,
 `openpets_say` — with Zod-validated input and read-only/idempotent annotations.
 On startup it acquires a lease, heartbeats every ~5s, and releases on transport
-close or SIGINT/SIGTERM. Shutdown waits for in-flight startup and recovery
-acquisitions before releasing, so an agent that replaces an MCP process cannot
-leave a temporary second pool pet behind—even if replacement overlaps a
-heartbeat-recovery retry. Errors are sanitized so IPC paths/tokens/sockets never
-leak into tool output. It is spawned by the CLI (`runMcp()`) which forwards
-stdio and signals. `--pet <id>` targets a specific pet.
+close or SIGINT/SIGTERM. Shutdown marks the shared lease context as closing,
+stops timers, waits for in-flight startup and single-flight recovery from either
+the heartbeat timer or a reaction/say tool, then releases the current lease
+before closing the server and exiting. No new recovery acquisition starts after
+teardown begins, so an agent that replaces an MCP process cannot leave a
+temporary second pool pet behind. Errors are sanitized so IPC paths/tokens/
+sockets never leak into tool output. It is spawned by the CLI (`runMcp()`) which
+forwards stdio and signals. `--pet <id>` targets a specific pet.
 
 > **Window confinement requires an installed pet.** Passing `--pet <id>` only
 > activates window confinement when the requested pet is actually installed. If

--- a/packages/mcp/codemap.md
+++ b/packages/mcp/codemap.md
@@ -24,7 +24,7 @@ Implements an MCP server exposing OpenPets functionality to AI agents via the Mo
 **Lifecycle Management** (`index.ts`):
 - Startup lease acquisition (async, non-blocking)
 - Heartbeat timer (5s interval, unref'd)
-- Graceful shutdown on SIGINT/SIGTERM (stop recovery sources, join startup/recovery, release lease, close server)
+- Graceful shutdown on SIGINT/SIGTERM (stop recovery sources, join startup/recovery, release retained lease IDs once, close server)
 - Stdio transport via `StdioServerTransport`
 
 **Argument Parsing** (`args.ts`):
@@ -52,7 +52,7 @@ server.connect(StdioServerTransport)
     ↓
 [Heartbeat] Every 5s: client.heartbeatLease()
     ↓
-[Shutdown] SIGINT/SIGTERM or transport close → mark shared lease context closing → stop timers → join startup/tool/timer recovery → releaseLease() → server.close() → exit once
+[Shutdown] SIGINT/SIGTERM or transport close → mark shared lease context closing → stop timers → join startup/tool/timer recovery → release retained active/stale/recovered lease IDs once → server.close() → exit once
 ```
 
 ## Integration Points

--- a/packages/mcp/codemap.md
+++ b/packages/mcp/codemap.md
@@ -16,7 +16,7 @@ Implements an MCP server exposing OpenPets functionality to AI agents via the Mo
 
 **Tool Implementations** (`tools.ts`):
 - Zod schemas for input validation (`saySchema`, `reactSchema`)
-- Lease-aware operations (acquires lease on startup, heartbeat every 5s)
+- Lease-aware operations (acquires lease on startup, heartbeat every 5s, and single-flight stale-lease recovery shared with lifecycle timers)
 - Throttling integration for speech/reactions
 - Error sanitization (hides IPC paths, tokens, sockets, and local paths)
 - Structured MCP results: tools return `structuredContent` with status, routing, lease, and operation result metadata when available.
@@ -24,7 +24,7 @@ Implements an MCP server exposing OpenPets functionality to AI agents via the Mo
 **Lifecycle Management** (`index.ts`):
 - Startup lease acquisition (async, non-blocking)
 - Heartbeat timer (5s interval, unref'd)
-- Graceful shutdown on SIGINT/SIGTERM (release lease, close server)
+- Graceful shutdown on SIGINT/SIGTERM (stop recovery sources, join startup/recovery, release lease, close server)
 - Stdio transport via `StdioServerTransport`
 
 **Argument Parsing** (`args.ts`):
@@ -52,7 +52,7 @@ server.connect(StdioServerTransport)
     ↓
 [Heartbeat] Every 5s: client.heartbeatLease()
     ↓
-[Shutdown] SIGINT/SIGTERM → releaseLease() → server.close()
+[Shutdown] SIGINT/SIGTERM or transport close → mark shared lease context closing → stop timers → join startup/tool/timer recovery → releaseLease() → server.close() → exit once
 ```
 
 ## Integration Points

--- a/packages/mcp/src/check-mcp-contract.ts
+++ b/packages/mcp/src/check-mcp-contract.ts
@@ -34,6 +34,7 @@ await checkStdioServerContract();
 await checkT6TransportOnclose();
 await checkT7EnsureLeaseHeartbeatFirst();
 await checkT8ExitOnce();
+await checkT9CloseDuringStartupAcquire();
 const builtEntrypoint = readFileSync(join("dist", "index.js"), "utf8");
 if (!builtEntrypoint.startsWith("#!/usr/bin/env node")) {
   throw new Error("Built MCP entrypoint is missing a Node shebang.");
@@ -388,5 +389,74 @@ async function checkT8ExitOnce(): Promise<void> {
   }
   if (releaseIdx >= exitIdx) {
     throw new Error("T8: release did not precede exit. Order: " + releaseOrder.join(","));
+  }
+}
+
+/**
+ * T9 — Closing while startup acquisition is unresolved must wait for that
+ * acquisition, release its eventual lease, and only then exit. Cursor can
+ * replace an MCP process during startup; leaking that process's lease briefly
+ * displays a second pool pet until the lease TTL expires.
+ */
+async function checkT9CloseDuringStartupAcquire(): Promise<void> {
+  const order: string[] = [];
+  const startupLeaseId = "t9-startup-lease";
+  let finishStartup: (() => void) | undefined;
+  const leaseReady = new Promise<void>((resolve) => {
+    finishStartup = resolve;
+  });
+  const lease: LeaseContext = {};
+  const fakeTransport: { onclose?: (() => void) | undefined } = {};
+  const fakeClient = {
+    status: async () => ({ ok: true, appRunning: true }),
+    listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
+    installPet: async () => { throw new Error("unused"); },
+    installLocalPet: async () => { throw new Error("unused"); },
+    acquireLease: async () => { throw new Error("unused"); },
+    heartbeatLease: async (leaseId: string) => ({ leaseId, expiresAt: Date.now() + 15_000 }),
+    releaseLease: async (leaseId: string) => { order.push(`release:${leaseId}`); return { released: true }; },
+    react: async () => ({ ok: true }),
+    say: async () => ({ ok: true }),
+    showMedia: async () => ({ ok: true, shown: true }),
+    hello: async () => ({ ok: true }),
+  };
+  const fakeServer = { close: async () => { order.push("server.close"); } };
+
+  wireTransportLifecycle({
+    transport: fakeTransport,
+    server: fakeServer,
+    client: fakeClient,
+    lease,
+    leaseReady,
+    exit: () => { order.push("exit"); },
+  });
+
+  fakeTransport.onclose?.();
+  fakeTransport.onclose?.();
+  await Promise.resolve();
+  if (order.includes("exit")) {
+    throw new Error(`T9: process exited before startup acquisition settled. Order: ${order.join(",")}`);
+  }
+
+  lease.lease = {
+    leaseId: startupLeaseId,
+    requestedPetId: undefined,
+    targetKind: "explicit",
+    actualTargetPetId: "snoopy",
+    actualTargetPetName: "Snoopy",
+    usingDefaultPet: false,
+    expiresAt: Date.now() + 15_000,
+    leaseActive: true,
+  };
+  finishStartup?.();
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+  const releaseIndex = order.indexOf(`release:${startupLeaseId}`);
+  const exitIndex = order.indexOf("exit");
+  if (releaseIndex === -1 || exitIndex === -1 || releaseIndex >= exitIndex) {
+    throw new Error(`T9: startup lease was not released before exit. Order: ${order.join(",")}`);
+  }
+  if (order.filter((event) => event === "exit").length !== 1) {
+    throw new Error(`T9: repeated close exited more than once. Order: ${order.join(",")}`);
   }
 }

--- a/packages/mcp/src/check-mcp-contract.ts
+++ b/packages/mcp/src/check-mcp-contract.ts
@@ -37,6 +37,7 @@ await checkT8ExitOnce();
 await checkT9CloseDuringStartupAcquire();
 await checkT10CloseDuringRecoveryAcquire();
 await checkT11CloseDuringToolRecovery();
+await checkT12CloseDuringHeartbeatFailure();
 const builtEntrypoint = readFileSync(join("dist", "index.js"), "utf8");
 if (!builtEntrypoint.startsWith("#!/usr/bin/env node")) {
   throw new Error("Built MCP entrypoint is missing a Node shebang.");
@@ -642,5 +643,201 @@ async function checkT11CloseDuringToolRecovery(): Promise<void> {
   }
   if (order.includes("react")) {
     throw new Error(`T11: reaction ran after teardown began. Order: ${order.join(",")}`);
+  }
+}
+
+/**
+ * T12 — A heartbeat may reject after close publishes its closing state, or just
+ * before it does. Teardown must release the original lease exactly once in both
+ * cases, and must also release a replacement lease that was already in flight.
+ */
+async function checkT12CloseDuringHeartbeatFailure(): Promise<void> {
+  // The heartbeat rejects after close starts while an existing recovery barrier
+  // keeps teardown from reaching release yet.
+  {
+    const order: string[] = [];
+    const activeLeaseId = "t12-active-lease";
+    let rejectHeartbeat!: (reason?: unknown) => void;
+    const heartbeatResult = new Promise<{ readonly leaseId: string; readonly expiresAt: number }>((_, reject) => {
+      rejectHeartbeat = reject;
+    });
+    let markHeartbeatStarted!: () => void;
+    const heartbeatStarted = new Promise<void>((resolve) => { markHeartbeatStarted = resolve; });
+    let finishRecovery!: () => void;
+    const recoveryBarrier = new Promise<void>((resolve) => { finishRecovery = resolve; });
+    let finishExit!: () => void;
+    const exitFinished = new Promise<void>((resolve) => { finishExit = resolve; });
+    const lease: LeaseContext = {
+      lease: {
+        leaseId: activeLeaseId,
+        requestedPetId: undefined,
+        targetKind: "default",
+        actualTargetPetId: "default",
+        actualTargetPetName: "Default",
+        usingDefaultPet: true,
+        expiresAt: Date.now() + 15_000,
+        leaseActive: true,
+      },
+      recoveryPromise: recoveryBarrier,
+    };
+    const fakeTransport: { onclose?: (() => void) | undefined } = {};
+    const fakeClient = {
+      status: async () => ({ ok: true, appRunning: true }),
+      listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
+      installPet: async () => { throw new Error("unused"); },
+      installLocalPet: async () => { throw new Error("unused"); },
+      acquireLease: async () => { throw new Error("unused"); },
+      heartbeatLease: async (_leaseId: string) => {
+        markHeartbeatStarted();
+        return heartbeatResult;
+      },
+      releaseLease: async (leaseId: string) => { order.push(`release:${leaseId}`); return { released: true }; },
+      react: async () => ({ ok: true }),
+      say: async () => ({ ok: true }),
+      showMedia: async () => ({ ok: true, shown: true }),
+      hello: async () => ({ ok: true }),
+    };
+    wireTransportLifecycle({
+      transport: fakeTransport,
+      server: { close: async () => { order.push("server.close"); } },
+      client: fakeClient,
+      lease,
+      leaseReady: Promise.resolve(),
+      heartbeatIntervalMs: 10,
+      exit: () => { order.push("exit"); finishExit(); },
+    });
+    // Production heartbeat/retry timers are unref'd; keep this deferred test alive
+    // without using the clock as a synchronization mechanism.
+    const keepAlive = setInterval(() => {}, 1_000);
+
+    try {
+      await heartbeatStarted;
+      fakeTransport.onclose?.();
+      rejectHeartbeat(new Error("heartbeat failed during close"));
+      await Promise.resolve();
+      if (order.length !== 0) {
+        throw new Error(`T12a: teardown released or closed before its barrier settled. Order: ${order.join(",")}`);
+      }
+      finishRecovery();
+      await exitFinished;
+
+      if (order.filter((event) => event === `release:${activeLeaseId}`).length !== 1) {
+        throw new Error(`T12a: original heartbeat lease was not released exactly once. Order: ${order.join(",")}`);
+      }
+      const releaseIndex = order.indexOf(`release:${activeLeaseId}`);
+      const serverCloseIndex = order.indexOf("server.close");
+      const exitIndex = order.indexOf("exit");
+      if (releaseIndex === -1 || serverCloseIndex === -1 || exitIndex === -1 || releaseIndex >= serverCloseIndex || serverCloseIndex >= exitIndex) {
+        throw new Error(`T12a: shutdown order was incorrect. Order: ${order.join(",")}`);
+      }
+    } finally {
+      clearInterval(keepAlive);
+    }
+  }
+
+  // If the heartbeat failure wins the race with close, retain its stale ID while
+  // the already-started recovery acquires a replacement lease.
+  {
+    const order: string[] = [];
+    const staleLeaseId = "t12-stale-lease";
+    const recoveredLeaseId = "t12-recovered-lease";
+    let rejectHeartbeat!: (reason?: unknown) => void;
+    const heartbeatResult = new Promise<{ readonly leaseId: string; readonly expiresAt: number }>((_, reject) => {
+      rejectHeartbeat = reject;
+    });
+    let markHeartbeatStarted!: () => void;
+    const heartbeatStarted = new Promise<void>((resolve) => { markHeartbeatStarted = resolve; });
+    let markAcquireStarted!: () => void;
+    const acquireStarted = new Promise<void>((resolve) => { markAcquireStarted = resolve; });
+    let finishAcquire!: (lease: OpenPetsLeaseResult) => void;
+    const acquireResult = new Promise<OpenPetsLeaseResult>((resolve) => { finishAcquire = resolve; });
+    let finishExit!: () => void;
+    const exitFinished = new Promise<void>((resolve) => { finishExit = resolve; });
+    const lease: LeaseContext = {
+      lease: {
+        leaseId: staleLeaseId,
+        requestedPetId: undefined,
+        targetKind: "default",
+        actualTargetPetId: "default",
+        actualTargetPetName: "Default",
+        usingDefaultPet: true,
+        expiresAt: Date.now() + 15_000,
+        leaseActive: true,
+      },
+    };
+    const fakeTransport: { onclose?: (() => void) | undefined } = {};
+    let heartbeatCalls = 0;
+    const fakeClient = {
+      status: async () => ({ ok: true, appRunning: true }),
+      listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
+      installPet: async () => { throw new Error("unused"); },
+      installLocalPet: async () => { throw new Error("unused"); },
+      acquireLease: async () => {
+        markAcquireStarted();
+        return acquireResult;
+      },
+      heartbeatLease: async (_leaseId: string) => {
+        heartbeatCalls += 1;
+        if (heartbeatCalls === 1) {
+          markHeartbeatStarted();
+          return heartbeatResult;
+        }
+        throw new Error("stale lease");
+      },
+      releaseLease: async (leaseId: string) => { order.push(`release:${leaseId}`); return { released: true }; },
+      react: async () => ({ ok: true }),
+      say: async () => ({ ok: true }),
+      showMedia: async () => ({ ok: true, shown: true }),
+      hello: async () => ({ ok: true }),
+    };
+    wireTransportLifecycle({
+      transport: fakeTransport,
+      server: { close: async () => { order.push("server.close"); } },
+      client: fakeClient,
+      lease,
+      leaseReady: Promise.resolve(),
+      heartbeatIntervalMs: 10,
+      retryDelayMs: 0,
+      exit: () => { order.push("exit"); finishExit(); },
+    });
+    const keepAlive = setInterval(() => {}, 1_000);
+
+    try {
+      await heartbeatStarted;
+      rejectHeartbeat(new Error("heartbeat failed before close"));
+      await acquireStarted;
+      fakeTransport.onclose?.();
+      await Promise.resolve();
+      if (order.length !== 0) {
+        throw new Error(`T12b: teardown completed before replacement acquisition settled. Order: ${order.join(",")}`);
+      }
+      finishAcquire({
+        leaseId: recoveredLeaseId,
+        requestedPetId: undefined,
+        targetKind: "default",
+        actualTargetPetId: "default",
+        actualTargetPetName: "Default",
+        usingDefaultPet: true,
+        expiresAt: Date.now() + 15_000,
+        leaseActive: true,
+      });
+      await exitFinished;
+
+      for (const leaseId of [staleLeaseId, recoveredLeaseId]) {
+        if (order.filter((event) => event === `release:${leaseId}`).length !== 1) {
+          throw new Error(`T12b: lease ${leaseId} was not released exactly once. Order: ${order.join(",")}`);
+        }
+      }
+      const staleReleaseIndex = order.indexOf(`release:${staleLeaseId}`);
+      const recoveredReleaseIndex = order.indexOf(`release:${recoveredLeaseId}`);
+      const serverCloseIndex = order.indexOf("server.close");
+      const exitIndex = order.indexOf("exit");
+      if (staleReleaseIndex === -1 || recoveredReleaseIndex === -1 || serverCloseIndex === -1 || exitIndex === -1
+        || staleReleaseIndex >= recoveredReleaseIndex || recoveredReleaseIndex >= serverCloseIndex || serverCloseIndex >= exitIndex) {
+        throw new Error(`T12b: stale/recovered lease shutdown order was incorrect. Order: ${order.join(",")}`);
+      }
+    } finally {
+      clearInterval(keepAlive);
+    }
   }
 }

--- a/packages/mcp/src/check-mcp-contract.ts
+++ b/packages/mcp/src/check-mcp-contract.ts
@@ -7,7 +7,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import { parseMcpArgs } from "./args.js";
-import { wireTransportLifecycle } from "./index.js";
+import { wireTransportLifecycle, type OpenPetsLeaseResult } from "./index.js";
 import { createOpenPetsMcpServer } from "./server.js";
 import { createMcpStatus, sanitizeUnavailableReason, type LeaseContext, type OpenPetsMcpStatus } from "./tools.js";
 
@@ -35,6 +35,7 @@ await checkT6TransportOnclose();
 await checkT7EnsureLeaseHeartbeatFirst();
 await checkT8ExitOnce();
 await checkT9CloseDuringStartupAcquire();
+await checkT10CloseDuringRecoveryAcquire();
 const builtEntrypoint = readFileSync(join("dist", "index.js"), "utf8");
 if (!builtEntrypoint.startsWith("#!/usr/bin/env node")) {
   throw new Error("Built MCP entrypoint is missing a Node shebang.");
@@ -458,5 +459,86 @@ async function checkT9CloseDuringStartupAcquire(): Promise<void> {
   }
   if (order.filter((event) => event === "exit").length !== 1) {
     throw new Error(`T9: repeated close exited more than once. Order: ${order.join(",")}`);
+  }
+}
+
+/**
+ * T10 — If shutdown begins while retry recovery is acquiring a replacement
+ * lease, teardown must join that recovery and release its eventual result.
+ */
+async function checkT10CloseDuringRecoveryAcquire(): Promise<void> {
+  const order: string[] = [];
+  const recoveredLeaseId = "t10-recovered-lease";
+  let finishAcquire: ((lease: OpenPetsLeaseResult) => void) | undefined;
+  const acquireResult = new Promise<OpenPetsLeaseResult>((resolve) => {
+    finishAcquire = resolve;
+  });
+  const lease: LeaseContext = {
+    lease: {
+      leaseId: "t10-stale-lease",
+      requestedPetId: undefined,
+      targetKind: "explicit",
+      actualTargetPetId: "snoopy",
+      actualTargetPetName: "Snoopy",
+      usingDefaultPet: false,
+      expiresAt: Date.now() + 15_000,
+      leaseActive: true,
+    },
+  };
+  const fakeTransport: { onclose?: (() => void) | undefined } = {};
+  const fakeClient = {
+    status: async () => ({ ok: true, appRunning: true }),
+    listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
+    installPet: async () => { throw new Error("unused"); },
+    installLocalPet: async () => { throw new Error("unused"); },
+    acquireLease: async () => { order.push("acquire:start"); return acquireResult; },
+    heartbeatLease: async () => { throw new Error("simulated heartbeat failure"); },
+    releaseLease: async (leaseId: string) => { order.push(`release:${leaseId}`); return { released: true }; },
+    react: async () => ({ ok: true }),
+    say: async () => ({ ok: true }),
+    showMedia: async () => ({ ok: true, shown: true }),
+    hello: async () => ({ ok: true }),
+  };
+
+  wireTransportLifecycle({
+    transport: fakeTransport,
+    server: { close: async () => { order.push("server.close"); } },
+    client: fakeClient,
+    lease,
+    leaseReady: Promise.resolve(),
+    heartbeatIntervalMs: 1,
+    retryDelayMs: 1,
+    exit: () => { order.push("exit"); },
+  });
+
+  for (let attempts = 0; attempts < 20 && !order.includes("acquire:start"); attempts += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 2));
+  }
+  if (!order.includes("acquire:start")) {
+    throw new Error(`T10: recovery acquisition did not start. Order: ${order.join(",")}`);
+  }
+
+  fakeTransport.onclose?.();
+  await Promise.resolve();
+  if (order.includes("exit")) {
+    throw new Error(`T10: process exited while recovery acquisition was unresolved. Order: ${order.join(",")}`);
+  }
+
+  finishAcquire?.({
+    leaseId: recoveredLeaseId,
+    requestedPetId: undefined,
+    targetKind: "explicit",
+    actualTargetPetId: "snoopy",
+    actualTargetPetName: "Snoopy",
+    usingDefaultPet: false,
+    expiresAt: Date.now() + 15_000,
+    leaseActive: true,
+  });
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+  const releaseIndex = order.indexOf(`release:${recoveredLeaseId}`);
+  const exitIndex = order.indexOf("exit");
+  if (releaseIndex === -1 || exitIndex === -1 || releaseIndex >= exitIndex) {
+    throw new Error(`T10: recovered lease was not released before exit. Order: ${order.join(",")}`);
   }
 }

--- a/packages/mcp/src/check-mcp-contract.ts
+++ b/packages/mcp/src/check-mcp-contract.ts
@@ -9,7 +9,7 @@ import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { parseMcpArgs } from "./args.js";
 import { wireTransportLifecycle, type OpenPetsLeaseResult } from "./index.js";
 import { createOpenPetsMcpServer } from "./server.js";
-import { createMcpStatus, sanitizeUnavailableReason, type LeaseContext, type OpenPetsMcpStatus } from "./tools.js";
+import { createMcpStatus, handleReact, sanitizeUnavailableReason, type LeaseContext, type OpenPetsMcpStatus } from "./tools.js";
 
 parseMcpArgs(["--pet", "snoopy"]);
 parseMcpArgs(["--pet=snoopy"]);
@@ -36,6 +36,7 @@ await checkT7EnsureLeaseHeartbeatFirst();
 await checkT8ExitOnce();
 await checkT9CloseDuringStartupAcquire();
 await checkT10CloseDuringRecoveryAcquire();
+await checkT11CloseDuringToolRecovery();
 const builtEntrypoint = readFileSync(join("dist", "index.js"), "utf8");
 if (!builtEntrypoint.startsWith("#!/usr/bin/env node")) {
   throw new Error("Built MCP entrypoint is missing a Node shebang.");
@@ -540,5 +541,106 @@ async function checkT10CloseDuringRecoveryAcquire(): Promise<void> {
   const exitIndex = order.indexOf("exit");
   if (releaseIndex === -1 || exitIndex === -1 || releaseIndex >= exitIndex) {
     throw new Error(`T10: recovered lease was not released before exit. Order: ${order.join(",")}`);
+  }
+}
+
+/**
+ * T11 — A public reaction tool can start recovery before transport teardown.
+ * Shutdown must join that single-flight recovery and release its eventual lease
+ * before closing the server and invoking the exit seam.
+ */
+async function checkT11CloseDuringToolRecovery(): Promise<void> {
+  const order: string[] = [];
+  const recoveredLeaseId = "t11-tool-recovered-lease";
+  let finishAcquire: ((lease: OpenPetsLeaseResult) => void) | undefined;
+  const acquireResult = new Promise<OpenPetsLeaseResult>((resolve) => {
+    finishAcquire = resolve;
+  });
+  let markAcquireStarted: (() => void) | undefined;
+  const acquireStarted = new Promise<void>((resolve) => {
+    markAcquireStarted = resolve;
+  });
+  let finishExit: (() => void) | undefined;
+  const exitFinished = new Promise<void>((resolve) => {
+    finishExit = resolve;
+  });
+  const staleLease: OpenPetsLeaseResult = {
+    leaseId: "t11-stale-lease",
+    requestedPetId: "snoopy",
+    targetKind: "explicit",
+    actualTargetPetId: "snoopy",
+    actualTargetPetName: "Snoopy",
+    usingDefaultPet: false,
+    expiresAt: Date.now() - 1_000,
+    leaseActive: true,
+  };
+  const lease: LeaseContext = { staleLeaseId: staleLease.leaseId, staleLease };
+  const fakeClient = {
+    status: async () => ({ ok: true, appRunning: true }),
+    listPets: async () => ({ ok: true as const, pets: [], defaultPetId: "builtin" }),
+    installPet: async () => { throw new Error("unused"); },
+    installLocalPet: async () => { throw new Error("unused"); },
+    acquireLease: async () => {
+      order.push("acquire:start");
+      markAcquireStarted?.();
+      return acquireResult;
+    },
+    heartbeatLease: async () => { throw new Error("simulated heartbeat failure"); },
+    releaseLease: async (leaseId: string) => { order.push(`release:${leaseId}`); return { released: true }; },
+    react: async () => { order.push("react"); return { ok: true }; },
+    say: async () => ({ ok: true }),
+    showMedia: async () => ({ ok: true, shown: true }),
+    hello: async () => ({ ok: true }),
+  };
+  const fakeTransport: { onclose?: (() => void) | undefined } = {};
+  const fakeServer = { close: async () => { order.push("server.close"); } };
+
+  wireTransportLifecycle({
+    transport: fakeTransport,
+    server: fakeServer,
+    client: fakeClient,
+    lease,
+    leaseReady: Promise.resolve(),
+    exit: () => { order.push("exit"); finishExit?.(); },
+  });
+
+  const toolResult = handleReact({ reaction: "waving" }, {
+    configuredPetId: "snoopy",
+    client: fakeClient,
+    lease,
+    leaseReady: Promise.resolve(),
+  });
+  await acquireStarted;
+
+  fakeTransport.onclose?.();
+  await Promise.resolve();
+  if (order.includes("server.close") || order.includes("exit")) {
+    throw new Error(`T11: teardown completed before tool recovery settled. Order: ${order.join(",")}`);
+  }
+
+  finishAcquire?.({
+    leaseId: recoveredLeaseId,
+    requestedPetId: "snoopy",
+    targetKind: "explicit",
+    actualTargetPetId: "snoopy",
+    actualTargetPetName: "Snoopy",
+    usingDefaultPet: false,
+    expiresAt: Date.now() + 15_000,
+    leaseActive: true,
+  });
+  await exitFinished;
+  await toolResult;
+
+  if (order.filter((event) => event === `release:${recoveredLeaseId}`).length !== 1) {
+    throw new Error(`T11: recovered tool lease was not released exactly once. Order: ${order.join(",")}`);
+  }
+  const releaseIndex = order.indexOf(`release:${recoveredLeaseId}`);
+  const serverCloseIndex = order.indexOf("server.close");
+  const exitIndex = order.indexOf("exit");
+  if (releaseIndex === -1 || serverCloseIndex === -1 || exitIndex === -1 || releaseIndex >= serverCloseIndex || serverCloseIndex >= exitIndex) {
+    throw new Error(`T11: tool lease teardown order was incorrect. Order: ${order.join(",")}`);
+  }
+  if (order.includes("react")) {
+    throw new Error(`T11: reaction ran after teardown began. Order: ${order.join(",")}`);
   }
 }

--- a/packages/mcp/src/codemap.md
+++ b/packages/mcp/src/codemap.md
@@ -14,7 +14,7 @@ Source implementation for the OpenPets MCP stdio server, including argument pars
 ## Data & Control Flow
 
 1. `index.ts` parses `--pet`, `--help`, and `--version`, creates a client-backed tool context, and starts the stdio transport.
-2. Startup lease acquisition runs asynchronously; heartbeat keeps the configured pet route alive while the MCP server is connected. Shutdown joins any in-flight startup acquisition before releasing its result, preventing replaced MCP processes from leaking temporary pool pets.
+2. Startup lease acquisition runs asynchronously; heartbeat keeps the configured pet route alive while the MCP server is connected. Shutdown joins in-flight startup and retry-recovery acquisitions before releasing their result, preventing replaced MCP processes from leaking temporary pool pets.
 3. `server.ts` registers `openpets_status`, `openpets_react`, and `openpets_say` against handlers in `tools.ts`.
 4. Handlers validate input, wait for lease readiness, acquire/reacquire a lease if needed, call `@open-pets/client`, and return text plus structured content.
 

--- a/packages/mcp/src/codemap.md
+++ b/packages/mcp/src/codemap.md
@@ -14,7 +14,7 @@ Source implementation for the OpenPets MCP stdio server, including argument pars
 ## Data & Control Flow
 
 1. `index.ts` parses `--pet`, `--help`, and `--version`, creates a client-backed tool context, and starts the stdio transport.
-2. Startup lease acquisition runs asynchronously; heartbeat keeps the configured pet route alive while the MCP server is connected.
+2. Startup lease acquisition runs asynchronously; heartbeat keeps the configured pet route alive while the MCP server is connected. Shutdown joins any in-flight startup acquisition before releasing its result, preventing replaced MCP processes from leaking temporary pool pets.
 3. `server.ts` registers `openpets_status`, `openpets_react`, and `openpets_say` against handlers in `tools.ts`.
 4. Handlers validate input, wait for lease readiness, acquire/reacquire a lease if needed, call `@open-pets/client`, and return text plus structured content.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,7 +8,7 @@ import type { OpenPetsClient, OpenPetsLeaseResult } from "@open-pets/client";
 
 import { createHelpText, parseMcpArgs } from "./args.js";
 import { createOpenPetsMcpServer } from "./server.js";
-import { createToolContext, type LeaseContext } from "./tools.js";
+import { createToolContext, recoverLease, type LeaseContext } from "./tools.js";
 
 /** Minimal transport interface required by wireTransportLifecycle (subset of StdioServerTransport). */
 export interface McpTransportHook {
@@ -55,56 +55,33 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
   const initialRetryDelayMs = opts.retryDelayMs ?? 5_000;
   let retryDelayMs = initialRetryDelayMs;
   const MAX_RETRY_DELAY_MS = 60_000;
-  let closing = false;
   let closePromise: Promise<void> | null = null;
-  let recoveryPromise: Promise<void> | null = null;
 
   function scheduleRetry(): void {
-    if (retryTimer || closing) return;
+    if (retryTimer || lease.closing) return;
     retryTimer = setTimeout(() => {
       retryTimer = null;
-      if (closing || lease.lease) return;
-      // Fix 2: attempt heartbeat-first recovery when a stale lease is saved
-      recoveryPromise = (async () => {
-        const staleLeaseId = lease.staleLeaseId;
-        const staleLease = lease.staleLease;
-        if (staleLeaseId && staleLease) {
-          try {
-            const hb = await client.heartbeatLease(staleLeaseId);
-            // Heartbeat succeeded — desktop still holds the original lease
-            lease.lease = { ...staleLease, leaseId: hb.leaseId, expiresAt: hb.expiresAt, leaseActive: true };
-            lease.staleLeaseId = undefined;
-            lease.staleLease = undefined;
-            lease.degradedReason = undefined;
-            retryDelayMs = initialRetryDelayMs;
-            return;
-          } catch {
-            // Heartbeat failed — fall through to acquireLease
-          }
-        }
-        try {
-          const result = await client.acquireLease({ requestedPetId });
-          lease.lease = result;
-          lease.staleLeaseId = undefined;
-          lease.staleLease = undefined;
-          lease.degradedReason = undefined;
+      if (lease.closing || lease.lease) return;
+      void recoverLease(client, lease, requestedPetId).then(
+        () => {
+          if (lease.closing) return;
           retryDelayMs = initialRetryDelayMs;
-        } catch (error: unknown) {
+        },
+        (error: unknown) => {
+          if (lease.closing) return;
           lease.degradedReason = sanitizeMcpRuntimeError(error);
           retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
           scheduleRetry();
-        }
-      })().finally(() => {
-        recoveryPromise = null;
-      });
+        },
+      );
     }, retryDelayMs);
     retryTimer.unref?.();
   }
 
   leaseReady.then(() => {
-    if (closing || !lease.lease) return;
+    if (lease.closing || !lease.lease) return;
     heartbeatTimer = setInterval(() => {
-      if (closing || !lease.lease) return;
+      if (lease.closing || !lease.lease) return;
       void client.heartbeatLease(lease.lease.leaseId).catch((error: unknown) => {
         // Save full stale lease for heartbeat-first recovery in scheduleRetry / ensureLease
         lease.staleLease = lease.lease;
@@ -120,14 +97,17 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
 
   const close = (): Promise<void> => {
     if (closePromise) return closePromise;
-    closing = true;
+    // Publish teardown state before any await so tools and timers cannot start recovery afterward.
+    lease.closing = true;
     closePromise = (async () => {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       heartbeatTimer = null;
       if (retryTimer) clearTimeout(retryTimer);
       retryTimer = null;
       try { await leaseReady; } catch { /* startup already records its degraded state */ }
-      if (recoveryPromise) await recoveryPromise;
+      if (lease.recoveryPromise) {
+        try { await lease.recoveryPromise; } catch { /* recovery failure is already reflected in degradedReason */ }
+      }
       const leaseId = lease.lease?.leaseId;
       lease.lease = undefined;
       if (leaseId) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -56,6 +56,20 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
   let retryDelayMs = initialRetryDelayMs;
   const MAX_RETRY_DELAY_MS = 60_000;
   let closePromise: Promise<void> | null = null;
+  const retainedLeaseIds = new Set<string>();
+
+  const retainLeaseId = (leaseId: string | undefined): void => {
+    if (leaseId) retainedLeaseIds.add(leaseId);
+  };
+
+  const releaseRetainedLeases = async (): Promise<void> => {
+    retainLeaseId(lease.lease?.leaseId);
+    retainLeaseId(lease.staleLeaseId);
+    retainLeaseId(lease.staleLease?.leaseId);
+    for (const leaseId of retainedLeaseIds) {
+      try { await client.releaseLease(leaseId); } catch { /* best effort */ }
+    }
+  };
 
   function scheduleRetry(): void {
     if (retryTimer || lease.closing) return;
@@ -83,6 +97,10 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
     heartbeatTimer = setInterval(() => {
       if (lease.closing || !lease.lease) return;
       void client.heartbeatLease(lease.lease.leaseId).catch((error: unknown) => {
+        // A heartbeat may have started before close() published its closing state.
+        // Once closing is set, preserve the lease for teardown instead of letting
+        // this late rejection erase the ID that must be released.
+        if (lease.closing || !lease.lease) return;
         // Save full stale lease for heartbeat-first recovery in scheduleRetry / ensureLease
         lease.staleLease = lease.lease;
         lease.staleLeaseId = lease.lease?.leaseId;
@@ -99,6 +117,9 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
     if (closePromise) return closePromise;
     // Publish teardown state before any await so tools and timers cannot start recovery afterward.
     lease.closing = true;
+    retainLeaseId(lease.lease?.leaseId);
+    retainLeaseId(lease.staleLeaseId);
+    retainLeaseId(lease.staleLease?.leaseId);
     closePromise = (async () => {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       heartbeatTimer = null;
@@ -108,11 +129,12 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
       if (lease.recoveryPromise) {
         try { await lease.recoveryPromise; } catch { /* recovery failure is already reflected in degradedReason */ }
       }
-      const leaseId = lease.lease?.leaseId;
+      await releaseRetainedLeases();
       lease.lease = undefined;
-      if (leaseId) {
-        try { await client.releaseLease(leaseId); } catch { /* best effort */ }
-      }
+      lease.staleLeaseId = undefined;
+      lease.staleLease = undefined;
+      lease.recoveryPromise = undefined;
+      lease.degradedReason = undefined;
       try { await server.close(); } catch { /* ignore shutdown errors */ }
     })();
     return closePromise;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,6 +27,9 @@ export interface TransportLifecycleOptions {
   readonly lease: LeaseContext;
   readonly leaseReady: Promise<void>;
   readonly requestedPetId?: string;
+  /** Test/runtime timing overrides; production defaults remain five seconds. */
+  readonly heartbeatIntervalMs?: number;
+  readonly retryDelayMs?: number;
   /**
    * Called after teardown when the transport closes. Defaults to `() => process.exit(0)`.
    * Override in tests to prevent the process from actually exiting.
@@ -48,10 +51,13 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
 
   let heartbeatTimer: NodeJS.Timeout | null = null;
   let retryTimer: NodeJS.Timeout | null = null;
-  let retryDelayMs = 5_000;
+  const heartbeatIntervalMs = opts.heartbeatIntervalMs ?? 5_000;
+  const initialRetryDelayMs = opts.retryDelayMs ?? 5_000;
+  let retryDelayMs = initialRetryDelayMs;
   const MAX_RETRY_DELAY_MS = 60_000;
   let closing = false;
   let closePromise: Promise<void> | null = null;
+  let recoveryPromise: Promise<void> | null = null;
 
   function scheduleRetry(): void {
     if (retryTimer || closing) return;
@@ -59,7 +65,7 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
       retryTimer = null;
       if (closing || lease.lease) return;
       // Fix 2: attempt heartbeat-first recovery when a stale lease is saved
-      void (async () => {
+      recoveryPromise = (async () => {
         const staleLeaseId = lease.staleLeaseId;
         const staleLease = lease.staleLease;
         if (staleLeaseId && staleLease) {
@@ -70,7 +76,7 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
             lease.staleLeaseId = undefined;
             lease.staleLease = undefined;
             lease.degradedReason = undefined;
-            retryDelayMs = 5_000;
+            retryDelayMs = initialRetryDelayMs;
             return;
           } catch {
             // Heartbeat failed — fall through to acquireLease
@@ -82,13 +88,15 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
           lease.staleLeaseId = undefined;
           lease.staleLease = undefined;
           lease.degradedReason = undefined;
-          retryDelayMs = 5_000;
+          retryDelayMs = initialRetryDelayMs;
         } catch (error: unknown) {
           lease.degradedReason = sanitizeMcpRuntimeError(error);
           retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
           scheduleRetry();
         }
-      })();
+      })().finally(() => {
+        recoveryPromise = null;
+      });
     }, retryDelayMs);
     retryTimer.unref?.();
   }
@@ -103,10 +111,10 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
         lease.staleLeaseId = lease.lease?.leaseId;
         lease.degradedReason = sanitizeMcpRuntimeError(error);
         lease.lease = undefined;
-        retryDelayMs = 5_000;
+        retryDelayMs = initialRetryDelayMs;
         scheduleRetry();
       });
-    }, 5_000);
+    }, heartbeatIntervalMs);
     heartbeatTimer.unref?.();
   }).catch(() => {});
 
@@ -119,6 +127,7 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
       if (retryTimer) clearTimeout(retryTimer);
       retryTimer = null;
       try { await leaseReady; } catch { /* startup already records its degraded state */ }
+      if (recoveryPromise) await recoveryPromise;
       const leaseId = lease.lease?.leaseId;
       lease.lease = undefined;
       if (leaseId) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -51,6 +51,7 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
   let retryDelayMs = 5_000;
   const MAX_RETRY_DELAY_MS = 60_000;
   let closing = false;
+  let closePromise: Promise<void> | null = null;
 
   function scheduleRetry(): void {
     if (retryTimer || closing) return;
@@ -93,7 +94,7 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
   }
 
   leaseReady.then(() => {
-    if (!lease.lease) return;
+    if (closing || !lease.lease) return;
     heartbeatTimer = setInterval(() => {
       if (closing || !lease.lease) return;
       void client.heartbeatLease(lease.lease.leaseId).catch((error: unknown) => {
@@ -109,19 +110,23 @@ export function wireTransportLifecycle(opts: TransportLifecycleOptions): { close
     heartbeatTimer.unref?.();
   }).catch(() => {});
 
-  const close = async (): Promise<void> => {
-    if (closing) return;
+  const close = (): Promise<void> => {
+    if (closePromise) return closePromise;
     closing = true;
-    if (heartbeatTimer) clearInterval(heartbeatTimer);
-    heartbeatTimer = null;
-    if (retryTimer) clearTimeout(retryTimer);
-    retryTimer = null;
-    const leaseId = lease.lease?.leaseId;
-    lease.lease = undefined;
-    if (leaseId) {
-      try { await client.releaseLease(leaseId); } catch { /* best effort */ }
-    }
-    try { await server.close(); } catch { /* ignore shutdown errors */ }
+    closePromise = (async () => {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+      if (retryTimer) clearTimeout(retryTimer);
+      retryTimer = null;
+      try { await leaseReady; } catch { /* startup already records its degraded state */ }
+      const leaseId = lease.lease?.leaseId;
+      lease.lease = undefined;
+      if (leaseId) {
+        try { await client.releaseLease(leaseId); } catch { /* best effort */ }
+      }
+      try { await server.close(); } catch { /* ignore shutdown errors */ }
+    })();
+    return closePromise;
   };
 
   // Fix 3: exit after teardown so the process doesn't linger as an orphan

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -34,6 +34,8 @@ export interface LeaseContext {
   /** Full lease object saved when the lease became stale; used for heartbeat-first recovery. */
   staleLease?: OpenPetsLeaseResult;
   degradedReason?: string;
+  closing?: boolean;
+  recoveryPromise?: Promise<void>;
 }
 
 export interface ToolContext {
@@ -73,39 +75,70 @@ export async function handleStatus(context: ToolContext): Promise<CallToolResult
   };
 }
 
-async function ensureLease(context: ToolContext): Promise<boolean> {
-  if (context.lease?.lease) return true;
-  try {
-    const client = context.client ?? createOpenPetsClient();
-    // Fix 2: attempt heartbeat-first recovery when a stale lease is saved
-    const staleLeaseId = context.lease?.staleLeaseId;
-    const staleLease = context.lease?.staleLease;
+export function recoverLease(client: OpenPetsClient, lease: LeaseContext, requestedPetId?: string): Promise<void> {
+  if (lease.recoveryPromise) return lease.recoveryPromise;
+  if (lease.closing || lease.lease) return Promise.resolve();
+
+  let resolveRecovery!: () => void;
+  let rejectRecovery!: (reason?: unknown) => void;
+  const recoveryPromise = new Promise<void>((resolve, reject) => {
+    resolveRecovery = resolve;
+    rejectRecovery = reject;
+  });
+
+  // Publish the shared promise before starting the async operation so tool and timer recovery cannot race into two acquisitions.
+  lease.recoveryPromise = recoveryPromise;
+  recoveryPromise.then(
+    () => {
+      if (lease.recoveryPromise === recoveryPromise) lease.recoveryPromise = undefined;
+    },
+    () => {
+      if (lease.recoveryPromise === recoveryPromise) lease.recoveryPromise = undefined;
+    },
+  );
+
+  void (async () => {
+    const staleLeaseId = lease.staleLeaseId;
+    const staleLease = lease.staleLease;
     if (staleLeaseId && staleLease) {
       try {
         const hb = await client.heartbeatLease(staleLeaseId);
-        // Heartbeat succeeded — desktop still holds the original lease
-        if (context.lease) {
-          context.lease.lease = { ...staleLease, leaseId: hb.leaseId, expiresAt: hb.expiresAt, leaseActive: true };
-          context.lease.staleLeaseId = undefined;
-          context.lease.staleLease = undefined;
-          context.lease.degradedReason = undefined;
-        }
-        return true;
+        // Heartbeat succeeded — desktop still holds the original lease.
+        lease.lease = { ...staleLease, leaseId: hb.leaseId, expiresAt: hb.expiresAt, leaseActive: true };
+        lease.staleLeaseId = undefined;
+        lease.staleLease = undefined;
+        lease.degradedReason = undefined;
+        return;
       } catch {
-        // Heartbeat failed — fall through to acquireLease
+        // Heartbeat failed — fall through to acquireLease.
       }
     }
-    const newLease = await client.acquireLease({ requestedPetId: context.configuredPetId });
-    if (context.lease) {
-      context.lease.lease = newLease;
-      context.lease.staleLeaseId = undefined;
-      context.lease.staleLease = undefined;
-      context.lease.degradedReason = undefined;
-    }
-    return !!newLease;
+
+    // Closing can begin while heartbeat recovery is in flight. Never start a new acquisition after that point.
+    if (lease.closing) return;
+
+    const newLease = await client.acquireLease({ requestedPetId });
+    // Keep the eventual lease visible to teardown even when closing began while acquireLease was in flight.
+    lease.lease = newLease;
+    lease.staleLeaseId = undefined;
+    lease.staleLease = undefined;
+    lease.degradedReason = undefined;
+  })().then(resolveRecovery, rejectRecovery);
+
+  return recoveryPromise;
+}
+
+async function ensureLease(context: ToolContext): Promise<boolean> {
+  const lease = context.lease;
+  if (!lease || lease.closing) return false;
+  if (lease.lease) return true;
+  try {
+    await recoverLease(context.client ?? createOpenPetsClient(), lease, context.configuredPetId);
   } catch {
     return false;
   }
+  // A tool may have joined recovery just before teardown began; it must not use the lease afterward.
+  return !lease.closing && !!lease.lease;
 }
 
 export async function handleReact(input: unknown, context: ToolContext): Promise<CallToolResult> {


### PR DESCRIPTION
Fixes #101.

## What changed

- make MCP shutdown wait for any in-flight startup lease acquisition
- release the lease produced by that acquisition before process exit
- share one teardown promise across repeated or re-entrant close events
- avoid starting the heartbeat timer after shutdown begins
- add a regression test for close-during-acquire ordering
- document the strengthened MCP shutdown contract

## Root cause

Cursor can replace an MCP process during startup. If transport shutdown happened
while `lease.acquire` was still unresolved, the old teardown path observed no
active lease and exited. The acquisition could then finish after teardown,
leaving an un-heartbeated pool lease and its pet visible until desktop lease
cleanup. The replacement process acquired another pool slot, so two different
pets appeared temporarily.

## Validation

- `pnpm --filter @open-pets/mcp check`
- `pnpm --filter @open-pets/desktop build`
- `pnpm --filter @open-pets/mcp build`

The MCP contract suite includes a deterministic regression that:

1. begins shutdown while startup acquisition is unresolved
2. triggers repeated close events
3. completes acquisition with a lease
4. verifies the lease is released before the single process exit

I also installed Cursor Agent `2026.07.20-8cc9c0b` and tested the local MCP
server against an isolated OpenPets desktop profile. Cursor discovered all
three tools, created exactly one lease during the authenticated agent session,
and sent regular heartbeats. This newer Cursor build did not reproduce the
reporter's original double-launch sequence from `2026.07.16-899851b`, so the
race itself is covered deterministically by the regression test.

After validation, Cursor Agent was logged out, its authentication tokens were
removed, and the CLI plus isolated test artifacts were removed from active use.
