### PR TITLE
Fix Windows OpenCode setup detection

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -22,6 +22,7 @@ const behaviorTests = [
   ".test-dist/tests/lan-persistence.test.js",
   ".test-dist/tests/default-pet-external-show.test.js",
   ".test-dist/tests/onboarding-state.test.js",
+  ".test-dist/tests/opencode-command.test.js",
   ".test-dist/tests/update-version.test.js",
   ".test-dist/tests/reaction-animation-mapping.test.js",
   ".test-dist/tests/zip-safety.test.js",

--- a/apps/desktop/src/agent-setup.ts
+++ b/apps/desktop/src/agent-setup.ts
@@ -11,6 +11,7 @@ import { doctorOpenCodeGlobalSetup, getGlobalOpenCodeConfigDir, parseOpenCodeCon
 
 import { getAppStateSnapshot, updatePreferences, type InstalledPetState, type OpenPetsStateV1 } from "./app-state.js";
 import { doctorClaudeOpenPetsMemory, installClaudeOpenPetsMemory, uninstallClaudeOpenPetsMemory, type ClaudeOpenPetsMemoryStatus } from "./claude-memory.js";
+import { getDefaultOpenCodeCommand, getOpenCodeCommandCandidates } from "./opencode-command.js";
 
 export type AgentSetupAction = "configure" | "replace" | "remove" | "install-memory" | "doctor-hooks" | "install-hooks" | "uninstall-hooks" | "opencode-install" | "opencode-remove" | "cursor-install" | "cursor-replace" | "cursor-remove";
 export type JournalAction = "configure" | "update" | "replace" | "remove";
@@ -342,14 +343,14 @@ async function getOpenCodeSetup(commandMode: OpenPetsCommandMode, selectedPetId:
   const pluginVersion = getOpenCodePackageVersion();
   const cliEntryPath = commandMode === "published" ? undefined : getDesktopCliEntryPath(commandMode);
   const prepared = safePrepareOpenCode(configDir, petId, cliVersion, pluginVersion, commandMode, cliEntryPath);
-  const detected = await runCommand({ command: getPreferredOpenCodeCommand(), args: ["--version"] });
+  const detected = await runOpenCodeCommand(["--version"]);
   const globalState = doctorOpenCodeGlobalSetup(configDir);
   const configured = globalState.status === "installed";
   return {
     status: {
       state: globalState.status === "error" || globalState.status === "custom" || globalState.status === "conflict" ? "error" : configured ? "configured" : detected.ok ? "needs_setup" : "not_detected",
       label: configured ? "Installed" : globalState.status === "custom" || globalState.status === "conflict" ? "Needs attention" : detected.ok ? "Ready" : "Not detected",
-      details: globalState.status === "custom" || globalState.status === "conflict" || globalState.status === "error" ? globalState.message : configured ? globalState.message : detected.ok ? "OpenCode was detected. Desktop setup writes global OpenCode config." : getPreferredOpenCodeCommand() === (process.platform === "win32" ? "opencode.cmd" : "opencode") ? "OpenCode was not found on PATH. You can still preview setup, but OpenCode must be installed to use it." : "OpenCode did not run from the saved command path. You can still preview setup, but OpenCode must be installed to use it.",
+      details: globalState.status === "custom" || globalState.status === "conflict" || globalState.status === "error" ? globalState.message : configured ? globalState.message : detected.ok ? "OpenCode was detected. Desktop setup writes global OpenCode config." : getPreferredOpenCodeCommand() === getDefaultOpenCodeCommand() ? "OpenCode was not found on PATH or in a Scoop shim directory. You can still preview setup, but OpenCode must be installed to use it." : "OpenCode did not run from the saved command path. You can still preview setup, but OpenCode must be installed to use it.",
       configDir: formatUserPath(configDir) ?? configDir,
       canInstall: prepared.ok && !configured,
       canRemove: configured,
@@ -455,7 +456,7 @@ function getPreferredNodeCommand(): string {
 }
 
 function getPreferredOpenCodeCommand(): string {
-  return getAppStateSnapshot().preferences.opencodeCommandPath || (process.platform === "win32" ? "opencode.cmd" : "opencode");
+  return getAppStateSnapshot().preferences.opencodeCommandPath || getDefaultOpenCodeCommand();
 }
 
 function normalizeOptionalCommandPath(value: unknown, label: string): string | undefined {
@@ -735,6 +736,21 @@ async function runClaudeCommand(spec: ClaudeCommandSpec): Promise<CommandResult>
     if (result.ok || !isCommandNotFound(result)) return result;
   }
   return { ok: false, timedOut: false, exitCode: null, stdout: "", stderr: "", error: "Claude command was not found." };
+}
+
+async function runOpenCodeCommand(args: readonly string[]): Promise<CommandResult> {
+  const preferences = getAppStateSnapshot().preferences;
+  const commands = getOpenCodeCommandCandidates({
+    configuredCommand: preferences.opencodeCommandPath,
+    env: process.env,
+    homeDir: app.getPath("home"),
+    platform: process.platform,
+  });
+  for (const command of commands) {
+    const result = await runCommand({ command, args });
+    if (result.ok || !isCommandNotFound(result)) return result;
+  }
+  return { ok: false, timedOut: false, exitCode: null, stdout: "", stderr: "", error: "OpenCode command was not found." };
 }
 
 function runCommand(spec: ClaudeCommandSpec): Promise<CommandResult> {

--- a/apps/desktop/src/opencode-command.ts
+++ b/apps/desktop/src/opencode-command.ts
@@ -1,0 +1,32 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface OpenCodeCommandCandidatesOptions {
+  readonly configuredCommand?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly homeDir: string;
+  readonly platform?: NodeJS.Platform | string;
+}
+
+export function getDefaultOpenCodeCommand(): string {
+  return "opencode";
+}
+
+export function getOpenCodeCommandCandidates(options: OpenCodeCommandCandidatesOptions): readonly string[] {
+  if (options.configuredCommand) return [options.configuredCommand];
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return [getDefaultOpenCodeCommand()];
+
+  const env = options.env ?? process.env;
+  const scoopRoots = [
+    env.SCOOP,
+    join(options.homeDir, "scoop"),
+    env.SCOOP_GLOBAL,
+    env.ProgramData ? join(env.ProgramData, "scoop") : undefined,
+  ].filter((path): path is string => Boolean(path));
+  const scoopCommands = [...new Set(scoopRoots)]
+    .map((root) => join(root, "shims", "opencode.exe"))
+    .filter((command) => existsSync(command));
+
+  return [...scoopCommands, getDefaultOpenCodeCommand(), "opencode.cmd"];
+}

--- a/apps/desktop/tests/opencode-command.test.ts
+++ b/apps/desktop/tests/opencode-command.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { getDefaultOpenCodeCommand, getOpenCodeCommandCandidates } from "../src/opencode-command.js";
+
+const root = mkdtempSync(join(tmpdir(), "openpets-opencode-command-"));
+
+try {
+  const userScoopShim = join(root, "scoop", "shims", "opencode.exe");
+  mkdirSync(join(root, "scoop", "shims"), { recursive: true });
+  writeFileSync(userScoopShim, "");
+
+  assert.equal(getDefaultOpenCodeCommand(), "opencode");
+  assert.deepEqual(
+    getOpenCodeCommandCandidates({ homeDir: root, platform: "win32", env: {} }),
+    [userScoopShim, "opencode", "opencode.cmd"],
+    "Windows detection must find the default Scoop shim even when the desktop PATH is stale.",
+  );
+
+  const customScoop = join(root, "portable-scoop");
+  const customScoopShim = join(customScoop, "shims", "opencode.exe");
+  mkdirSync(join(customScoop, "shims"), { recursive: true });
+  writeFileSync(customScoopShim, "");
+  assert.equal(
+    getOpenCodeCommandCandidates({ homeDir: join(root, "other-home"), platform: "win32", env: { SCOOP: customScoop } })[0],
+    customScoopShim,
+    "Windows detection must respect a custom SCOOP root.",
+  );
+
+  assert.deepEqual(
+    getOpenCodeCommandCandidates({ configuredCommand: "C:\\Tools\\opencode.exe", homeDir: root, platform: "win32" }),
+    ["C:\\Tools\\opencode.exe"],
+    "A user-selected executable must take precedence over automatic detection.",
+  );
+  assert.deepEqual(getOpenCodeCommandCandidates({ homeDir: root, platform: "darwin" }), ["opencode"]);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -123,13 +123,19 @@ Ships both a config manager and a runtime plugin.
   global `~/.config/opencode/`), choosing the right file among `config.json` /
   `opencode.json` / `opencode.jsonc` and preserving user arrays. Managed
   instruction blocks use `<!-- OPENPETS:START/END -->` markers. Full
-  prepare/write/remove/doctor lifecycle.
+  prepare/write/remove/doctor lifecycle. OpenCode uses the XDG-style
+  `~/.config/opencode/` location on Windows as well; it does not use
+  `%APPDATA%\opencode`.
 - **Runtime** (`opencode-plugin-runtime.ts`, plugin id `open-pets-opencode`):
   hooks `event`, `chat.message`, `tool.execute.before/after`, classifies them to
   reactions/speech, manages a lease (renew with a 2s buffer), and applies the
   same throttle windows as Claude. The optional `excludeReactions` plugin option is an
   array of reactions to suppress before IPC or throttling. It can be used without a
   `pet` target: `["@open-pets/opencode", { "excludeReactions": ["success", "thinking"] }]`.
+- **Windows detection**: the desktop app checks user and global Scoop shim
+  directories before falling back to `opencode` / `opencode.cmd` on `PATH`, so
+  a Scoop installation is detectable even when Electron inherited an older
+  environment.
 
 ## Cursor — `@open-pets/cursor`
 

--- a/packages/opencode/src/check-opencode-foundation.ts
+++ b/packages/opencode/src/check-opencode-foundation.ts
@@ -25,9 +25,10 @@ try {
 
   assert.equal(getGlobalOpenCodeConfigDir({ OPENCODE_CONFIG_DIR: join(root, "custom") }, root, "linux"), join(root, "custom"));
   assert.equal(getGlobalOpenCodeConfigDir({ XDG_CONFIG_HOME: join(root, "xdg") }, root, "linux"), join(root, "xdg", "opencode"));
-  assert.equal(getGlobalOpenCodeConfigDir({ APPDATA: join(root, "appdata") }, root, "win32"), join(root, "appdata", "opencode"));
+  assert.equal(getGlobalOpenCodeConfigDir({ APPDATA: join(root, "appdata") }, root, "win32"), join(root, ".config", "opencode"), "Windows OpenCode config is XDG-based, not stored under APPDATA.");
+  assert.equal(getGlobalOpenCodeConfigDir({ XDG_CONFIG_HOME: join(root, "xdg") }, root, "win32"), join(root, "xdg", "opencode"));
   assert.deepEqual(getGlobalOpenCodeConfigPaths({ OPENCODE_CONFIG_DIR: join(root, "global") }, root, "linux").candidates.map((path) => path.slice(join(root, "global").length + 1)), ["config.json", "opencode.json", "opencode.jsonc"]);
-  assert.deepEqual(createOpenCodeExecutableDetection({ platform: "win32" }).command, "opencode.cmd");
+  assert.deepEqual(createOpenCodeExecutableDetection({ platform: "win32" }).command, "opencode");
   assert.deepEqual(createOpenCodeExecutableDetection({ platform: "darwin" }).command, "opencode");
 
   assert.deepEqual(formatOpenCodeMcpConfig({ cliVersion: "0.0.0", petId: "fixer" }), { mcp: { openpets: { type: "local", command: ["npx", "-y", "@open-pets/cli@0.0.0", "mcp", "--pet", "fixer"], enabled: true } } });

--- a/packages/opencode/src/opencode-config.ts
+++ b/packages/opencode/src/opencode-config.ts
@@ -51,9 +51,8 @@ export function selectProjectOpenCodeConfigPath(projectDir: string): string {
   return paths.candidates.find((candidate) => existsSync(candidate)) ?? paths.defaultCreatePath;
 }
 
-export function getGlobalOpenCodeConfigDir(env: NodeJS.ProcessEnv = process.env, homeDir = homedir(), platform = process.platform): string {
+export function getGlobalOpenCodeConfigDir(env: NodeJS.ProcessEnv = process.env, homeDir = homedir(), _platform = process.platform): string {
   if (env.OPENCODE_CONFIG_DIR) return env.OPENCODE_CONFIG_DIR;
-  if (platform === "win32") return join(env.APPDATA || join(homeDir, "AppData", "Roaming"), "opencode");
   return join(env.XDG_CONFIG_HOME || join(homeDir, ".config"), "opencode");
 }
 
@@ -68,7 +67,7 @@ export function getGlobalOpenCodeConfigPaths(env: NodeJS.ProcessEnv = process.en
 export function createOpenCodeExecutableDetection(input: Partial<OpenCodeExecutableDetection> & { readonly platform?: NodeJS.Platform | string } = {}): OpenCodeExecutableDetection {
   const platform = input.platform ?? process.platform;
   return {
-    command: input.command ?? (platform === "win32" ? "opencode.cmd" : "opencode"),
+    command: input.command ?? "opencode",
     platform,
     available: input.available ?? false,
     version: input.version,


### PR DESCRIPTION
## Summary

Fix the OpenCode integration on Windows when OpenCode is installed through Scoop.

OpenPets previously:

- looked for `opencode.cmd`, while Scoop commonly exposes `opencode.exe` through its shim directory;
- wrote the global OpenCode configuration to `%APPDATA%\opencode`;
- failed to detect Scoop installations when the Electron process inherited an outdated `PATH`.

OpenCode actually uses the XDG-style global configuration directory at:

```text
%USERPROFILE%\.config\opencode
```

## Changes

- Use `~/.config/opencode` as the default global OpenCode configuration directory on Windows.
- Continue respecting `OPENCODE_CONFIG_DIR` and `XDG_CONFIG_HOME`.
- Use `opencode` as the default executable name on all platforms.
- Detect `opencode.exe` in:
  - the user Scoop shim directory;
  - a custom `SCOOP` directory;
  - `SCOOP_GLOBAL`;
  - the global Scoop directory under `%ProgramData%`.
- Fall back to `opencode` and `opencode.cmd` from `PATH`.
- Preserve explicitly configured OpenCode executable paths.
- Add regression tests and update the agent integration documentation.

## Reproduction before this change

1. Install OpenCode on Windows using Scoop.
2. Open OpenPets → Integrations → OpenCode.
3. OpenPets reports:

   > Not detected  
   > OpenCode was not found on PATH.

4. Continue with global setup.
5. OpenPets writes the configuration under `%APPDATA%\opencode`, but OpenCode reads `%USERPROFILE%\.config\opencode`.
6. The setup appears successful, but the OpenPets plugin is not loaded.

Manually adding the plugin to `%USERPROFILE%\.config\opencode\opencode.json` makes the integration work.

## Validation

Passed:

- `pnpm --filter @open-pets/opencode check`
- `pnpm --filter @open-pets/desktop test:build`
- OpenCode Scoop command regression test
- `pnpm --filter @open-pets/desktop typecheck`

The full desktop test suite reaches an unrelated existing failure in:

```text
pet-motion-engine-nan-guard.test.js
```

The same test fails when rerun independently because an in-flight `motionMoveTo` promise remains pending. No pet motion files are changed by this PR.