### PR TITLE
Add privacy-safe LAN work returns

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -16,6 +16,7 @@ const behaviorTests = [
   ".test-dist/tests/lease-manager.test.js",
   ".test-dist/tests/lease-manager-fixes.test.js",
   ".test-dist/tests/lan-state.test.js",
+  ".test-dist/tests/lan-pet-presence.test.js",
   ".test-dist/tests/lan-auth.test.js",
   ".test-dist/tests/lan-controller.test.js",
   ".test-dist/tests/lan-client-retry.test.js",

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -17,6 +17,7 @@ const behaviorTests = [
   ".test-dist/tests/lease-manager-fixes.test.js",
   ".test-dist/tests/lan-state.test.js",
   ".test-dist/tests/lan-pet-presence.test.js",
+  ".test-dist/tests/lan-pet-activity.test.js",
   ".test-dist/tests/lan-auth.test.js",
   ".test-dist/tests/lan-controller.test.js",
   ".test-dist/tests/lan-client-retry.test.js",

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -61,6 +61,10 @@ missing or broken catalog assets are skipped without stopping LAN polling.
 single-use visitor departures. `lan-pet-controller.ts` renders the built-in
 return line plus `running` animation before `lan-controller.ts` requests the
 coordinator return the visitor to its owner.
+Registration also issues a random per-host session credential:
+`lan-controller.ts` presents it for later position, claim, activity, and return
+mutations, while `lan-http-controller.ts` rejects shared-token peers that claim
+another active host identity.
 pet-window.ts
 ├── createDefaultPetWindow() / createAgentPetWindow()
 ├── loadDefaultPetContent() / loadExplicitPetContent()

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -48,6 +48,15 @@ local-ipc.ts → parseIpcRequest() → handleRequest()
 
 **Pet Display Flow**:
 ```
+
+**LAN visiting-pet flow**: with `OPENPETS_LAN_PETS=multi`, each client
+registers its selected default pet through `lan-http-controller.ts`.
+`lan-controller.ts` reports positions for every pet currently hosted locally
+and reconciles coordinator snapshots through `lan-pet-controller.ts`.
+Visiting windows are keyed by owner host, use `lan-pet-presence.ts` for pure
+show/close and asset-availability decisions, and stay isolated from agent
+leases. The bundled pet can render explicitly for fresh-profile LAN testing;
+missing or broken catalog assets are skipped without stopping LAN polling.
 pet-window.ts
 ├── createDefaultPetWindow() / createAgentPetWindow()
 ├── loadDefaultPetContent() / loadExplicitPetContent()

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -57,6 +57,10 @@ Visiting windows are keyed by owner host, use `lan-pet-presence.ts` for pure
 show/close and asset-availability decisions, and stay isolated from agent
 leases. The bundled pet can render explicitly for fresh-profile LAN testing;
 missing or broken catalog assets are skipped without stopping LAN polling.
+`lan-pet-activity.ts` gates coarse work signals to active meetings and plans
+single-use visitor departures. `lan-pet-controller.ts` renders the built-in
+return line plus `running` animation before `lan-controller.ts` requests the
+coordinator return the visitor to its owner.
 pet-window.ts
 ├── createDefaultPetWindow() / createAgentPetWindow()
 ├── loadDefaultPetContent() / loadExplicitPetContent()

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -12,6 +12,7 @@ import { PetBubbleArbiter, type ActiveBubble, type PetBubbleSink } from "./plugi
 import { publishPluginPetEvent } from "./plugin-events-source.js";
 import { reclampAgentPetWindows } from "./agent-pet-controller.js";
 import { reclampPluginPetWindows } from "./plugin-pet-registry.js";
+import { reclampLanVisitingPetWindows } from "./lan-pet-controller.js";
 
 let defaultPetWindow: BrowserWindow | null = null;
 let paused = false;
@@ -497,6 +498,7 @@ function reclampDefaultPetWindow(reason: DisplayChangeReason, changedDisplay?: D
 function reclampAllLivePetWindows(reason: DisplayChangeReason, changedDisplay?: Display): void {
   reclampDefaultPetWindow(reason, changedDisplay);
   reclampAgentPetWindows();
+  reclampLanVisitingPetWindows();
   reclampPluginPetWindows();
 }
 

--- a/apps/desktop/src/lan-controller.ts
+++ b/apps/desktop/src/lan-controller.ts
@@ -59,6 +59,7 @@ let activeMode: LanMode = "off";
 let activeServerUrl = "";
 let activeLocalHost = "";
 let activeToken: string | null = null;
+let activeSessionToken: string | null = null;
 const seenActivitySequences = new Map<string, number>();
 const pendingWorkReturns = new Map<string, NodeJS.Timeout>();
 
@@ -150,7 +151,10 @@ async function registerLanClient(serverUrl: string, localHost: string, token: st
       host: localHost,
       position,
       ...(multiPetEnabled ? { petId: getAppStateSnapshot().preferences.defaultPetId } : {}),
-    }, token);
+    }, token, activeSessionToken, (headers) => {
+      const session = headers["x-openpets-lan-session"];
+      activeSessionToken = typeof session === "string" ? session : activeSessionToken;
+    });
     missedPolls = 0;
     applyLanState(state, localHost);
   } catch (registerError) {
@@ -174,13 +178,17 @@ function scheduleLanPoll(serverUrl: string, localHost: string, token: string | n
 }
 async function pollLanServer(serverUrl: string, localHost: string, token: string | null): Promise<void> {
   try {
+    if (!activeSessionToken) {
+      await registerLanClient(serverUrl, localHost, token);
+      return;
+    }
     let state: LanState;
     if (multiPetEnabled && lastLanState?.pets) {
       state = await postJson<LanState>(`${serverUrl}/position`, {
         host: localHost,
         position: getDefaultPetLanPosition(),
         edge: null,
-      }, token);
+      }, token, activeSessionToken);
       for (const pet of lastLanState.pets) {
         if (pet.currentHost !== localHost) continue;
         const position = pet.ownerHost === localHost ? getDefaultPetLanPosition() : getLanVisitingPetPosition(pet.ownerHost);
@@ -190,12 +198,12 @@ async function pollLanServer(serverUrl: string, localHost: string, token: string
           ownerHost: pet.ownerHost,
           position,
           edge: detectEdge(position),
-        }, token);
+        }, token, activeSessionToken);
       }
     } else {
       const position = getDefaultPetLanPosition();
       const edge = position ? detectEdge(position) : null;
-      state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token);
+      state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token, activeSessionToken);
     }
     missedPolls = 0;
     applyLanState(state, localHost);
@@ -238,7 +246,7 @@ export function broadcastLanPetActivity(reaction: OpenPetsReaction): void {
   void postJson<LanState>(`${activeServerUrl}/activity`, {
     ownerHost: activeLocalHost,
     kind: "work",
-  }, activeToken)
+  }, activeToken, activeSessionToken)
     .then((state) => applyLanState(state, activeLocalHost))
     .catch((activityError) => warn("app", "lan work activity publish failed", {
       error: activityError instanceof Error ? activityError.message : String(activityError),
@@ -269,7 +277,7 @@ function scheduleLanWorkReturn(localHost: string, ownerHost: string, sequence: n
     void postJson<LanState>(`${activeServerUrl}/return`, {
       host: localHost,
       ownerHost,
-    }, activeToken)
+    }, activeToken, activeSessionToken)
       .then((nextState) => {
         pendingWorkReturns.delete(ownerHost);
         applyLanState(nextState, localHost);
@@ -300,7 +308,13 @@ function detectEdge(position: LanPoint): LanEdge | null {
   return null;
 }
 
-function postJson<T>(target: string, body: Record<string, unknown>, token: string | null): Promise<T> {
+function postJson<T>(
+  target: string,
+  body: Record<string, unknown>,
+  token: string | null,
+  sessionToken: string | null = null,
+  onResponse?: (headers: Record<string, string | string[] | undefined>) => void,
+): Promise<T> {
   const url = new URL(target);
   const payload = Buffer.from(JSON.stringify(body));
   return new Promise((resolve, reject) => {
@@ -309,6 +323,7 @@ function postJson<T>(target: string, body: Record<string, unknown>, token: strin
       "content-length": payload.length,
     };
     if (token) headers["x-openpets-lan-token"] = token;
+    if (sessionToken) headers["x-openpets-lan-session"] = sessionToken;
 
     const req = request({
       method: "POST",
@@ -318,6 +333,7 @@ function postJson<T>(target: string, body: Record<string, unknown>, token: strin
       headers,
       timeout: requestTimeoutMs,
     }, (res) => {
+      onResponse?.(res.headers);
       const chunks: Buffer[] = [];
       let size = 0;
       res.on("data", (chunk) => {
@@ -331,6 +347,7 @@ function postJson<T>(target: string, body: Record<string, unknown>, token: strin
       });
       res.on("end", () => {
         if ((res.statusCode ?? 500) >= 400) {
+          if (res.statusCode === 403 && sessionToken) activeSessionToken = null;
           reject(new Error(`HTTP ${res.statusCode}`));
           return;
         }

--- a/apps/desktop/src/lan-controller.ts
+++ b/apps/desktop/src/lan-controller.ts
@@ -10,9 +10,11 @@ import { resolveLanAuthConfig, type LanAuthSource } from "./lan-auth.js";
 import { defaultLanRetryOptions, getLanRetryDelayMs, shouldHideLanPetAfterMisses, shouldLogLanPollFailure } from "./lan-client-retry.js";
 import { createLanRequestHandler } from "./lan-http-controller.js";
 import { readPersistedLanState, writePersistedLanState } from "./lan-persistence.js";
-import { getLanVisitingPetPosition, syncLanVisitingPets } from "./lan-pet-controller.js";
+import { planLanWorkActivities, shouldPublishLanWorkSignal, shouldRetryLanWorkReturn } from "./lan-pet-activity.js";
+import { applyLanVisitingPetSay, getLanVisitingPetPosition, syncLanVisitingPets } from "./lan-pet-controller.js";
 import { LanCoordinator, countLanTopologyLinks, normalizeLanHost, normalizeLanTopology, validateLanTopology, type LanEdge, type LanPoint, type LanState, type LanTopology, type LanTopologyIssue } from "./lan-state.js";
 import { info, warn, error as logError } from "./logger.js";
+import type { OpenPetsReaction } from "./local-ipc-protocol.js";
 
 type LanMode = "off" | "server" | "client";
 
@@ -41,6 +43,9 @@ const pollMs = defaultLanRetryOptions.baseDelayMs;
 const requestTimeoutMs = 8_000;
 const maxLanResponseBodyBytes = 16 * 1024;
 const edgeThresholdPx = 18;
+const maxLanActivityAgeMs = 15_000;
+const lanWorkReturnDelayMs = 1_500;
+const lanWorkDepartureMessage = "Oh, I've got to get back to work!";
 
 let coordinator = new LanCoordinator({ staleClientMs });
 let pollTimer: NodeJS.Timeout | null = null;
@@ -50,6 +55,12 @@ let missedPolls = 0;
 let lastPollWarningAt = 0;
 let multiPetEnabled = false;
 let lastLanState: LanState | null = null;
+let activeMode: LanMode = "off";
+let activeServerUrl = "";
+let activeLocalHost = "";
+let activeToken: string | null = null;
+const seenActivitySequences = new Map<string, number>();
+const pendingWorkReturns = new Map<string, NodeJS.Timeout>();
 
 export function startLanController(): void {
   const mode = normalizeMode(process.env.OPENPETS_LAN_MODE);
@@ -62,6 +73,10 @@ export function startLanController(): void {
   const token = auth.token;
   const topology = parseLanTopology(process.env.OPENPETS_LAN_TOPOLOGY);
   multiPetEnabled = process.env.OPENPETS_LAN_PETS === "multi";
+  activeMode = mode;
+  activeServerUrl = serverUrl;
+  activeLocalHost = localHost;
+  activeToken = token;
   const topologyIssues = validateLanTopology(topology);
   coordinator = new LanCoordinator({ staleClientMs, topology });
   for (const issue of topologyIssues) warn("app", "lan topology issue", issue);
@@ -205,10 +220,74 @@ function applyLanState(state: LanState, localHost: string): void {
     if (localPet?.currentHost === localHost) showDefaultPetForLan();
     else hideDefaultPetForLan();
     syncLanVisitingPets(localHost, state.pets);
+    applyLanWorkActivities(state, localHost);
     return;
   }
   if (state.currentHost === localHost) showDefaultPetForLan();
   else hideDefaultPetForLan();
+}
+
+export function broadcastLanPetActivity(reaction: OpenPetsReaction): void {
+  if (
+    activeMode === "off"
+    || !multiPetEnabled
+    || !activeServerUrl
+    || !activeLocalHost
+    || !shouldPublishLanWorkSignal(activeLocalHost, lastLanState, reaction)
+  ) return;
+  void postJson<LanState>(`${activeServerUrl}/activity`, {
+    ownerHost: activeLocalHost,
+    kind: "work",
+  }, activeToken)
+    .then((state) => applyLanState(state, activeLocalHost))
+    .catch((activityError) => warn("app", "lan work activity publish failed", {
+      error: activityError instanceof Error ? activityError.message : String(activityError),
+    }));
+}
+
+function applyLanWorkActivities(state: LanState, localHost: string): void {
+  const hostedOwners = new Set((state.pets ?? []).filter((pet) => pet.currentHost === localHost).map((pet) => pet.ownerHost));
+  for (const [ownerHost, timer] of pendingWorkReturns) {
+    if (hostedOwners.has(ownerHost)) continue;
+    clearTimeout(timer);
+    pendingWorkReturns.delete(ownerHost);
+  }
+
+  const plan = planLanWorkActivities(localHost, state.pets ?? [], seenActivitySequences, state.updatedAt, maxLanActivityAgeMs);
+  for (const observed of plan.observed) seenActivitySequences.set(observed.ownerHost, observed.sequence);
+  for (const departure of plan.departures) {
+    if (pendingWorkReturns.has(departure.ownerHost)) continue;
+    const shown = applyLanVisitingPetSay(departure.ownerHost, lanWorkDepartureMessage, "running", departure.sequence);
+    if (!shown) continue;
+    info("app", "lan visiting pet preparing work return", { ownerHost: departure.ownerHost, host: localHost, sequence: departure.sequence });
+    scheduleLanWorkReturn(localHost, departure.ownerHost, departure.sequence, lanWorkReturnDelayMs);
+  }
+}
+
+function scheduleLanWorkReturn(localHost: string, ownerHost: string, sequence: number, delayMs: number): void {
+  const timer = setTimeout(() => {
+    void postJson<LanState>(`${activeServerUrl}/return`, {
+      host: localHost,
+      ownerHost,
+    }, activeToken)
+      .then((nextState) => {
+        pendingWorkReturns.delete(ownerHost);
+        applyLanState(nextState, localHost);
+      })
+      .catch((returnError) => {
+        warn("app", "lan work return failed", {
+          ownerHost,
+          error: returnError instanceof Error ? returnError.message : String(returnError),
+        });
+        if (shouldRetryLanWorkReturn(localHost, ownerHost, sequence, lastLanState)) {
+          scheduleLanWorkReturn(localHost, ownerHost, sequence, pollMs);
+        } else {
+          pendingWorkReturns.delete(ownerHost);
+        }
+      });
+  }, delayMs);
+  timer.unref?.();
+  pendingWorkReturns.set(ownerHost, timer);
 }
 
 function detectEdge(position: LanPoint): LanEdge | null {

--- a/apps/desktop/src/lan-controller.ts
+++ b/apps/desktop/src/lan-controller.ts
@@ -4,11 +4,13 @@ import { hostname } from "node:os";
 import { URL } from "node:url";
 
 import { defaultPetWindowSize } from "./display.js";
+import { getAppStateSnapshot } from "./app-state.js";
 import { getDefaultPetLanPosition, hideDefaultPetForLan, showDefaultPetForLan } from "./default-pet-controller.js";
 import { resolveLanAuthConfig, type LanAuthSource } from "./lan-auth.js";
 import { defaultLanRetryOptions, getLanRetryDelayMs, shouldHideLanPetAfterMisses, shouldLogLanPollFailure } from "./lan-client-retry.js";
 import { createLanRequestHandler } from "./lan-http-controller.js";
 import { readPersistedLanState, writePersistedLanState } from "./lan-persistence.js";
+import { getLanVisitingPetPosition, syncLanVisitingPets } from "./lan-pet-controller.js";
 import { LanCoordinator, countLanTopologyLinks, normalizeLanHost, normalizeLanTopology, validateLanTopology, type LanEdge, type LanPoint, type LanState, type LanTopology, type LanTopologyIssue } from "./lan-state.js";
 import { info, warn, error as logError } from "./logger.js";
 
@@ -46,6 +48,8 @@ let serverStarted = false;
 let serverStarting = false;
 let missedPolls = 0;
 let lastPollWarningAt = 0;
+let multiPetEnabled = false;
+let lastLanState: LanState | null = null;
 
 export function startLanController(): void {
   const mode = normalizeMode(process.env.OPENPETS_LAN_MODE);
@@ -57,6 +61,7 @@ export function startLanController(): void {
   const auth = resolveLanAuthConfig(app.getPath("userData"), process.env, { serverMode: mode === "server" });
   const token = auth.token;
   const topology = parseLanTopology(process.env.OPENPETS_LAN_TOPOLOGY);
+  multiPetEnabled = process.env.OPENPETS_LAN_PETS === "multi";
   const topologyIssues = validateLanTopology(topology);
   coordinator = new LanCoordinator({ staleClientMs, topology });
   for (const issue of topologyIssues) warn("app", "lan topology issue", issue);
@@ -126,13 +131,20 @@ function startLanClient(serverUrl: string, localHost: string, token: string | nu
 async function registerLanClient(serverUrl: string, localHost: string, token: string | null): Promise<void> {
   try {
     const position = getDefaultPetLanPosition();
-    const state = await postJson<LanState>(`${serverUrl}/register`, { host: localHost, position }, token);
+    const state = await postJson<LanState>(`${serverUrl}/register`, {
+      host: localHost,
+      position,
+      ...(multiPetEnabled ? { petId: getAppStateSnapshot().preferences.defaultPetId } : {}),
+    }, token);
     missedPolls = 0;
     applyLanState(state, localHost);
   } catch (registerError) {
     missedPolls += 1;
     warn("app", "lan register failed", { error: registerError instanceof Error ? registerError.message : String(registerError), missedPolls });
-    if (shouldHideLanPetAfterMisses(missedPolls)) hideDefaultPetForLan();
+    if (shouldHideLanPetAfterMisses(missedPolls)) {
+      hideDefaultPetForLan();
+      if (multiPetEnabled) syncLanVisitingPets(localHost, []);
+    }
   }
 }
 
@@ -146,10 +158,30 @@ function scheduleLanPoll(serverUrl: string, localHost: string, token: string | n
   pollTimer.unref?.();
 }
 async function pollLanServer(serverUrl: string, localHost: string, token: string | null): Promise<void> {
-  const position = getDefaultPetLanPosition();
-  const edge = position ? detectEdge(position) : null;
   try {
-    const state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token);
+    let state: LanState;
+    if (multiPetEnabled && lastLanState?.pets) {
+      state = await postJson<LanState>(`${serverUrl}/position`, {
+        host: localHost,
+        position: getDefaultPetLanPosition(),
+        edge: null,
+      }, token);
+      for (const pet of lastLanState.pets) {
+        if (pet.currentHost !== localHost) continue;
+        const position = pet.ownerHost === localHost ? getDefaultPetLanPosition() : getLanVisitingPetPosition(pet.ownerHost);
+        if (!position) continue;
+        state = await postJson<LanState>(`${serverUrl}/position`, {
+          host: localHost,
+          ownerHost: pet.ownerHost,
+          position,
+          edge: detectEdge(position),
+        }, token);
+      }
+    } else {
+      const position = getDefaultPetLanPosition();
+      const edge = position ? detectEdge(position) : null;
+      state = await postJson<LanState>(`${serverUrl}/position`, { host: localHost, position, edge }, token);
+    }
     missedPolls = 0;
     applyLanState(state, localHost);
   } catch (pollError) {
@@ -159,11 +191,22 @@ async function pollLanServer(serverUrl: string, localHost: string, token: string
       lastPollWarningAt = now;
       warn("app", "lan poll failed", { error: pollError instanceof Error ? pollError.message : String(pollError), missedPolls, nextPollMs: getLanRetryDelayMs(missedPolls) });
     }
-    if (shouldHideLanPetAfterMisses(missedPolls)) hideDefaultPetForLan();
+    if (shouldHideLanPetAfterMisses(missedPolls)) {
+      hideDefaultPetForLan();
+      if (multiPetEnabled) syncLanVisitingPets(localHost, []);
+    }
   }
 }
 
 function applyLanState(state: LanState, localHost: string): void {
+  lastLanState = state;
+  if (multiPetEnabled && state.pets) {
+    const localPet = state.pets.find((pet) => pet.ownerHost === localHost);
+    if (localPet?.currentHost === localHost) showDefaultPetForLan();
+    else hideDefaultPetForLan();
+    syncLanVisitingPets(localHost, state.pets);
+    return;
+  }
   if (state.currentHost === localHost) showDefaultPetForLan();
   else hideDefaultPetForLan();
 }

--- a/apps/desktop/src/lan-http-controller.ts
+++ b/apps/desktop/src/lan-http-controller.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { URL } from "node:url";
 
-import { LanCoordinator, normalizeLanEdge, normalizeLanHost, normalizeLanPoint, type LanState } from "./lan-state.js";
+import { LanCoordinator, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, type LanState } from "./lan-state.js";
 
 const maxLanRequestBodyBytes = 16 * 1024;
 
@@ -50,8 +50,13 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       writeJson(res, 400, { error: "missing_host" });
       return;
     }
+    const petId = normalizeLanPetId(body.petId);
+    if (body.petId !== undefined && !petId) {
+      writeJson(res, 400, { error: "invalid_pet_id" });
+      return;
+    }
     const previousHost = lanCoordinator.currentHost();
-    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), now());
+    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), now(), petId ?? undefined);
     writeJson(res, 200, state);
     notifyStateChangeIfOwnerChanged(previousHost, state, options);
     return;
@@ -79,7 +84,8 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       return;
     }
     const previousHost = lanCoordinator.currentHost();
-    const state = lanCoordinator.updatePosition(host, normalizeLanPoint(body.position), normalizeLanEdge(body.edge), now());
+    const ownerHost = normalizeLanHost(body.ownerHost) ?? undefined;
+    const state = lanCoordinator.updatePosition(host, normalizeLanPoint(body.position), normalizeLanEdge(body.edge), now(), ownerHost);
     writeJson(res, 200, state);
     notifyStateChangeIfOwnerChanged(previousHost, state, options);
     return;

--- a/apps/desktop/src/lan-http-controller.ts
+++ b/apps/desktop/src/lan-http-controller.ts
@@ -1,9 +1,11 @@
+import { randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { URL } from "node:url";
 
 import { LanCoordinator, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, type LanState } from "./lan-state.js";
 
 const maxLanRequestBodyBytes = 16 * 1024;
+const lanSessionHeader = "x-openpets-lan-session";
 
 class LanRequestBodyTooLargeError extends Error {
   constructor() {
@@ -19,8 +21,9 @@ export type LanRequestHandlerOptions = {
 
 export function createLanRequestHandler(lanCoordinator: LanCoordinator, token: string | null, options: LanRequestHandlerOptions = {}): (req: IncomingMessage, res: ServerResponse) => void {
   const now = options.now ?? Date.now;
+  const hostSessions = new Map<string, string>();
   return (req, res) => {
-    void routeLanRequest(req, res, lanCoordinator, token, now, options).catch((requestError) => {
+    void routeLanRequest(req, res, lanCoordinator, token, now, options, hostSessions).catch((requestError) => {
       if (requestError instanceof LanRequestBodyTooLargeError) {
         writeJson(res, 413, { error: "body_too_large" });
         return;
@@ -31,7 +34,15 @@ export function createLanRequestHandler(lanCoordinator: LanCoordinator, token: s
   };
 }
 
-async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoordinator: LanCoordinator, token: string | null, now: () => number, options: LanRequestHandlerOptions): Promise<void> {
+async function routeLanRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  lanCoordinator: LanCoordinator,
+  token: string | null,
+  now: () => number,
+  options: LanRequestHandlerOptions,
+  hostSessions: Map<string, string>,
+): Promise<void> {
   const url = new URL(req.url || "/", "http://127.0.0.1");
   if (!isAuthorized(req, token)) {
     writeJson(res, 401, { error: "unauthorized" });
@@ -55,9 +66,19 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       writeJson(res, 400, { error: "invalid_pet_id" });
       return;
     }
+    const requestNow = now();
+    const existingSession = hostSessions.get(host);
+    if (existingSession && lanCoordinator.hasClient(host, requestNow) && req.headers[lanSessionHeader] !== existingSession) {
+      writeJson(res, 403, { error: "host_identity_conflict" });
+      return;
+    }
+    const session = existingSession && req.headers[lanSessionHeader] === existingSession
+      ? existingSession
+      : randomBytes(32).toString("base64url");
+    hostSessions.set(host, session);
     const previousHost = lanCoordinator.currentHost();
-    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), now(), petId ?? undefined);
-    writeJson(res, 200, state);
+    const state = lanCoordinator.register(host, normalizeLanPoint(body.position), requestNow, petId ?? undefined);
+    writeJson(res, 200, state, { [lanSessionHeader]: session });
     notifyStateChangeIfOwnerChanged(previousHost, state, options);
     return;
   }
@@ -65,8 +86,16 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
   if (req.method === "POST" && url.pathname === "/claim") {
     const body = await readBody(req);
     const host = normalizeLanHost(body.host);
+    if (!host) {
+      writeJson(res, 400, { error: "unknown_host" });
+      return;
+    }
+    if (!isHostAuthorized(req, host, hostSessions)) {
+      writeJson(res, 403, { error: "host_identity_mismatch" });
+      return;
+    }
     const previousHost = lanCoordinator.currentHost();
-    const state = host ? lanCoordinator.claim(host, now()) : null;
+    const state = lanCoordinator.claim(host, now());
     if (!state) {
       writeJson(res, 400, { error: "unknown_host" });
       return;
@@ -81,6 +110,10 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
     const host = normalizeLanHost(body.host);
     if (!host) {
       writeJson(res, 400, { error: "missing_host" });
+      return;
+    }
+    if (!isHostAuthorized(req, host, hostSessions)) {
+      writeJson(res, 403, { error: "host_identity_mismatch" });
       return;
     }
     const previousHost = lanCoordinator.currentHost();
@@ -98,6 +131,10 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
       writeJson(res, 400, { error: "invalid_activity" });
       return;
     }
+    if (!isHostAuthorized(req, ownerHost, hostSessions)) {
+      writeJson(res, 403, { error: "host_identity_mismatch" });
+      return;
+    }
     const state = lanCoordinator.publishActivity(ownerHost, now());
     if (!state) {
       writeJson(res, 400, { error: "unknown_pet" });
@@ -111,7 +148,15 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
     const body = await readBody(req);
     const host = normalizeLanHost(body.host);
     const ownerHost = normalizeLanHost(body.ownerHost);
-    const state = host && ownerHost ? lanCoordinator.returnPet(host, ownerHost, now()) : null;
+    if (!host || !ownerHost) {
+      writeJson(res, 400, { error: "invalid_return" });
+      return;
+    }
+    if (!isHostAuthorized(req, host, hostSessions)) {
+      writeJson(res, 403, { error: "host_identity_mismatch" });
+      return;
+    }
+    const state = lanCoordinator.returnPet(host, ownerHost, now());
     if (!state) {
       writeJson(res, 400, { error: "invalid_return" });
       return;
@@ -145,11 +190,12 @@ function notifyStateChangeIfOwnerChanged(previousHost: string | null, state: Lan
   if (previousHost !== state.currentHost) options.onStateChange?.(state);
 }
 
-function writeJson(res: ServerResponse, status: number, body: unknown): void {
+function writeJson(res: ServerResponse, status: number, body: unknown, extraHeaders: Readonly<Record<string, string>> = {}): void {
   const payload = Buffer.from(JSON.stringify(body));
   res.writeHead(status, {
     "content-type": "application/json; charset=utf-8",
     "content-length": payload.length,
+    ...extraHeaders,
   });
   res.end(payload);
 }
@@ -157,4 +203,9 @@ function writeJson(res: ServerResponse, status: number, body: unknown): void {
 function isAuthorized(req: IncomingMessage, token: string | null): boolean {
   if (!token) return true;
   return req.headers["x-openpets-lan-token"] === token;
+}
+
+function isHostAuthorized(req: IncomingMessage, host: string, hostSessions: ReadonlyMap<string, string>): boolean {
+  const session = hostSessions.get(host);
+  return Boolean(session) && req.headers[lanSessionHeader] === session;
 }

--- a/apps/desktop/src/lan-http-controller.ts
+++ b/apps/desktop/src/lan-http-controller.ts
@@ -91,6 +91,35 @@ async function routeLanRequest(req: IncomingMessage, res: ServerResponse, lanCoo
     return;
   }
 
+  if (req.method === "POST" && url.pathname === "/activity") {
+    const body = await readBody(req);
+    const ownerHost = normalizeLanHost(body.ownerHost);
+    if (!ownerHost || body.kind !== "work" || Object.keys(body).some((key) => key !== "ownerHost" && key !== "kind")) {
+      writeJson(res, 400, { error: "invalid_activity" });
+      return;
+    }
+    const state = lanCoordinator.publishActivity(ownerHost, now());
+    if (!state) {
+      writeJson(res, 400, { error: "unknown_pet" });
+      return;
+    }
+    writeJson(res, 200, state);
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/return") {
+    const body = await readBody(req);
+    const host = normalizeLanHost(body.host);
+    const ownerHost = normalizeLanHost(body.ownerHost);
+    const state = host && ownerHost ? lanCoordinator.returnPet(host, ownerHost, now()) : null;
+    if (!state) {
+      writeJson(res, 400, { error: "invalid_return" });
+      return;
+    }
+    writeJson(res, 200, state);
+    return;
+  }
+
   writeJson(res, 404, { error: "not_found" });
 }
 

--- a/apps/desktop/src/lan-pet-activity.ts
+++ b/apps/desktop/src/lan-pet-activity.ts
@@ -1,0 +1,64 @@
+import type { LanPetRecord, LanState } from "./lan-state.js";
+
+export type LanWorkDeparture = {
+  readonly ownerHost: string;
+  readonly sequence: number;
+};
+
+export type LanWorkActivityPlan = {
+  readonly observed: readonly LanWorkDeparture[];
+  readonly departures: readonly LanWorkDeparture[];
+};
+
+const workReactions = new Set(["working", "editing", "running", "testing"]);
+
+export function shouldPublishLanWorkSignal(localHost: string, state: LanState | null, reaction: string): boolean {
+  if (!workReactions.has(reaction)) return false;
+  const localPet = state?.pets?.find((pet) => pet.ownerHost === localHost);
+  if (!localPet || localPet.currentHost === localHost) return false;
+  return (state?.pets?.filter((pet) => pet.currentHost === localPet.currentHost).length ?? 0) >= 2;
+}
+
+export function planLanWorkActivities(
+  localHost: string,
+  pets: readonly LanPetRecord[],
+  seenSequences: ReadonlyMap<string, number>,
+  coordinatorNow: number,
+  maxAgeMs: number,
+): LanWorkActivityPlan {
+  const meetingOwners = new Set(
+    pets.filter((pet) => pet.currentHost === localHost).map((pet) => pet.ownerHost),
+  );
+  const isMeeting = meetingOwners.size >= 2;
+  const observed: LanWorkDeparture[] = [];
+  const departures: LanWorkDeparture[] = [];
+
+  for (const pet of pets) {
+    const activity = pet.activity;
+    if (!activity || activity.kind !== "work" || activity.sequence <= (seenSequences.get(pet.ownerHost) ?? 0)) continue;
+    const item = { ownerHost: pet.ownerHost, sequence: activity.sequence };
+    observed.push(item);
+    const ageMs = coordinatorNow - activity.createdAt;
+    if (
+      isMeeting
+      && pet.ownerHost !== localHost
+      && pet.currentHost === localHost
+      && ageMs >= 0
+      && ageMs <= maxAgeMs
+    ) {
+      departures.push(item);
+    }
+  }
+
+  return { observed, departures };
+}
+
+export function shouldRetryLanWorkReturn(
+  localHost: string,
+  ownerHost: string,
+  sequence: number,
+  state: LanState | null,
+): boolean {
+  const pet = state?.pets?.find((candidate) => candidate.ownerHost === ownerHost);
+  return pet?.currentHost === localHost && pet.activity?.kind === "work" && pet.activity.sequence === sequence;
+}

--- a/apps/desktop/src/lan-pet-controller.ts
+++ b/apps/desktop/src/lan-pet-controller.ts
@@ -1,0 +1,130 @@
+import { BrowserWindow } from "electron";
+
+import { getAppStateSnapshot, type PetScaleValue } from "./app-state.js";
+import { clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosition } from "./display.js";
+import { debug, info, warn } from "./logger.js";
+import { planLanPetPresence, resolveRenderableLanPetId } from "./lan-pet-presence.js";
+import type { LanPetRecord, LanPoint } from "./lan-state.js";
+import { createAgentPetWindow, readWindowPosition } from "./pet-window.js";
+import { registerRoamingPet, unregisterRoamingPet } from "./pet-roaming-controller.js";
+
+type VisitingPetWindow = {
+  readonly ownerHost: string;
+  readonly requestedPetId: string;
+  readonly renderedPetId: string;
+  readonly motionHandleId: string;
+  readonly window: BrowserWindow;
+};
+
+const visitingPetWindows = new Map<string, VisitingPetWindow>();
+const dismissedOwnerHosts = new Set<string>();
+const unavailablePetWarnings = new Set<string>();
+
+export function syncLanVisitingPets(localHost: string, pets: readonly LanPetRecord[]): void {
+  const plan = planLanPetPresence(localHost, pets, [...visitingPetWindows.keys()]);
+  const desiredOwners = new Set(plan.show.map((pet) => pet.ownerHost));
+  for (const ownerHost of [...dismissedOwnerHosts]) {
+    if (!desiredOwners.has(ownerHost)) dismissedOwnerHosts.delete(ownerHost);
+  }
+  for (const ownerHost of [...unavailablePetWarnings]) {
+    if (!desiredOwners.has(ownerHost)) unavailablePetWarnings.delete(ownerHost);
+  }
+  for (const ownerHost of plan.closeOwnerHosts) {
+    closeLanVisitingPet(ownerHost);
+  }
+  for (const pet of plan.show) showLanVisitingPet(pet);
+}
+
+export function getLanVisitingPetPosition(ownerHost: string): LanPoint | null {
+  const entry = visitingPetWindows.get(ownerHost);
+  if (!entry || entry.window.isDestroyed() || !entry.window.isVisible()) return null;
+  return readWindowPosition(entry.window);
+}
+
+export function closeAllLanVisitingPets(): void {
+  for (const ownerHost of [...visitingPetWindows.keys()]) closeLanVisitingPet(ownerHost);
+  dismissedOwnerHosts.clear();
+  unavailablePetWarnings.clear();
+}
+
+export function reclampLanVisitingPetWindows(): void {
+  for (const entry of visitingPetWindows.values()) {
+    if (entry.window.isDestroyed()) continue;
+    const safe = readWindowPosition(entry.window);
+    const [x, y] = entry.window.getPosition();
+    if (safe.x !== x || safe.y !== y) entry.window.setPosition(safe.x, safe.y, false);
+  }
+}
+
+function showLanVisitingPet(pet: LanPetRecord): void {
+  if (dismissedOwnerHosts.has(pet.ownerHost)) return;
+  const state = getAppStateSnapshot();
+  const renderedPetId = resolveRenderableLanPetId(pet.petId, state.pets.installed);
+  if (!renderedPetId) {
+    if (!unavailablePetWarnings.has(pet.ownerHost)) {
+      unavailablePetWarnings.add(pet.ownerHost);
+      warn("pet.agent", "lan visiting pet unavailable", { ownerHost: pet.ownerHost, petId: pet.petId });
+    }
+    closeLanVisitingPet(pet.ownerHost);
+    return;
+  }
+  unavailablePetWarnings.delete(pet.ownerHost);
+
+  const existing = visitingPetWindows.get(pet.ownerHost);
+  if (existing && !existing.window.isDestroyed() && existing.renderedPetId === renderedPetId) {
+    existing.window.showInactive();
+    return;
+  }
+  if (existing) closeLanVisitingPet(pet.ownerHost);
+
+  const installed = state.pets.installed.find((candidate) => candidate.id === renderedPetId);
+  if (!installed) return;
+  const offset = visitingPetWindows.size + 1;
+  const base = getDefaultPetInitialPosition(defaultPetWindowSize);
+  const position = clampToVisibleWorkArea({ x: base.x - offset * 48, y: base.y - offset * 28 }, defaultPetWindowSize);
+  const motionHandleId = `lan:${pet.ownerHost}`;
+  const window = createAgentPetWindow({
+    petId: renderedPetId,
+    displayName: `${installed.displayName} — ${pet.ownerHost}`,
+    scale: state.preferences.petScale as PetScaleValue,
+    position,
+    display: null,
+    badge: null,
+    plainContextMenu: true,
+    onCloseRequested: () => {
+      dismissedOwnerHosts.add(pet.ownerHost);
+      closeLanVisitingPet(pet.ownerHost);
+    },
+  });
+  const entry: VisitingPetWindow = {
+    ownerHost: pet.ownerHost,
+    requestedPetId: pet.petId,
+    renderedPetId,
+    motionHandleId,
+    window,
+  };
+  visitingPetWindows.set(pet.ownerHost, entry);
+  window.once("closed", () => {
+    const current = visitingPetWindows.get(pet.ownerHost);
+    if (current?.window !== window) return;
+    unregisterRoamingPet(motionHandleId);
+    visitingPetWindows.delete(pet.ownerHost);
+  });
+  window.showInactive();
+  registerRoamingPet(motionHandleId, () => {
+    const current = visitingPetWindows.get(pet.ownerHost);
+    return current?.window && !current.window.isDestroyed() ? current.window : null;
+  });
+  info("pet.agent", "lan visiting pet shown", { ownerHost: pet.ownerHost, requestedPetId: pet.petId, renderedPetId, windowId: window.id });
+}
+
+function closeLanVisitingPet(ownerHost: string): void {
+  const entry = visitingPetWindows.get(ownerHost);
+  if (!entry) return;
+  visitingPetWindows.delete(ownerHost);
+  unregisterRoamingPet(entry.motionHandleId);
+  if (!entry.window.isDestroyed()) {
+    debug("pet.agent", "lan visiting pet close", { ownerHost, petId: entry.renderedPetId, windowId: entry.window.id });
+    entry.window.destroy();
+  }
+}

--- a/apps/desktop/src/lan-pet-controller.ts
+++ b/apps/desktop/src/lan-pet-controller.ts
@@ -5,7 +5,8 @@ import { clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosit
 import { debug, info, warn } from "./logger.js";
 import { planLanPetPresence, resolveRenderableLanPetId } from "./lan-pet-presence.js";
 import type { LanPetRecord, LanPoint } from "./lan-state.js";
-import { createAgentPetWindow, readWindowPosition } from "./pet-window.js";
+import { createAgentPetWindow, getTransientDisplayDurationMs, loadExplicitPetContent, readWindowPosition } from "./pet-window.js";
+import type { OpenPetsReaction } from "./local-ipc-protocol.js";
 import { registerRoamingPet, unregisterRoamingPet } from "./pet-roaming-controller.js";
 
 type VisitingPetWindow = {
@@ -19,6 +20,7 @@ type VisitingPetWindow = {
 const visitingPetWindows = new Map<string, VisitingPetWindow>();
 const dismissedOwnerHosts = new Set<string>();
 const unavailablePetWarnings = new Set<string>();
+const displayClearTimers = new Map<string, NodeJS.Timeout>();
 
 export function syncLanVisitingPets(localHost: string, pets: readonly LanPetRecord[]): void {
   const plan = planLanPetPresence(localHost, pets, [...visitingPetWindows.keys()]);
@@ -45,6 +47,23 @@ export function closeAllLanVisitingPets(): void {
   for (const ownerHost of [...visitingPetWindows.keys()]) closeLanVisitingPet(ownerHost);
   dismissedOwnerHosts.clear();
   unavailablePetWarnings.clear();
+}
+
+export function applyLanVisitingPetSay(ownerHost: string, message: string, reaction: OpenPetsReaction, sequence: number): boolean {
+  const entry = visitingPetWindows.get(ownerHost);
+  if (!entry || entry.window.isDestroyed()) return false;
+  const existingTimer = displayClearTimers.get(ownerHost);
+  if (existingTimer) clearTimeout(existingTimer);
+  const display = { message, reaction, suppressReactionMessage: true, dismissToken: `lan-work:${ownerHost}:${sequence}` };
+  void loadExplicitPetContent(entry.window, entry.renderedPetId, display, null, display.dismissToken, getAppStateSnapshot().preferences.petScale as PetScaleValue);
+  const timer = setTimeout(() => {
+    displayClearTimers.delete(ownerHost);
+    const current = visitingPetWindows.get(ownerHost);
+    if (current && !current.window.isDestroyed()) void loadExplicitPetContent(current.window, current.renderedPetId);
+  }, getTransientDisplayDurationMs(display));
+  timer.unref?.();
+  displayClearTimers.set(ownerHost, timer);
+  return true;
 }
 
 export function reclampLanVisitingPetWindows(): void {
@@ -119,6 +138,9 @@ function showLanVisitingPet(pet: LanPetRecord): void {
 }
 
 function closeLanVisitingPet(ownerHost: string): void {
+  const displayTimer = displayClearTimers.get(ownerHost);
+  if (displayTimer) clearTimeout(displayTimer);
+  displayClearTimers.delete(ownerHost);
   const entry = visitingPetWindows.get(ownerHost);
   if (!entry) return;
   visitingPetWindows.delete(ownerHost);

--- a/apps/desktop/src/lan-pet-presence.ts
+++ b/apps/desktop/src/lan-pet-presence.ts
@@ -1,0 +1,25 @@
+import type { LanPetRecord } from "./lan-state.js";
+
+export type LanPetPresencePlan = {
+  readonly show: readonly LanPetRecord[];
+  readonly closeOwnerHosts: readonly string[];
+};
+
+export function planLanPetPresence(localHost: string, pets: readonly LanPetRecord[], activeOwnerHosts: readonly string[]): LanPetPresencePlan {
+  const show = pets
+    .filter((pet) => pet.ownerHost !== localHost && pet.currentHost === localHost)
+    .sort((a, b) => a.ownerHost.localeCompare(b.ownerHost));
+  const desiredOwners = new Set(show.map((pet) => pet.ownerHost));
+  return {
+    show,
+    closeOwnerHosts: activeOwnerHosts.filter((ownerHost) => !desiredOwners.has(ownerHost)).sort(),
+  };
+}
+
+export function resolveRenderableLanPetId(
+  requestedPetId: string,
+  installedPets: readonly { readonly id: string; readonly broken?: boolean; readonly builtIn?: boolean }[],
+): string | null {
+  const pet = installedPets.find((candidate) => candidate.id === requestedPetId);
+  return pet && !pet.broken ? pet.id : null;
+}

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -18,12 +18,21 @@ export type LanClientRecord = {
   readonly host: string;
   readonly lastSeen: number;
   readonly position?: LanPoint;
+  readonly petId?: string;
+};
+
+export type LanPetRecord = {
+  readonly ownerHost: string;
+  readonly petId: string;
+  readonly currentHost: string;
+  readonly position?: LanPoint;
 };
 
 export type LanState = {
   readonly enabled: true;
   readonly currentHost: string | null;
   readonly clients: readonly LanClientRecord[];
+  readonly pets?: readonly LanPetRecord[];
   readonly updatedAt: number;
 };
 
@@ -36,6 +45,8 @@ export interface LanCoordinatorOptions {
 export class LanCoordinator {
   readonly #staleClientMs: number;
   readonly #clients = new Map<string, LanClientRecord>();
+  readonly #pets = new Map<string, LanPetRecord>();
+  readonly #petEdgeArmed = new Set<string>();
   readonly #topology: LanTopology;
   #currentHost: string | null = null;
   #preferredHost: string | null = null;
@@ -55,8 +66,17 @@ export class LanCoordinator {
     }
   }
 
-  register(host: string, position: LanPoint | undefined, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  register(host: string, position: LanPoint | undefined, now: number, petId?: string): LanState {
+    this.#clients.set(host, { host, lastSeen: now, position, petId });
+    if (petId) {
+      const existingPet = this.#pets.get(host);
+      this.#pets.set(host, {
+        ownerHost: host,
+        petId,
+        currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
+        position: existingPet?.position ?? position,
+      });
+    }
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -76,8 +96,10 @@ export class LanCoordinator {
     return this.snapshot(now);
   }
 
-  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position });
+  updatePosition(host: string, position: LanPoint | undefined, edge: LanEdge | null, now: number, ownerHost?: string): LanState {
+    const existingClient = this.#clients.get(host);
+    this.#clients.set(host, { host, lastSeen: now, position, petId: existingClient?.petId });
+    if (ownerHost) this.#updatePetPosition(host, ownerHost, position, edge);
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
       this.#edgeArmed = false;
@@ -104,6 +126,7 @@ export class LanCoordinator {
       enabled: true,
       currentHost: this.#currentHost,
       clients: [...this.#clients.values()].sort((a, b) => a.host.localeCompare(b.host)),
+      pets: [...this.#pets.values()].filter((pet) => this.#clients.has(pet.ownerHost) && this.#clients.has(pet.currentHost)).sort((a, b) => a.ownerHost.localeCompare(b.ownerHost)),
       updatedAt: now,
     };
   }
@@ -112,10 +135,40 @@ export class LanCoordinator {
     for (const [host, record] of this.#clients) {
       if (now - record.lastSeen > this.#staleClientMs) this.#clients.delete(host);
     }
+    for (const [ownerHost, pet] of this.#pets) {
+      if (!this.#clients.has(ownerHost)) {
+        this.#pets.delete(ownerHost);
+        this.#petEdgeArmed.delete(ownerHost);
+      } else if (!this.#clients.has(pet.currentHost)) {
+        this.#pets.set(ownerHost, { ...pet, currentHost: ownerHost });
+      }
+    }
     if (this.#currentHost && !this.#clients.has(this.#currentHost)) {
       this.#currentHost = this.#clients.keys().next().value ?? null;
       this.#edgeArmed = false;
     }
+  }
+
+  #updatePetPosition(host: string, ownerHost: string, position: LanPoint | undefined, edge: LanEdge | null): void {
+    const pet = this.#pets.get(ownerHost);
+    if (!pet || pet.currentHost !== host) return;
+    let currentHost = pet.currentHost;
+    if (!edge) this.#petEdgeArmed.add(ownerHost);
+    else if (position && this.#petEdgeArmed.has(ownerHost)) {
+      currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
+      this.#petEdgeArmed.delete(ownerHost);
+    }
+    this.#pets.set(ownerHost, { ...pet, currentHost, position });
+  }
+
+  #getPetNeighbor(currentHost: string, edge: LanEdge): string | null {
+    const configured = this.#topology[currentHost]?.[edge];
+    if (configured && this.#clients.has(configured)) return configured;
+    const hosts = [...this.#clients.keys()].sort();
+    if (hosts.length < 2) return null;
+    const index = hosts.indexOf(currentHost);
+    if (index < 0) return null;
+    return edge === "right" || edge === "down" ? hosts[(index + 1) % hosts.length] : hosts[(index - 1 + hosts.length) % hosts.length];
   }
 
   #migrate(edge: LanEdge): void {
@@ -157,6 +210,10 @@ export function normalizeLanPoint(value: unknown): LanPoint | undefined {
 
 export function normalizeLanEdge(value: unknown): LanEdge | null {
   return value === "left" || value === "right" || value === "up" || value === "down" ? value : null;
+}
+
+export function normalizeLanPetId(value: unknown): string | null {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value) ? value : null;
 }
 
 export function normalizeLanTopology(value: unknown): LanTopology {

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -26,6 +26,13 @@ export type LanPetRecord = {
   readonly petId: string;
   readonly currentHost: string;
   readonly position?: LanPoint;
+  readonly activity?: LanPetActivity;
+};
+
+export type LanPetActivity = {
+  readonly kind: "work";
+  readonly sequence: number;
+  readonly createdAt: number;
 };
 
 export type LanState = {
@@ -46,6 +53,7 @@ export class LanCoordinator {
   readonly #staleClientMs: number;
   readonly #clients = new Map<string, LanClientRecord>();
   readonly #pets = new Map<string, LanPetRecord>();
+  readonly #activitySequences = new Map<string, number>();
   readonly #petEdgeArmed = new Set<string>();
   readonly #topology: LanTopology;
   #currentHost: string | null = null;
@@ -76,6 +84,7 @@ export class LanCoordinator {
         petId: normalizedPetId,
         currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
         position: existingPet?.position ?? position,
+        activity: existingPet?.activity,
       });
     } else {
       this.#pets.delete(host);
@@ -122,6 +131,38 @@ export class LanCoordinator {
 
   currentHost(): string | null {
     return this.#currentHost;
+  }
+
+  publishActivity(ownerHost: string, now: number): LanState | null {
+    const pet = this.#pets.get(ownerHost);
+    const meetingSize = pet
+      ? [...this.#pets.values()].filter((candidate) => candidate.currentHost === pet.currentHost).length
+      : 0;
+    if (!pet || pet.currentHost === ownerHost || meetingSize < 2) return null;
+    const sequence = Math.max((this.#activitySequences.get(ownerHost) ?? 0) + 1, now);
+    this.#activitySequences.set(ownerHost, sequence);
+    this.#pets.set(ownerHost, {
+      ...pet,
+      activity: {
+        kind: "work",
+        sequence,
+        createdAt: now,
+      },
+    });
+    return this.snapshot(now);
+  }
+
+  returnPet(host: string, ownerHost: string, now: number): LanState | null {
+    const pet = this.#pets.get(ownerHost);
+    if (!pet || pet.currentHost !== host || pet.ownerHost === host || !this.#clients.has(pet.ownerHost)) return null;
+    const { activity: _activity, ...rest } = pet;
+    this.#pets.set(ownerHost, {
+      ...rest,
+      currentHost: pet.ownerHost,
+      position: this.#clients.get(pet.ownerHost)?.position,
+    });
+    this.#petEdgeArmed.delete(ownerHost);
+    return this.snapshot(now);
   }
 
   snapshot(now: number): LanState {

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -133,6 +133,11 @@ export class LanCoordinator {
     return this.#currentHost;
   }
 
+  hasClient(host: string, now: number): boolean {
+    this.prune(now);
+    return this.#clients.has(host);
+  }
+
   publishActivity(ownerHost: string, now: number): LanState | null {
     const pet = this.#pets.get(ownerHost);
     const meetingSize = pet

--- a/apps/desktop/src/lan-state.ts
+++ b/apps/desktop/src/lan-state.ts
@@ -67,15 +67,19 @@ export class LanCoordinator {
   }
 
   register(host: string, position: LanPoint | undefined, now: number, petId?: string): LanState {
-    this.#clients.set(host, { host, lastSeen: now, position, petId });
-    if (petId) {
+    const normalizedPetId = normalizeLanPetId(petId) ?? undefined;
+    this.#clients.set(host, { host, lastSeen: now, position, petId: normalizedPetId });
+    if (normalizedPetId) {
       const existingPet = this.#pets.get(host);
       this.#pets.set(host, {
         ownerHost: host,
-        petId,
+        petId: normalizedPetId,
         currentHost: existingPet?.currentHost && this.#clients.has(existingPet.currentHost) ? existingPet.currentHost : host,
         position: existingPet?.position ?? position,
       });
+    } else {
+      this.#pets.delete(host);
+      this.#petEdgeArmed.delete(host);
     }
     if (host === this.#preferredHost && this.#currentHost !== host) {
       this.#currentHost = host;
@@ -141,6 +145,7 @@ export class LanCoordinator {
         this.#petEdgeArmed.delete(ownerHost);
       } else if (!this.#clients.has(pet.currentHost)) {
         this.#pets.set(ownerHost, { ...pet, currentHost: ownerHost });
+        this.#petEdgeArmed.delete(ownerHost);
       }
     }
     if (this.#currentHost && !this.#clients.has(this.#currentHost)) {
@@ -154,9 +159,9 @@ export class LanCoordinator {
     if (!pet || pet.currentHost !== host) return;
     let currentHost = pet.currentHost;
     if (!edge) this.#petEdgeArmed.add(ownerHost);
-    else if (position && this.#petEdgeArmed.has(ownerHost)) {
-      currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
+    else if (this.#petEdgeArmed.has(ownerHost)) {
       this.#petEdgeArmed.delete(ownerHost);
+      if (position) currentHost = this.#getPetNeighbor(currentHost, edge) ?? currentHost;
     }
     this.#pets.set(ownerHost, { ...pet, currentHost, position });
   }

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -5,6 +5,7 @@ import { shutdownDesktopAnalytics } from "./analytics.js";
 import { destroyDefaultPet } from "./default-pet-controller.js";
 import { info } from "./logger.js";
 import { stopLocalIpcServer } from "./local-ipc.js";
+import { closeAllLanVisitingPets } from "./lan-pet-controller.js";
 import { stopPluginService } from "./plugin-service.js";
 import { focusOpenTaskWindows } from "./windows.js";
 
@@ -36,6 +37,7 @@ export function installAppLifecycle(): void {
     scheduleHardExitFallback("before-quit");
     stopPluginService();
     stopLocalIpcServer();
+    closeAllLanVisitingPets();
     closeAllAgentPets();
     destroyDefaultPet();
     shutdownDesktopAnalytics();

--- a/apps/desktop/src/local-ipc.ts
+++ b/apps/desktop/src/local-ipc.ts
@@ -21,6 +21,7 @@ import { findTerminalWindowForPid, subscribeWindowTracking, type TerminalWindowI
 import { warnPetFallback } from "./pet-fallback-notify.js";
 import { getEligiblePoolPetIds, resolvePoolAssignment } from "./pet-pool.js";
 import { t } from "./i18n/index.js";
+import { broadcastLanPetActivity } from "./lan-controller.js";
 
 let ipcServer: net.Server | null = null;
 let ipcDiscovery: OpenPetsDiscoveryFile | null = null;
@@ -431,6 +432,7 @@ async function handleRequest(request: OpenPetsIpcRequest): Promise<unknown> {
       return { ok: true, reaction, shown: applied.shown, reason: applied.reason, leaseId: lease.leaseId };
     }
     const applied = applyExternalPetReaction(reaction);
+    broadcastLanPetActivity(reaction);
     safeRecordOpenPetsActivity({ kind: "react", reaction, petId, surface: "default" });
     trackDesktopIntegrationActivity("react", { integration_type: "ipc", target_kind: lease?.targetKind ?? "default", shown: applied.shown, reason: applied.reason });
     return { ok: true, reaction, shown: applied.shown, reason: applied.reason };

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -761,12 +761,14 @@ export async function loadExplicitPetContent(window: BrowserWindow, petId: strin
     applyPetWindowFocusPolicy(window, petPluginBubblesHaveInteractiveInput(pluginBubbles));
     const state = getAppStateSnapshot();
     const pet = state.pets.installed.find((candidate) => candidate.id === petId);
-    if (!pet || pet.broken || pet.id === builtInPet.id) {
+    if (!pet || pet.broken) {
       throw new Error(`Cannot render explicit pet: ${petId}`);
     }
     debug("pet.window", "explicit content render begin", { windowId: window.id, sequence, petId, displayName: pet.displayName, hasDisplay: Boolean(display), reaction: display?.reaction, hasMessage: Boolean(display?.message), badge });
     const scale = scaleOverride ?? state.preferences.petScale as PetScaleValue;
-    const render = await createInstalledPetRender(pet.id, pet.displayName, false, display, scale, badge, `explicit:${pet.id}`, dismissToken, pluginBubbles);
+    const render = pet.id === builtInPet.id
+      ? createBuiltInPetRender(false, display, badge, scale, `explicit:${pet.id}`, dismissToken, pluginBubbles)
+      : await createInstalledPetRender(pet.id, pet.displayName, false, display, scale, badge, `explicit:${pet.id}`, dismissToken, pluginBubbles);
     applyLinuxPetWindowShape(window, scale, Boolean(display?.message || display?.reactionMessage || display?.reaction || display?.mediaPath || badge || pluginBubbles?.transient || pluginBubbles?.pinned));
     if (tryUpdateLoadedPetContent(window, render, `explicit-${pet.id}`, sequence)) return;
     await loadPetHtmlFile(window, render.html, `explicit-${pet.id}`, sequence);
@@ -933,15 +935,19 @@ async function createDefaultPetRender(paused: boolean, display: PetTransientDisp
     return installedPetRender;
   }
 
+  const scale = getAppStateSnapshot().preferences.petScale as PetScaleValue;
+  return createBuiltInPetRender(paused, display, badge, scale, "default:builtin", dismissToken, pluginBubbles);
+}
+
+function createBuiltInPetRender(paused: boolean, display: PetTransientDisplay | null, badge: PetStatusBadgeReaction | null, scale: PetScaleValue, cachePrefix: string, dismissToken?: string, pluginBubbles: PetPluginBubbles | null = null): PetContentRender {
   const spriteUrl = pathToFileURL(join(app.getAppPath(), "assets", defaultPetSprite.fileName)).toString();
   const hasPinned = Boolean(pluginBubbles?.pinned);
   const bodyHtml = createPetBodyMarkup("OpenPets default pet", createBubbleMarkup(display, paused, badge, dismissToken, pluginBubbles), `<div class="sprite" role="img" aria-label="Claude animated default pet"></div>`, createPinnedBubbleMarkup(pluginBubbles), hasPinned);
   const reactionState = getReactionSpriteState(display?.reaction);
   const stateRows = defaultPetSprite.states;
-  const scale = getAppStateSnapshot().preferences.petScale as PetScaleValue;
 
   return {
-    cacheKey: `default:builtin:${paused}:${scale}:${getActiveLocale()}`,
+    cacheKey: `${cachePrefix}:${paused}:${scale}:${getActiveLocale()}`,
     bodyHtml,
     reactionState,
     html: `<!doctype html>

--- a/apps/desktop/tests/lan-controller.test.ts
+++ b/apps/desktop/tests/lan-controller.test.ts
@@ -32,67 +32,80 @@ try {
   const alphaRegister = await requestJson<LanState>("POST", "/register", { host: "alpha", position: { x: 10, y: 20 } }, token);
   assert.equal(alphaRegister.status, 200);
   assert.equal(alphaRegister.body.currentHost, "alpha", "first registered client should own the pet");
+  const alphaSession = String(alphaRegister.headers["x-openpets-lan-session"]);
+  assert.ok(alphaSession, "registration should issue a host-bound session credential");
 
   now += 100;
   const betaRegister = await requestJson<LanState>("POST", "/register", { host: "beta", position: { x: 400, y: 20 } }, token);
   assert.equal(betaRegister.status, 200);
+  const betaSession = String(betaRegister.headers["x-openpets-lan-session"]);
+  assert.ok(betaSession && betaSession !== alphaSession, "each host should receive a distinct session credential");
   assert.equal(betaRegister.body.currentHost, "alpha", "second register should not steal current ownership");
   assert.deepEqual(betaRegister.body.clients.map((client) => client.host), ["alpha", "beta"]);
+  const spoofedActiveRegistration = await requestJson("POST", "/register", { host: "alpha", position: { x: 20, y: 20 } }, token, betaSession);
+  assert.equal(spoofedActiveRegistration.status, 403, "another authenticated peer must not replace an active host identity");
 
-  const alphaPetRegister = await requestJson<LanState>("POST", "/register", { host: "alpha", petId: "cat", position: { x: 10, y: 20 } }, token);
-  const betaPetRegister = await requestJson<LanState>("POST", "/register", { host: "beta", petId: "cat", position: { x: 400, y: 20 } }, token);
+  const alphaPetRegister = await requestJson<LanState>("POST", "/register", { host: "alpha", petId: "cat", position: { x: 10, y: 20 } }, token, alphaSession);
+  const betaPetRegister = await requestJson<LanState>("POST", "/register", { host: "beta", petId: "cat", position: { x: 400, y: 20 } }, token, betaSession);
   assert.deepEqual(betaPetRegister.body.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
     ["alpha", "cat", "alpha"],
     ["beta", "cat", "beta"],
   ], "HTTP registration should preserve separate owners even when both choose the same pet ID");
-  const armBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 200, y: 20 }, edge: null }, token);
+  const armBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 200, y: 20 }, edge: null }, token, betaSession);
   assert.equal(armBetaPet.status, 200);
-  const moveBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 5, y: 20 }, edge: "left" }, token);
+  const moveBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 5, y: 20 }, edge: "left" }, token, betaSession);
   assert.deepEqual(moveBetaPet.body.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
     ["alpha", "alpha"],
     ["beta", "alpha"],
   ], "HTTP position updates should allow two pets to meet on one host");
-  const workActivity = await requestJson<LanState>("POST", "/activity", { ownerHost: "beta", kind: "work" }, token);
+  const spoofedActivity = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work" }, token, alphaSession);
+  assert.equal(spoofedActivity.status, 403, "an authenticated peer must not publish activity for another owner");
+  const workActivity = await requestJson<LanState>("POST", "/activity", { ownerHost: "beta", kind: "work" }, token, betaSession);
   assert.equal(workActivity.status, 200);
   assert.deepEqual(workActivity.body.pets?.find((pet) => pet.ownerHost === "beta")?.activity, { kind: "work", sequence: now, createdAt: now }, "HTTP activity should expose only the coarse authenticated work signal");
-  const messageBearingActivity = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work", message: "private MCP text" }, token);
+  const messageBearingActivity = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work", message: "private MCP text" }, token, betaSession);
   assert.equal(messageBearingActivity.status, 400, "LAN activity must reject message-bearing payloads");
-  const returnBetaPet = await requestJson<LanState>("POST", "/return", { host: "alpha", ownerHost: "beta" }, token);
+  const spoofedReturn = await requestJson("POST", "/return", { host: "alpha", ownerHost: "beta" }, token, betaSession);
+  assert.equal(spoofedReturn.status, 403, "an authenticated peer must not return a visitor on behalf of its meeting host");
+  const returnBetaPet = await requestJson<LanState>("POST", "/return", { host: "alpha", ownerHost: "beta" }, token, alphaSession);
   assert.equal(returnBetaPet.status, 200);
   assert.equal(returnBetaPet.body.pets?.find((pet) => pet.ownerHost === "beta")?.currentHost, "beta", "the meeting host should be able to return a visitor after its dash animation");
-  const repeatedReturn = await requestJson("POST", "/return", { host: "alpha", ownerHost: "beta" }, token);
+  const repeatedReturn = await requestJson("POST", "/return", { host: "alpha", ownerHost: "beta" }, token, alphaSession);
   assert.equal(repeatedReturn.status, 400, "a host must not return a pet it no longer holds");
-  const activityAtHome = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work" }, token);
+  const activityAtHome = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work" }, token, betaSession);
   assert.equal(activityAtHome.status, 400, "the coordinator must reject activity when the pet is not visiting a meeting");
 
   now += 100;
-  const moveAway = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 200, y: 20 }, edge: null }, token);
+  const moveAway = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 200, y: 20 }, edge: null }, token, alphaSession);
   assert.equal(moveAway.body.currentHost, "alpha", "moving away from the edge arms handoff without migrating");
 
   now += 100;
-  const edgeHandoff = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 999, y: 20 }, edge: "right" }, token);
+  const edgeHandoff = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 999, y: 20 }, edge: "right" }, token, alphaSession);
   assert.equal(edgeHandoff.body.currentHost, "beta", "right edge should migrate ownership through the HTTP controller");
 
-  const claimAlpha = await requestJson<LanState>("POST", "/claim", { host: "alpha" }, token);
+  const claimAlpha = await requestJson<LanState>("POST", "/claim", { host: "alpha" }, token, alphaSession);
   assert.equal(claimAlpha.status, 200);
   assert.equal(claimAlpha.body.currentHost, "alpha", "claim should move ownership to a connected client");
 
-  const missingClaim = await requestJson("POST", "/claim", { host: "missing" }, token);
-  assert.equal(missingClaim.status, 400, "claim should reject unknown clients");
+  const missingClaim = await requestJson("POST", "/claim", { host: "missing" }, token, alphaSession);
+  assert.equal(missingClaim.status, 403, "claim should reject identities without a matching host session");
 
   const missingHostRegister = await requestJson("POST", "/register", {}, token);
   assert.equal(missingHostRegister.status, 400, "register should reject requests without a host");
-  const invalidPetRegister = await requestJson("POST", "/register", { host: "alpha", petId: "../cat" }, token);
+  const invalidPetRegister = await requestJson("POST", "/register", { host: "alpha", petId: "../cat" }, token, alphaSession);
   assert.equal(invalidPetRegister.status, 400, "register should reject unsafe pet IDs instead of silently downgrading to legacy state");
 
   now += 11_000;
-  const staleOwnerPrune = await requestJson<LanState>("POST", "/position", { host: "beta", position: { x: 420, y: 20 }, edge: null }, token);
+  const staleOwnerPrune = await requestJson<LanState>("POST", "/position", { host: "beta", position: { x: 420, y: 20 }, edge: null }, token, betaSession);
   assert.equal(staleOwnerPrune.body.currentHost, "beta", "a live client should become owner when the previous owner is pruned as stale");
+  const reclaimedAlpha = await requestJson<LanState>("POST", "/register", { host: "alpha", position: { x: 20, y: 20 } }, token);
+  assert.equal(reclaimedAlpha.status, 200, "a restarted client should reclaim its identity after the previous session becomes stale");
+  assert.notEqual(reclaimedAlpha.headers["x-openpets-lan-session"], alphaSession, "stale identity reclamation should rotate the host session");
 
   const largeBody = await requestRaw("POST", "/register", "{" + `"padding":"${"x".repeat(17 * 1024)}"` + "}", token);
   assert.equal(largeBody.status, 413, "oversized LAN request bodies should be rejected");
 
-  assert.deepEqual(changedHosts, ["alpha", "beta", "alpha", "beta"], "successful mutating requests should emit persisted owner snapshots when ownership changes, including stale-owner pruning");
+  assert.deepEqual(changedHosts, ["alpha", "beta", "alpha", "beta", "alpha"], "successful mutating requests should emit persisted owner snapshots when ownership changes, including stale-owner pruning and identity reclamation");
 } finally {
   server.close();
   await once(server, "close");
@@ -127,7 +140,7 @@ type JsonResponse<T = unknown> = {
   readonly headers: Record<string, string | string[] | undefined>;
 };
 
-function requestJson<T = unknown>(method: string, path: string, body?: unknown, requestToken?: string): Promise<JsonResponse<T>> {
+function requestJson<T = unknown>(method: string, path: string, body?: unknown, requestToken?: string, sessionToken?: string): Promise<JsonResponse<T>> {
   const payload = body === undefined ? undefined : Buffer.from(JSON.stringify(body));
   return new Promise((resolve, reject) => {
     const headers: Record<string, string | number> = {};
@@ -136,6 +149,7 @@ function requestJson<T = unknown>(method: string, path: string, body?: unknown, 
       headers["content-length"] = payload.length;
     }
     if (requestToken) headers["x-openpets-lan-token"] = requestToken;
+    if (sessionToken) headers["x-openpets-lan-session"] = sessionToken;
 
     const req = request({ method, hostname: "127.0.0.1", port, path, headers }, (res) => {
       const chunks: Buffer[] = [];

--- a/apps/desktop/tests/lan-controller.test.ts
+++ b/apps/desktop/tests/lan-controller.test.ts
@@ -39,6 +39,20 @@ try {
   assert.equal(betaRegister.body.currentHost, "alpha", "second register should not steal current ownership");
   assert.deepEqual(betaRegister.body.clients.map((client) => client.host), ["alpha", "beta"]);
 
+  const alphaPetRegister = await requestJson<LanState>("POST", "/register", { host: "alpha", petId: "cat", position: { x: 10, y: 20 } }, token);
+  const betaPetRegister = await requestJson<LanState>("POST", "/register", { host: "beta", petId: "cat", position: { x: 400, y: 20 } }, token);
+  assert.deepEqual(betaPetRegister.body.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
+    ["alpha", "cat", "alpha"],
+    ["beta", "cat", "beta"],
+  ], "HTTP registration should preserve separate owners even when both choose the same pet ID");
+  const armBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 200, y: 20 }, edge: null }, token);
+  assert.equal(armBetaPet.status, 200);
+  const moveBetaPet = await requestJson<LanState>("POST", "/position", { host: "beta", ownerHost: "beta", position: { x: 5, y: 20 }, edge: "left" }, token);
+  assert.deepEqual(moveBetaPet.body.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
+    ["alpha", "alpha"],
+    ["beta", "alpha"],
+  ], "HTTP position updates should allow two pets to meet on one host");
+
   now += 100;
   const moveAway = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 200, y: 20 }, edge: null }, token);
   assert.equal(moveAway.body.currentHost, "alpha", "moving away from the edge arms handoff without migrating");
@@ -56,6 +70,8 @@ try {
 
   const missingHostRegister = await requestJson("POST", "/register", {}, token);
   assert.equal(missingHostRegister.status, 400, "register should reject requests without a host");
+  const invalidPetRegister = await requestJson("POST", "/register", { host: "alpha", petId: "../cat" }, token);
+  assert.equal(invalidPetRegister.status, 400, "register should reject unsafe pet IDs instead of silently downgrading to legacy state");
 
   now += 11_000;
   const staleOwnerPrune = await requestJson<LanState>("POST", "/position", { host: "beta", position: { x: 420, y: 20 }, edge: null }, token);

--- a/apps/desktop/tests/lan-controller.test.ts
+++ b/apps/desktop/tests/lan-controller.test.ts
@@ -52,6 +52,18 @@ try {
     ["alpha", "alpha"],
     ["beta", "alpha"],
   ], "HTTP position updates should allow two pets to meet on one host");
+  const workActivity = await requestJson<LanState>("POST", "/activity", { ownerHost: "beta", kind: "work" }, token);
+  assert.equal(workActivity.status, 200);
+  assert.deepEqual(workActivity.body.pets?.find((pet) => pet.ownerHost === "beta")?.activity, { kind: "work", sequence: now, createdAt: now }, "HTTP activity should expose only the coarse authenticated work signal");
+  const messageBearingActivity = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work", message: "private MCP text" }, token);
+  assert.equal(messageBearingActivity.status, 400, "LAN activity must reject message-bearing payloads");
+  const returnBetaPet = await requestJson<LanState>("POST", "/return", { host: "alpha", ownerHost: "beta" }, token);
+  assert.equal(returnBetaPet.status, 200);
+  assert.equal(returnBetaPet.body.pets?.find((pet) => pet.ownerHost === "beta")?.currentHost, "beta", "the meeting host should be able to return a visitor after its dash animation");
+  const repeatedReturn = await requestJson("POST", "/return", { host: "alpha", ownerHost: "beta" }, token);
+  assert.equal(repeatedReturn.status, 400, "a host must not return a pet it no longer holds");
+  const activityAtHome = await requestJson("POST", "/activity", { ownerHost: "beta", kind: "work" }, token);
+  assert.equal(activityAtHome.status, 400, "the coordinator must reject activity when the pet is not visiting a meeting");
 
   now += 100;
   const moveAway = await requestJson<LanState>("POST", "/position", { host: "alpha", position: { x: 200, y: 20 }, edge: null }, token);

--- a/apps/desktop/tests/lan-pet-activity.test.ts
+++ b/apps/desktop/tests/lan-pet-activity.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+
+import { planLanWorkActivities, shouldPublishLanWorkSignal, shouldRetryLanWorkReturn } from "../src/lan-pet-activity.js";
+import type { LanState } from "../src/lan-state.js";
+
+const meetingState: LanState = {
+  enabled: true,
+  currentHost: "alpha",
+  clients: [],
+  pets: [
+    { ownerHost: "alpha", petId: "cat", currentHost: "alpha" },
+    { ownerHost: "beta", petId: "dog", currentHost: "alpha", activity: { kind: "work", sequence: 1, createdAt: 1_000 } },
+  ],
+  updatedAt: 1_100,
+};
+
+assert.equal(shouldPublishLanWorkSignal("beta", meetingState, "testing"), true, "work should publish only when the owner's pet is away and meeting another pet");
+assert.equal(shouldPublishLanWorkSignal("alpha", meetingState, "testing"), false, "a pet already home should not publish a return signal");
+assert.equal(shouldPublishLanWorkSignal("beta", meetingState, "thinking"), false, "non-work reactions must remain local");
+
+const firstPlan = planLanWorkActivities("alpha", meetingState.pets ?? [], new Map(), meetingState.updatedAt, 15_000);
+assert.deepEqual(firstPlan.departures, [{ ownerHost: "beta", sequence: 1 }], "a fresh remote work signal should trigger one meeting departure");
+assert.deepEqual(firstPlan.observed, [{ ownerHost: "beta", sequence: 1 }], "processed sequences should be recorded even though no message content is present");
+
+const repeatedPlan = planLanWorkActivities("alpha", meetingState.pets ?? [], new Map([["beta", 1]]), meetingState.updatedAt, 15_000);
+assert.deepEqual(repeatedPlan.departures, [], "polling the same activity sequence must not replay dialogue or departure");
+
+const stalePets = [
+  { ownerHost: "alpha", petId: "cat", currentHost: "alpha" },
+  { ownerHost: "beta", petId: "dog", currentHost: "alpha", activity: { kind: "work" as const, sequence: 2, createdAt: 1_000 } },
+];
+const stalePlan = planLanWorkActivities("alpha", stalePets, new Map(), 20_000, 15_000);
+assert.deepEqual(stalePlan.departures, [], "stale work activity should not make a visiting pet leave later");
+assert.deepEqual(stalePlan.observed, [{ ownerHost: "beta", sequence: 2 }], "stale activity must still be consumed so it cannot replay");
+
+assert.equal(shouldRetryLanWorkReturn("alpha", "beta", 1, meetingState), true, "a failed return should retry while the same visitor activity is still current");
+assert.equal(shouldRetryLanWorkReturn("alpha", "beta", 2, meetingState), false, "a superseded activity must not retry an older return");
+assert.equal(shouldRetryLanWorkReturn("beta", "beta", 1, meetingState), false, "a host must not retry returning a pet it does not hold");
+
+console.log("LAN privacy-preserving work activity validation passed.");

--- a/apps/desktop/tests/lan-pet-presence.test.ts
+++ b/apps/desktop/tests/lan-pet-presence.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import { planLanPetPresence, resolveRenderableLanPetId } from "../src/lan-pet-presence.js";
+
+const pets = [
+  { ownerHost: "alpha", petId: "cat", currentHost: "beta" },
+  { ownerHost: "beta", petId: "dog", currentHost: "beta" },
+  { ownerHost: "gamma", petId: "cat", currentHost: "beta" },
+];
+
+const plan = planLanPetPresence("beta", pets, ["alpha", "departed"]);
+assert.deepEqual(plan.show.map((pet) => pet.ownerHost), ["alpha", "gamma"], "all remote pets hosted locally should render, including duplicate pet IDs");
+assert.deepEqual(plan.closeOwnerHosts, ["departed"], "windows whose owners moved away should close");
+assert.equal(plan.show.some((pet) => pet.ownerHost === "beta"), false, "the local owner's default pet must not be duplicated as a visiting window");
+
+assert.equal(resolveRenderableLanPetId("cat", [{ id: "cat" }]), "cat", "an installed healthy pet should render");
+assert.equal(resolveRenderableLanPetId("cat", [{ id: "cat", broken: true }]), null, "a broken pet should not open a blank visiting window");
+assert.equal(resolveRenderableLanPetId("builtin", [{ id: "builtin", builtIn: true }]), "builtin", "the bundled pet should support fresh-profile LAN testing");
+assert.equal(resolveRenderableLanPetId("missing", [{ id: "cat" }]), null, "a missing remote asset should degrade safely");
+
+console.log("LAN visiting pet presence validation passed.");

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
+import { LanCoordinator, countLanTopologyLinks, normalizeLanEdge, normalizeLanHost, normalizeLanPetId, normalizeLanPoint, normalizeLanTopology, validateLanTopology } from "../src/lan-state.js";
 
 const coordinator = new LanCoordinator({ staleClientMs: 1_000 });
 
@@ -68,6 +68,22 @@ offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 120, y: 1
 offlineState = offlineNeighborCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 6_300);
 assert.equal(offlineState.currentHost, "beta", "offline configured neighbor should fall back to sorted cycling");
 
+// Multi-pet foundation: each host contributes an independently movable pet,
+// allowing two pets to occupy the same host without changing legacy behavior.
+const multiPetCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let multiPetState = multiPetCoordinator.register("alpha", { x: 100, y: 100 }, 7_000, "cat");
+multiPetState = multiPetCoordinator.register("beta", { x: 200, y: 100 }, 7_100, "dog");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.petId, pet.currentHost]), [
+  ["alpha", "cat", "alpha"],
+  ["beta", "dog", "beta"],
+], "each LAN host should register its own independently hosted pet");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 7_200, "alpha");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 7_300, "alpha");
+assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHost]), [
+  ["alpha", "beta"],
+  ["beta", "beta"],
+], "one LAN pet should migrate onto a host that already has another pet");
+
 
 const topologyDiagnostics = normalizeLanTopology({
   alpha: { right: "beta", left: "alpha" },
@@ -90,5 +106,7 @@ assert.deepEqual(normalizeLanPoint({ x: 12.7, y: "9" }), { x: 13, y: 9 });
 assert.equal(normalizeLanPoint({ x: Number.NaN, y: 1 }), undefined);
 assert.equal(normalizeLanEdge("left"), "left");
 assert.equal(normalizeLanEdge("diagonal"), null);
+assert.equal(normalizeLanPetId("pixel-cat"), "pixel-cat");
+assert.equal(normalizeLanPetId("../cat"), null);
 
 console.log("LAN coordinator validation passed.");

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -83,6 +83,18 @@ assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHos
   ["alpha", "beta"],
   ["beta", "beta"],
 ], "one LAN pet should migrate onto a host that already has another pet");
+multiPetState = multiPetCoordinator.publishActivity("alpha", 7_400) ?? assert.fail("a visiting pet in a meeting should accept coarse work activity");
+assert.deepEqual(multiPetState.pets?.find((pet) => pet.ownerHost === "alpha")?.activity, { kind: "work", sequence: 7_400, createdAt: 7_400 }, "activity should contain only coarse kind, ordering, and coordinator time");
+multiPetState = multiPetCoordinator.returnPet("beta", "alpha", 7_500) ?? assert.fail("the current host should be able to return a visiting pet");
+assert.equal(multiPetState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "work return should send the visitor back to its owner");
+assert.equal(multiPetState.pets?.find((pet) => pet.ownerHost === "alpha")?.activity, undefined, "return should consume the coarse activity");
+assert.equal(multiPetCoordinator.returnPet("beta", "alpha", 7_600), null, "a host that no longer holds the pet cannot return it again");
+assert.equal(multiPetCoordinator.publishActivity("missing", 7_700), null, "unknown owners cannot publish activity");
+assert.equal(multiPetCoordinator.publishActivity("alpha", 7_800), null, "a pet at home must not publish LAN work activity");
+multiPetCoordinator.updatePosition("alpha", { x: 50, y: 20 }, null, 7_900, "alpha");
+multiPetState = multiPetCoordinator.updatePosition("alpha", { x: 0, y: 20 }, "left", 8_000, "alpha");
+multiPetState = multiPetCoordinator.publishActivity("alpha", 8_100) ?? assert.fail("a pet should publish again during a later meeting");
+assert.equal(multiPetState.pets?.find((pet) => pet.ownerHost === "alpha")?.activity?.sequence, 8_100, "later visits must use a sequence newer than the consumed activity");
 
 // Registration is the coordinator trust boundary: unsafe IDs must never enter
 // snapshots, and a host that no longer selects a pet must remove its old record.

--- a/apps/desktop/tests/lan-state.test.ts
+++ b/apps/desktop/tests/lan-state.test.ts
@@ -84,6 +84,42 @@ assert.deepEqual(multiPetState.pets?.map((pet) => [pet.ownerHost, pet.currentHos
   ["beta", "beta"],
 ], "one LAN pet should migrate onto a host that already has another pet");
 
+// Registration is the coordinator trust boundary: unsafe IDs must never enter
+// snapshots, and a host that no longer selects a pet must remove its old record.
+const registrationCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_000, "../cat");
+assert.equal(registrationState.clients[0]?.petId, undefined, "invalid pet IDs should be discarded at registration");
+assert.deepEqual(registrationState.pets, [], "invalid pet IDs should not create coordinator pet records");
+registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_100, "cat");
+assert.equal(registrationState.pets?.[0]?.petId, "cat", "a valid selection should create the owner's pet record");
+registrationState = registrationCoordinator.register("alpha", { x: 100, y: 100 }, 8_200);
+assert.equal(registrationState.clients[0]?.petId, undefined, "deselection should clear the client selection");
+assert.deepEqual(registrationState.pets, [], "deselection should remove the owner's previous pet record");
+
+// An interrupted crossing consumes the arm. Reconnecting another host while
+// the pet remains at the edge must not cause a delayed, surprise handoff.
+const interruptedHandoffCoordinator = new LanCoordinator({ staleClientMs: 10_000 });
+let interruptedState = interruptedHandoffCoordinator.register("alpha", { x: 100, y: 100 }, 9_000, "cat");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 9_100, "alpha");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", undefined, "right", 9_200, "alpha");
+interruptedState = interruptedHandoffCoordinator.register("beta", { x: 200, y: 100 }, 9_300, "dog");
+interruptedState = interruptedHandoffCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 9_400, "alpha");
+assert.equal(interruptedState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "an interrupted handoff should require moving away from the edge before retrying");
+
+// If a destination disappears, recovery returns the pet to its owner and
+// clears the old host's arm so a reconnect cannot immediately bounce it away.
+const hostLossCoordinator = new LanCoordinator({ staleClientMs: 1_000 });
+let hostLossState = hostLossCoordinator.register("alpha", { x: 100, y: 100 }, 10_000, "cat");
+hostLossState = hostLossCoordinator.register("beta", { x: 200, y: 100 }, 10_100, "dog");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 120, y: 100 }, null, 10_200, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 10_300, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("beta", { x: 220, y: 100 }, null, 10_400, "alpha");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 100, y: 100 }, null, 11_500);
+assert.equal(hostLossState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "host loss should return a visiting pet to its connected owner");
+hostLossState = hostLossCoordinator.register("beta", { x: 200, y: 100 }, 11_600, "dog");
+hostLossState = hostLossCoordinator.updatePosition("alpha", { x: 999, y: 100 }, "right", 11_700, "alpha");
+assert.equal(hostLossState.pets?.find((pet) => pet.ownerHost === "alpha")?.currentHost, "alpha", "host-loss recovery should require a fresh interior position before another handoff");
+
 
 const topologyDiagnostics = normalizeLanTopology({
   alpha: { right: "beta", left: "alpha" },

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -84,6 +84,9 @@ Experimental multi-pet LAN mode converts only default-target `working`,
 `work` activity when the owner's pet is away and meeting another pet. The LAN
 request contains no MCP text or arbitrary message field; `pet.say`,
 `pet.showMedia`, non-work reactions, and explicit lease targets remain local.
+The LAN coordinator binds these mutations to a per-host session credential
+issued during registration; possession of the shared LAN token alone cannot
+publish activity or return a pet for another active host.
 
 `pet.showMedia` renders a local image file as a transient media bubble on the
 pet — for example an image a local generation tool just produced. Params:

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -79,6 +79,12 @@ Client method names (`hello()`, `status()`, `listPets()`, `installPet()`,
 absolute path and an explicit `zip`/`folder` kind. `react()`/`say()`/
 `showMedia()` accept an optional `leaseId` to target a specific pet.
 
+Experimental multi-pet LAN mode converts only default-target `working`,
+`editing`, `running`, and `testing` reactions into a coarse authenticated
+`work` activity when the owner's pet is away and meeting another pet. The LAN
+request contains no MCP text or arbitrary message field; `pet.say`,
+`pet.showMedia`, non-work reactions, and explicit lease targets remain local.
+
 `pet.showMedia` renders a local image file as a transient media bubble on the
 pet — for example an image a local generation tool just produced. Params:
 `path` (required absolute path, extension must be `.png`/`.jpg`/`.jpeg`/

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -43,6 +43,24 @@ draggable built-in pets on one host, return cleanup, and stale-client pruning
 after one instance disconnected. Validation across two physical machines is
 still pending.
 
+### Experimental privacy-preserving work returns
+
+Phase 3 adds an intentionally narrow MCP-to-LAN signal. When a host's default
+pet is visiting another pet and receives a `working`, `editing`, `running`, or
+`testing` reaction, its client may publish only `{ ownerHost, kind: "work" }`.
+Actual MCP messages, prompts, speech, media, tool names, and explicit-lease pet
+activity never cross the LAN boundary. Message-bearing activity requests are
+rejected by the coordinator.
+
+The meeting host consumes each fresh work sequence once. The visiting pet says
+the built-in line “Oh, I've got to get back to work!”, plays its configured
+`running` animation as a dash, and then returns to its owner. No signal is sent
+when the pet is already home, is not meeting another pet, or receives a
+non-work reaction. The coordinator independently enforces the active-meeting
+condition. Stale signals are consumed without replaying dialogue, activity
+ordering remains monotonic across later visits, and a transient return failure
+is retried without repeating the dialogue.
+
 ## Server PC
 
 PowerShell:

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -11,11 +11,33 @@ connected host. Each record keeps the pet's owner host, selected pet ID, current
 host, and latest position. This foundation allows two pets to occupy the same
 host while preserving the existing single-pet fields and behavior.
 
-Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
-and Control Center setup are intentionally deferred to later phases of
+Meeting interactions, privacy-preserving MCP work signals, and Control Center
+setup are intentionally deferred to later phases of
 [issue #93](https://github.com/alvinunreal/openpets/issues/93). Multi-machine GUI
 validation is pending while the second test system is unavailable, so this work
 remains experimental.
+
+### Experimental visiting-pet rendering
+
+Set `OPENPETS_LAN_PETS=multi` on every participating host to exercise the next
+experimental phase. Each host registers its selected default pet. When that pet
+migrates away, its default window hides; the destination opens a dedicated
+visiting-pet window keyed by owner host. Owner identity—not pet package ID—is
+the window key, so two people may select the same pet without colliding.
+
+The destination must have the selected pet installed and healthy. The bundled
+built-in pet works without extra setup. Missing or broken catalog assets are
+skipped with a scoped diagnostic;
+the local pet and LAN polling continue normally. Visiting windows close when
+their pet leaves, their owner disconnects, or LAN polling exceeds its failure
+threshold. This phase contains no meeting dialogue, MCP relay, or social
+animation.
+
+This rendering phase has been exercised with two isolated Electron profiles on
+one computer. The test covered both handoff directions, two independently
+draggable built-in pets on one host, return cleanup, and stale-client pruning
+after one instance disconnected. Validation across two physical machines is
+still pending.
 
 ## Server PC
 

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -10,6 +10,10 @@ The coordinator state can also represent one independently traveling pet per
 connected host. Each record keeps the pet's owner host, selected pet ID, current
 host, and latest position. This foundation allows two pets to occupy the same
 host while preserving the existing single-pet fields and behavior.
+Pet IDs are normalized at registration, and clearing a host's selection removes
+its coordinator record. Every edge-crossing attempt consumes its arm; returning
+a pet to its owner after host loss also requires a fresh move away from the edge
+before another handoff.
 
 Meeting interactions, privacy-preserving MCP work signals, and Control Center
 setup are intentionally deferred to later phases of

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -52,6 +52,13 @@ Actual MCP messages, prompts, speech, media, tool names, and explicit-lease pet
 activity never cross the LAN boundary. Message-bearing activity requests are
 rejected by the coordinator.
 
+The shared LAN token grants access to the coordinator but does not establish a
+host identity. Registration therefore issues a random per-host session
+credential. Position, claim, activity, and return mutations must present the
+session belonging to the host they act for. An active identity cannot be
+replaced by another shared-token peer; after its client becomes stale, a
+restarted client can register again and receives a rotated session.
+
 The meeting host consumes each fresh work sequence once. The visiting pet says
 the built-in line “Oh, I've got to get back to work!”, plays its configured
 `running` animation as a dash, and then returns to its owner. No signal is sent

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -4,6 +4,19 @@ This experimental mode makes one OpenPets default pet shared across PCs on a LAN
 Only the current owner machine shows the pet. Dragging the pet to a screen edge
 hands ownership to the next/previous connected host.
 
+## Experimental multi-pet foundation
+
+The coordinator state can also represent one independently traveling pet per
+connected host. Each record keeps the pet's owner host, selected pet ID, current
+host, and latest position. This foundation allows two pets to occupy the same
+host while preserving the existing single-pet fields and behavior.
+
+Rendering two pets, meeting interactions, privacy-preserving MCP work signals,
+and Control Center setup are intentionally deferred to later phases of
+[issue #93](https://github.com/alvinunreal/openpets/issues/93). Multi-machine GUI
+validation is pending while the second test system is unavailable, so this work
+remains experimental.
+
 ## Server PC
 
 PowerShell:

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -50,6 +50,11 @@ Two distinct window roles, two controllers:
 Both are created by `pet-window.ts` as transparent, frameless, always-on-top
 windows, driven through `pet-preload.cjs` for drag and click-through behavior.
 
+Experimental multi-pet LAN mode adds a third, isolated controller for visiting
+pets. Windows are keyed by LAN owner host rather than pet ID, so they do not
+collide with lease-managed agent pets or with another visitor using the same
+pet package. Unavailable remote assets are logged and skipped safely.
+
 While a pet is click-through it only learns that the cursor is over it through
 *forwarded* mouse events (`setIgnoreMouseEvents(true, { forward: true })`), which
 Electron delivers on macOS and Windows but not on Linux (Linux pet windows are

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -54,6 +54,9 @@ Experimental multi-pet LAN mode adds a third, isolated controller for visiting
 pets. Windows are keyed by LAN owner host rather than pet ID, so they do not
 collide with lease-managed agent pets or with another visitor using the same
 pet package. Unavailable remote assets are logged and skipped safely.
+Fresh coarse work activity can temporarily render a built-in return-to-work
+line with the visitor's `running` animation; after the dash delay, coordinator
+state returns that visitor to its owner.
 
 While a pet is click-through it only learns that the cursor is over it through
 *forwarded* mouse events (`setIgnoreMouseEvents(true, { forward: true })`), which


### PR DESCRIPTION
## Summary

- add a privacy-preserving LAN `work` activity that never forwards MCP text
- let a visiting pet announce that it must return to work, play its running animation, and return home
- restrict publishing to supported default-pet work reactions during an active two-pet meeting
- keep activity ordering monotonic across later visits and retry transient return failures without replaying dialogue

## Why

This is Phase 3 of the experimental multi-pet LAN work. It gives visiting pets a small social reaction to local agent activity without exposing prompts, messages, tool names, media, or explicit-lease activity to another machine.

This work follows the Phase 1 foundation in #94 and Phase 2 visiting-pet rendering in #103.

## Validation

- `pnpm --filter @open-pets/desktop test:build`
- focused LAN coordinator, activity, and HTTP tests
- `pnpm --filter @open-pets/desktop typecheck`
- `pnpm --filter @open-pets/desktop build`
- full desktop behavior and contract test stages
- two local Electron instances, including two successive visit → work reaction → dialogue/dash → return cycles

The full desktop suite reaches its final packaging check, which is currently blocked by the unrelated missing `web/app/plugins/posthog.client.js` file in this checkout. Testing across two physical machines remains pending while the second system is unavailable.
