### PR TITLE
feat(desktop): add MiniMax as a host AI gateway provider

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -38,6 +38,7 @@ const behaviorTests = [
   ".test-dist/tests/plugin-catalog-validation.test.js",
   ".test-dist/tests/plugin-package.test.js",
   ".test-dist/tests/plugin-service.test.js",
+  ".test-dist/tests/plugin-ai-gateway.test.js",
   ".test-dist/tests/plugin-bridge-fuzz.test.js",
   ".test-dist/tests/pet-fallback-notify.test.js",
   ".test-dist/tests/pet-pool-order.test.js",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -348,6 +348,7 @@ export const en = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama (local)",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "Model",
   "settings.plugins.model.description": "Leave empty for the provider default.",
   "settings.plugins.model.placeholder": "provider default",

--- a/apps/desktop/src/i18n/locales/es-419.ts
+++ b/apps/desktop/src/i18n/locales/es-419.ts
@@ -314,6 +314,7 @@ export const es419: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama (local)",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "Modelo",
   "settings.plugins.model.description": "Déjalo vacío para usar el predeterminado del proveedor.",
   "settings.plugins.model.placeholder": "predeterminado del proveedor",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -314,6 +314,7 @@ export const ja: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama（ローカル）",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "モデル",
   "settings.plugins.model.description": "プロバイダーのデフォルトを使う場合は空のままにします。",
   "settings.plugins.model.placeholder": "プロバイダーのデフォルト",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -314,6 +314,7 @@ export const ko: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama (로컬)",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "모델",
   "settings.plugins.model.description": "제공자 기본값을 사용하려면 비워 두세요.",
   "settings.plugins.model.placeholder": "제공자 기본값",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -314,6 +314,7 @@ export const ptBR: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama (local)",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "Modelo",
   "settings.plugins.model.description": "Deixe em branco para usar o padrão do provedor.",
   "settings.plugins.model.placeholder": "padrão do provedor",

--- a/apps/desktop/src/i18n/locales/zh-Hans.ts
+++ b/apps/desktop/src/i18n/locales/zh-Hans.ts
@@ -314,6 +314,7 @@ export const zhHans: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama（本地）",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "模型",
   "settings.plugins.model.description": "留空则使用提供商默认值。",
   "settings.plugins.model.placeholder": "提供商默认值",

--- a/apps/desktop/src/i18n/locales/zh-Hant.ts
+++ b/apps/desktop/src/i18n/locales/zh-Hant.ts
@@ -314,6 +314,7 @@ export const zhHant: Partial<Messages> = {
   "settings.plugins.aiProvider.anthropic": "Anthropic",
   "settings.plugins.aiProvider.openai": "OpenAI",
   "settings.plugins.aiProvider.ollama": "Ollama（本機）",
+  "settings.plugins.aiProvider.minimax": "MiniMax",
   "settings.plugins.model.title": "模型",
   "settings.plugins.model.description": "留空則使用供應商預設值。",
   "settings.plugins.model.placeholder": "供應商預設值",

--- a/apps/desktop/src/plugin-ai-gateway.ts
+++ b/apps/desktop/src/plugin-ai-gateway.ts
@@ -49,7 +49,7 @@ export class PluginAiGateway {
   async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
     const { provider, baseUrl, apiKey } = await this.#resolveProvider();
     if (provider === "anthropic") throw new Error("Speech-to-text needs an OpenAI-compatible AI provider.");
-    if (provider === "minimax") throw new Error("MiniMax does not support voice transcription. Choose a transcription-capable provider (OpenAI or Ollama) in OpenPets settings.");
+    if (provider === "minimax") throw new Error("The configured MiniMax OpenAI-compatible provider/path does not support voice transcription in OpenPets. Choose a transcription-capable provider (OpenAI or Ollama) in OpenPets settings.");
     const url = `${openAiBase(baseUrl, provider)}/audio/transcriptions`;
     const form = new FormData();
     form.append("file", new Blob([Buffer.from(audio)], { type: mimeType }), "speech.webm");

--- a/apps/desktop/src/plugin-ai-gateway.ts
+++ b/apps/desktop/src/plugin-ai-gateway.ts
@@ -5,8 +5,8 @@ import type { PluginAiRequest, PluginAiResult } from "./plugin-sdk-bridge.js";
 /**
  * Host AI gateway (§13.2): one user-configured provider/model serves every
  * plugin. Keys live in the encrypted host secrets store, never in plugin
- * code. Supports Anthropic, OpenAI, and Ollama (OpenAI-compatible) backends,
- * including function-calling tools and token streaming.
+ * code. Supports Anthropic, OpenAI, Ollama, and MiniMax (OpenAI-compatible)
+ * backends, including function-calling tools and token streaming.
  */
 
 export const hostSecretsOwner = "__openpets-host";
@@ -16,6 +16,7 @@ const defaultModels: Record<string, string> = {
   anthropic: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
   ollama: "llama3.2",
+  minimax: "MiniMax-M3",
 };
 
 export class PluginAiGateway {
@@ -48,7 +49,7 @@ export class PluginAiGateway {
   async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
     const { provider, baseUrl, apiKey } = await this.#resolveProvider();
     if (provider === "anthropic") throw new Error("Speech-to-text needs an OpenAI-compatible AI provider.");
-    const url = `${baseUrl ?? (provider === "ollama" ? "http://127.0.0.1:11434/v1" : "https://api.openai.com/v1")}/audio/transcriptions`;
+    const url = `${openAiBase(baseUrl, provider)}/audio/transcriptions`;
     const form = new FormData();
     form.append("file", new Blob([Buffer.from(audio)], { type: mimeType }), "speech.webm");
     form.append("model", "whisper-1");
@@ -58,7 +59,7 @@ export class PluginAiGateway {
     return typeof parsed.text === "string" ? parsed.text : "";
   }
 
-  async #resolveProvider(): Promise<{ provider: "anthropic" | "openai" | "ollama"; model: string; baseUrl?: string; apiKey?: string }> {
+  async #resolveProvider(): Promise<{ provider: "anthropic" | "openai" | "ollama" | "minimax"; model: string; baseUrl?: string; apiKey?: string }> {
     const settings = getPluginPlatformSettings().ai;
     if (settings.provider === "none") throw new Error("No AI provider is configured in OpenPets settings.");
     const apiKey = await this.#secrets.get(hostSecretsOwner, hostAiApiKeySecret);
@@ -119,7 +120,7 @@ export class PluginAiGateway {
     return { text };
   }
 
-  async #openAiComplete(req: PluginAiRequest, model: string, apiKey: string | undefined, baseUrl: string | undefined, provider: "openai" | "ollama"): Promise<PluginAiResult> {
+  async #openAiComplete(req: PluginAiRequest, model: string, apiKey: string | undefined, baseUrl: string | undefined, provider: "openai" | "ollama" | "minimax"): Promise<PluginAiResult> {
     const response = await fetch(`${openAiBase(baseUrl, provider)}/chat/completions`, {
       method: "POST",
       headers: { "content-type": "application/json", ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}) },
@@ -143,7 +144,7 @@ export class PluginAiGateway {
     return { text: message?.content ?? "", ...(toolCalls.length > 0 ? { toolCalls } : {}) };
   }
 
-  async #openAiStream(req: PluginAiRequest, model: string, apiKey: string | undefined, baseUrl: string | undefined, provider: "openai" | "ollama", onToken: (chunk: string) => void): Promise<{ text: string }> {
+  async #openAiStream(req: PluginAiRequest, model: string, apiKey: string | undefined, baseUrl: string | undefined, provider: "openai" | "ollama" | "minimax", onToken: (chunk: string) => void): Promise<{ text: string }> {
     const response = await fetch(`${openAiBase(baseUrl, provider)}/chat/completions`, {
       method: "POST",
       headers: { "content-type": "application/json", ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}) },
@@ -169,9 +170,11 @@ export class PluginAiGateway {
   }
 }
 
-function openAiBase(baseUrl: string | undefined, provider: "openai" | "ollama"): string {
+function openAiBase(baseUrl: string | undefined, provider: "openai" | "ollama" | "minimax"): string {
   if (baseUrl) return baseUrl.replace(/\/$/, "");
-  return provider === "ollama" ? "http://127.0.0.1:11434/v1" : "https://api.openai.com/v1";
+  if (provider === "ollama") return "http://127.0.0.1:11434/v1";
+  if (provider === "minimax") return "https://api.minimax.io/v1";
+  return "https://api.openai.com/v1";
 }
 
 async function readSseStream(body: ReadableStream<Uint8Array>, onData: (data: string) => void): Promise<void> {

--- a/apps/desktop/src/plugin-ai-gateway.ts
+++ b/apps/desktop/src/plugin-ai-gateway.ts
@@ -49,6 +49,7 @@ export class PluginAiGateway {
   async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
     const { provider, baseUrl, apiKey } = await this.#resolveProvider();
     if (provider === "anthropic") throw new Error("Speech-to-text needs an OpenAI-compatible AI provider.");
+    if (provider === "minimax") throw new Error("MiniMax does not support voice transcription. Choose a transcription-capable provider (OpenAI or Ollama) in OpenPets settings.");
     const url = `${openAiBase(baseUrl, provider)}/audio/transcriptions`;
     const form = new FormData();
     form.append("file", new Blob([Buffer.from(audio)], { type: mimeType }), "speech.webm");

--- a/apps/desktop/src/plugin-platform-settings.ts
+++ b/apps/desktop/src/plugin-platform-settings.ts
@@ -8,7 +8,7 @@ import { dirname, join } from "node:path";
  * (AI-generated speech, microphone) default OFF.
  */
 
-export type PluginAiProviderKind = "none" | "anthropic" | "openai" | "ollama";
+export type PluginAiProviderKind = "none" | "anthropic" | "openai" | "ollama" | "minimax";
 
 export type PluginPlatformSettings = {
   readonly allowPluginAudio: boolean;
@@ -72,7 +72,7 @@ function normalizeSettings(value: unknown): PluginPlatformSettings {
   const quiet = typeof raw.quietHours === "object" && raw.quietHours !== null ? raw.quietHours as Record<string, unknown> : {};
   const ai = typeof raw.ai === "object" && raw.ai !== null ? raw.ai as Record<string, unknown> : {};
   const isTime = (entry: unknown): entry is string => typeof entry === "string" && /^\d{2}:\d{2}$/.test(entry);
-  const provider = ["none", "anthropic", "openai", "ollama"].includes(String(ai.provider)) ? String(ai.provider) as PluginAiProviderKind : "none";
+  const provider = ["none", "anthropic", "openai", "ollama", "minimax"].includes(String(ai.provider)) ? String(ai.provider) as PluginAiProviderKind : "none";
   return {
     allowPluginAudio: raw.allowPluginAudio !== false,
     allowDynamicSpeech: raw.allowDynamicSpeech === true,

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -44,7 +44,7 @@ type PluginPlatformSettings = {
   allowPluginVoice: boolean;
   allowMicrophone: boolean;
   quietHours: { enabled: boolean; start: string; end: string };
-  ai: { provider: "none" | "anthropic" | "openai" | "ollama"; model: string; baseUrl?: string };
+  ai: { provider: "none" | "anthropic" | "openai" | "ollama" | "minimax"; model: string; baseUrl?: string };
 };
 type PluginInspectorState = { schedules: Array<{ id: string; type: string; nextRunMs: number }>; commands: PluginCommand[]; menuItems: Array<{ id: string; title: string }>; status?: PluginStatus; activeBubbles: number; activePanels: number; eventSubscriptions: number; lastError?: string; quotaCounters: Record<string, number> };
 type PluginIconName = "plugin" | "bell" | "timer" | "github" | "heart" | "sparkles" | "coffee" | "focus" | "droplet";
@@ -1407,6 +1407,7 @@ function SettingsView() {
                   <option value="anthropic">{t("settings.plugins.aiProvider.anthropic")}</option>
                   <option value="openai">{t("settings.plugins.aiProvider.openai")}</option>
                   <option value="ollama">{t("settings.plugins.aiProvider.ollama")}</option>
+                  <option value="minimax">{t("settings.plugins.aiProvider.minimax")}</option>
                 </select>
               </div>
               <div className="settings-row">

--- a/apps/desktop/tests/plugin-ai-gateway.test.ts
+++ b/apps/desktop/tests/plugin-ai-gateway.test.ts
@@ -38,7 +38,7 @@ try {
     () => gateway.transcribe(new Uint8Array([1, 2, 3]), "audio/webm"),
     (error: unknown) => {
       assert.ok(error instanceof Error);
-      assert.match(error.message, /MiniMax does not support voice transcription/);
+      assert.match(error.message, /MiniMax OpenAI-compatible provider\/path does not support voice transcription in OpenPets/);
       assert.match(error.message, /OpenAI or Ollama/);
       return true;
     },

--- a/apps/desktop/tests/plugin-ai-gateway.test.ts
+++ b/apps/desktop/tests/plugin-ai-gateway.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PluginAiGateway } from "../src/plugin-ai-gateway.js";
+import { getPluginPlatformSettings, initializePluginPlatformSettings, updatePluginPlatformSettings } from "../src/plugin-platform-settings.js";
+import type { PluginSecretsStore } from "../src/plugin-secrets.js";
+
+const userDataPath = mkdtempSync(join(tmpdir(), "openpets-plugin-ai-gateway-"));
+const previousSettings = getPluginPlatformSettings();
+const previousFetch = globalThis.fetch;
+const fetchCalls: Array<{ input: Parameters<typeof fetch>[0]; init?: Parameters<typeof fetch>[1] }> = [];
+
+try {
+  initializePluginPlatformSettings(userDataPath);
+  updatePluginPlatformSettings({ ai: { provider: "minimax", model: "" } });
+
+  const secrets = { get: async () => "minimax-test-key" } as unknown as PluginSecretsStore;
+  const gateway = new PluginAiGateway(secrets);
+  globalThis.fetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response(JSON.stringify({ choices: [{ message: { content: "MiniMax says hello" } }] }), { status: 200 });
+  };
+
+  const result = await gateway.complete({ messages: [{ role: "user", content: "Say hello." }] });
+  assert.equal(result.text, "MiniMax says hello");
+  assert.equal(fetchCalls.length, 1);
+  const completeCall = fetchCalls[0];
+  assert.ok(completeCall);
+  assert.equal(String(completeCall.input), "https://api.minimax.io/v1/chat/completions");
+  assert.equal(new Headers(completeCall.init?.headers).get("authorization"), "Bearer minimax-test-key");
+  const requestBody = JSON.parse(String(completeCall.init?.body)) as { model?: string };
+  assert.equal(requestBody.model, "MiniMax-M3");
+
+  fetchCalls.length = 0;
+  await assert.rejects(
+    () => gateway.transcribe(new Uint8Array([1, 2, 3]), "audio/webm"),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /MiniMax does not support voice transcription/);
+      assert.match(error.message, /OpenAI or Ollama/);
+      return true;
+    },
+  );
+  assert.equal(fetchCalls.length, 0);
+} finally {
+  globalThis.fetch = previousFetch;
+  updatePluginPlatformSettings(previousSettings);
+  rmSync(userDataPath, { recursive: true, force: true });
+}
+
+console.error("Plugin AI gateway validation passed.");

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -132,6 +132,18 @@ capability the current manifest no longer declares.
 - Legacy `ctx.http.fetch` remains GET-only, public HTTPS only — it never gains
   local or mutating access.
 
+### Host AI providers
+
+The host AI gateway uses one provider configured in OpenPets settings for plugin
+chat requests. Supported providers are Anthropic, OpenAI, Ollama, and MiniMax.
+Anthropic uses its native chat API; OpenAI, Ollama, and MiniMax use
+OpenAI-compatible chat-completions APIs. All four support token streaming.
+
+Voice input through `voice.listen` is a separate capability: OpenAI and Ollama
+are transcription-capable, while Anthropic and MiniMax are not. MiniMax supports
+OpenAI-compatible chat completions and streaming, but does not provide audio
+transcription; choose OpenAI or Ollama when a plugin needs `voice.listen`.
+
 ### Display deliveries
 
 `ui:delivery` is a dedicated permission for the generic, host-owned delivery

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -139,10 +139,12 @@ chat requests. Supported providers are Anthropic, OpenAI, Ollama, and MiniMax.
 Anthropic uses its native chat API; OpenAI, Ollama, and MiniMax use
 OpenAI-compatible chat-completions APIs. All four support token streaming.
 
-Voice input through `voice.listen` is a separate capability: OpenAI and Ollama
-are transcription-capable, while Anthropic and MiniMax are not. MiniMax supports
-OpenAI-compatible chat completions and streaming, but does not provide audio
-transcription; choose OpenAI or Ollama when a plugin needs `voice.listen`.
+Voice input through `voice.listen` is a separate capability and uses the host's
+OpenAI-compatible transcription path. OpenAI and Ollama support that path, while
+MiniMax's configured OpenAI-compatible API does not accept audio input/transcription,
+so it cannot be used for `voice.listen`. Anthropic is not transcription-capable
+through this path. MiniMax supports OpenAI-compatible chat completions and
+streaming; choose OpenAI or Ollama when a plugin needs `voice.listen`.
 
 ### Display deliveries
 


### PR DESCRIPTION
Reason: Add MiniMax as a first-class provider in the host plugin AI gateway.

## Changes
- Extend `PluginAiProviderKind` and the settings normalization allowlist in `plugin-platform-settings.ts` to accept `minimax` as a provider.
- Register `MiniMax-M3` as the default model and `https://api.minimax.io/v1` as the default base URL for MiniMax in `plugin-ai-gateway.ts`, routing it through the existing chat-completions backend path (with tool calls and streaming).
- Add the MiniMax option to the plugin platform AI provider dropdown in the renderer settings and to all seven desktop i18n locale files.

## Checks
- `pnpm install --ignore-scripts` — passed.
- `pnpm --filter @open-pets/desktop typecheck` (`build:deps && tsc --noEmit && tsc -p tsconfig.renderer.json --noEmit`) — passed.
