### PR TITLE
Slow down the waiting animation cycle

### DIFF
--- a/apps/desktop/src/reaction-animation-mapping.ts
+++ b/apps/desktop/src/reaction-animation-mapping.ts
@@ -45,7 +45,7 @@ export const defaultPetSprite = {
     waving: { row: 3, frames: 4, durationMs: 700, iterations: 2 },
     jumping: { row: 4, frames: 5, durationMs: 840, iterations: 2 },
     failed: { row: 5, frames: 8, durationMs: 1220, iterations: 2 },
-    waiting: { row: 6, frames: 6, durationMs: 1010 },
+    waiting: { row: 6, frames: 6, durationMs: 2200 },
     running: { row: 7, frames: 6, durationMs: 820 },
     review: { row: 8, frames: 6, durationMs: 1030 },
   } satisfies Record<UniversalSpriteState, SpriteStateDefinition>,


### PR DESCRIPTION
## Summary
- Doubles the `waiting` sprite state's cycle duration from 1010ms to 2200ms in `defaultPetSprite.states` (`apps/desktop/src/reaction-animation-mapping.ts`).

## Why
The `waiting` animation (used for the `waiting`/`testing` reactions, including the Claude Code `PermissionRequest` hook) cycled through its 6 frames in about a second, which felt rushed for a state meant to represent blocked/pending work. A longer cycle reads as a calmer, more deliberate wait.

## Note for reviewers
This is a global timing tweak — it affects the `waiting` animation for every pet (built-in and custom), not just one specific pet. It's a small, subjective pacing change rather than a bug fix, so feel free to push back on the exact duration if 2200ms feels off.

## Test plan
- [x] Rebuilt and ran the desktop app locally (`pnpm --filter @open-pets/desktop dev`) and confirmed the `waiting` animation now runs at the slower pace.
- [ ] No automated tests added (pure timing constant change, no behavioral branching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)