### PR TITLE
feat(desktop): harden voice capture lifecycle

### DIFF
--- a/apps/desktop/assets/voice-capture.html
+++ b/apps/desktop/assets/voice-capture.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">

--- a/apps/desktop/codemap.md
+++ b/apps/desktop/codemap.md
@@ -85,6 +85,7 @@ OpenPets desktop companion application. Tray-first Electron app providing animat
 - `plugin-pet-api.ts`: Runtime bridge from plugin actions to default pet speech/reaction APIs
 - `plugin-js-host.ts`: Hidden sandboxed BrowserWindow host for JavaScript plugin entry modules, SDK IPC tokening, session hardening, startup handshake, and teardown
 - `plugin-sdk-bridge.ts`: Permission-checked SDK API for JavaScript plugins with quotas, plugin storage, schedules, config listeners, commands/status, logs, and restricted HTTPS fetch
+- `plugin-voice.ts` plus `voice-capture*.ts`, `voice-listening-service.ts`, and `voice-privacy-indicator*.ts`: Host-owned one-shot voice capture, transcription bounds, privacy state, and teardown cleanup
 - `pet-installation.ts`: Catalog ZIP download and extraction
 - `codex-pets.ts`: Local Codex pet import
 - `catalog.ts`: Remote catalog fetching with V3 pagination and fixture fallback
@@ -100,7 +101,7 @@ OpenPets desktop companion application. Tray-first Electron app providing animat
 
 ## Test Structure
 
-- **Behavior tests** (`tests/*.test.ts`): Unit tests for lease manager (incl. PID liveness + pool toggle), state management, version checking, ZIP safety, Codex pets, Claude memory, reaction animation mapping, display geometry helpers (`display.test.ts`), pet motion-engine clamping and shared-ticker (`pet-motion-engine-clamp.test.ts`, `pet-motion-engine-shared-ticker.test.ts`), gravity seam (`pet-motion-engine-gravity-seam.test.ts`), single-writer invariant (`pet-motion-engine-single-writer.test.ts`), roaming controller (`pet-roaming-controller.test.ts`), and pool toggle (`pool-toggle.test.ts`). Compiled to `.test-dist/tests/`.
+- **Behavior tests** (`tests/*.test.ts`): Unit tests for lease manager (incl. PID liveness + pool toggle), state management, version checking, ZIP safety, Codex pets, Claude memory, reaction animation mapping, plugin bridge/gateway guards, bounded voice capture lifecycle (`voice-lifecycle.test.ts`), display geometry helpers (`display.test.ts`), pet motion-engine clamping and shared-ticker (`pet-motion-engine-clamp.test.ts`, `pet-motion-engine-shared-ticker.test.ts`), gravity seam (`pet-motion-engine-gravity-seam.test.ts`), single-writer invariant (`pet-motion-engine-single-writer.test.ts`), roaming controller (`pet-roaming-controller.test.ts`), and pool toggle (`pool-toggle.test.ts`). Compiled to `.test-dist/tests/`.
 - **Contract tests** (`contracts/*.contract.ts`): Public API boundary validation for catalog fixtures, IPC protocol, and plugin manifest schema. Compiled to `.test-dist/contracts/`.
 - **Runtime checks** (`src/check-*.ts`): Remaining runtime validation checks compiled to `dist/`.
 - **Test runner** (`scripts/run-tests.mjs`): Orchestrates preload syntax checks → test compilation → behavior tests → contract tests → dist checks.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -34,6 +34,8 @@ toolsets:
 mac:
   icon: assets/app-icon.icns
   category: public.app-category.utilities
+  extendInfo:
+    NSMicrophoneUsageDescription: OpenPets uses your microphone only for one-shot, user-initiated voice input.
   target:
     - dmg
     - zip

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -39,6 +39,8 @@ const behaviorTests = [
   ".test-dist/tests/plugin-package.test.js",
   ".test-dist/tests/plugin-service.test.js",
   ".test-dist/tests/plugin-ai-gateway.test.js",
+  ".test-dist/tests/voice-bridge.test.js",
+  ".test-dist/tests/voice-lifecycle.test.js",
   ".test-dist/tests/plugin-bridge-fuzz.test.js",
   ".test-dist/tests/pet-fallback-notify.test.js",
   ".test-dist/tests/pet-pool-order.test.js",

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -41,6 +41,7 @@ const behaviorTests = [
   ".test-dist/tests/plugin-ai-gateway.test.js",
   ".test-dist/tests/voice-bridge.test.js",
   ".test-dist/tests/voice-lifecycle.test.js",
+  ".test-dist/tests/tray-voice.test.js",
   ".test-dist/tests/plugin-bridge-fuzz.test.js",
   ".test-dist/tests/pet-fallback-notify.test.js",
   ".test-dist/tests/pet-pool-order.test.js",

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -125,7 +125,10 @@ main.ts → initializePluginService(userData, defaultPluginPetApi, appVersion, E
 │   ├── declarative runtime schedules timer triggers
 │   ├── plugin-js-host.ts starts hidden sandboxed BrowserWindow hosts for JavaScript plugins
 │   └── plugin-sdk-bridge.ts dispatches namespaced SDK routes
-│       ├── plugin-sdk-audio.ts/plugin-voice.ts → renderer/OS playback and speech surfaces
+│       ├── plugin-sdk-audio.ts/plugin-voice.ts → renderer/OS playback and one-shot voice surfaces
+│       │   ├── voice-capture.ts/voice-capture-electron.ts → bounded microphone ownership and cleanup
+│       │   ├── voice-listening-service.ts → transcription timeout, cancellation, and empty-text guard
+│       │   └── voice-privacy-indicator-electron.ts → host-owned live-track indicator
 │       ├── plugin-sdk-bus.ts/plugin-sdk-events.ts → curated pub/sub and host event streams
 │       ├── plugin-sdk-config.ts/plugin-sdk-storage.ts/plugin-sdk-state.ts → config, persistent plugin data, and subscriptions
 │       ├── plugin-sdk-ui.ts/plugin-panels.ts/plugin-toast.ts → bubbles, alerts, commands, panels, and toasts
@@ -261,7 +264,10 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `plugin-secrets.ts`: Plugin-scoped encrypted secret storage backed by Electron safe storage primitives.
 - `plugin-toast.ts`: Host toast/notification routing for plugin UI events.
 - `plugin-user-sound-store.ts`: Plugin-scoped imported user sound registry that stores opaque sound refs instead of raw filesystem paths.
-- `plugin-voice.ts`: Voice/TTS and one-shot listen facade gated by settings and permissions.
+- `plugin-voice.ts`: Voice/TTS and one-shot listen facade gated by settings and permissions; owns host cancellation hooks.
+- `voice-capture.ts` / `voice-capture-electron.ts`: One-active-at-a-time microphone capture with separate acquisition timeout, media-track cleanup, and temporary-session teardown.
+- `voice-listening-service.ts`: Transcription timeout, abort handling, whitespace-only rejection, and late-event suppression.
+- `voice-privacy-indicator.ts` / `voice-privacy-indicator-electron.ts`: Track-driven host privacy indicator, hidden until acquisition succeeds.
 
 **Agent Integration**:
 - `agent-setup.ts`: Claude/OpenCode/Cursor detection, MCP configuration, hooks management, action journaling

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -127,7 +127,9 @@ main.ts → initializePluginService(userData, defaultPluginPetApi, appVersion, E
 │   └── plugin-sdk-bridge.ts dispatches namespaced SDK routes
 │       ├── plugin-sdk-audio.ts/plugin-voice.ts → renderer/OS playback and one-shot voice surfaces
 │       │   ├── voice-capture.ts/voice-capture-electron.ts → bounded microphone ownership and cleanup
+│       │   ├── voice-capture-cancellation.ts → idempotent renderer-cancel/window-destroy ordering
 │       │   ├── voice-listening-service.ts → transcription timeout, cancellation, and empty-text guard
+│       │   ├── voice-operation-state.ts → internal tray cancellation state and phase tracking
 │       │   └── voice-privacy-indicator-electron.ts → host-owned live-track indicator
 │       ├── plugin-sdk-bus.ts/plugin-sdk-events.ts → curated pub/sub and host event streams
 │       ├── plugin-sdk-config.ts/plugin-sdk-storage.ts/plugin-sdk-state.ts → config, persistent plugin data, and subscriptions
@@ -266,7 +268,9 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `plugin-user-sound-store.ts`: Plugin-scoped imported user sound registry that stores opaque sound refs instead of raw filesystem paths.
 - `plugin-voice.ts`: Voice/TTS and one-shot listen facade gated by settings and permissions; owns host cancellation hooks.
 - `voice-capture.ts` / `voice-capture-electron.ts`: One-active-at-a-time microphone capture with separate acquisition timeout, media-track cleanup, and temporary-session teardown.
+- `voice-capture-cancellation.ts`: Idempotent renderer-cancel/window-destroy ordering for Electron capture teardown.
 - `voice-listening-service.ts`: Transcription timeout, abort handling, whitespace-only rejection, and late-event suppression.
+- `voice-operation-state.ts`: Internal acquisition/recording/transcription state surfaced to host tray controls.
 - `voice-privacy-indicator.ts` / `voice-privacy-indicator-electron.ts`: Track-driven host privacy indicator, hidden until acquisition succeeds.
 
 **Agent Integration**:

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -18,6 +18,8 @@ export const en = {
   "tray.integrations": "Integrations...",
   "tray.plugins": "Plugins...",
   "tray.settings": "Settings...",
+  "tray.cancelVoiceListening": "Stop microphone listening",
+  "tray.cancelVoiceTranscription": "Cancel transcription",
   "tray.openLogsFolder": "Open Logs Folder...",
   "tray.quit": "Quit OpenPets",
 

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -6,9 +6,12 @@ import { info } from "./logger.js";
 import { stopLocalIpcServer } from "./local-ipc.js";
 import { closeAllLanVisitingPets } from "./lan-pet-controller.js";
 import { stopPluginService } from "./plugin-service.js";
+import { shutdownPluginVoice } from "./plugin-voice.js";
 import { focusOpenTaskWindows } from "./windows.js";
 
 let intentionalQuit = false;
+let cleanupStarted = false;
+let cleanupFinished = false;
 let hardExitTimer: NodeJS.Timeout | null = null;
 
 export function installAppLifecycle(): void {
@@ -30,15 +33,24 @@ export function installAppLifecycle(): void {
     console.log("OpenPets activate event received; not opening a dashboard window.");
   });
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
+    if (cleanupFinished) return;
+    event.preventDefault();
+    if (cleanupStarted) return;
+    cleanupStarted = true;
     intentionalQuit = true;
     info("app", "before quit cleanup begin");
     scheduleHardExitFallback("before-quit");
-    stopPluginService();
-    stopLocalIpcServer();
-    closeAllLanVisitingPets();
-    closeAllAgentPets();
-    destroyDefaultPet();
+    void (async () => {
+      await shutdownPluginVoice().catch(() => undefined);
+      await stopPluginService().catch(() => undefined);
+      stopLocalIpcServer();
+      closeAllLanVisitingPets();
+      closeAllAgentPets();
+      destroyDefaultPet();
+      cleanupFinished = true;
+      app.quit();
+    })();
   });
 }
 

--- a/apps/desktop/src/plugin-ai-gateway.ts
+++ b/apps/desktop/src/plugin-ai-gateway.ts
@@ -46,15 +46,15 @@ export class PluginAiGateway {
   }
 
   /** One-shot audio transcription backing voice.listen (OpenAI-compatible only). */
-  async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
+  async transcribe(audio: Uint8Array, mimeType: string, signal?: AbortSignal): Promise<string> {
     const { provider, baseUrl, apiKey } = await this.#resolveProvider();
     if (provider === "anthropic") throw new Error("Speech-to-text needs an OpenAI-compatible AI provider.");
     if (provider === "minimax") throw new Error("The configured MiniMax OpenAI-compatible provider/path does not support voice transcription in OpenPets. Choose a transcription-capable provider (OpenAI or Ollama) in OpenPets settings.");
     const url = `${openAiBase(baseUrl, provider)}/audio/transcriptions`;
     const form = new FormData();
-    form.append("file", new Blob([Buffer.from(audio)], { type: mimeType }), "speech.webm");
+    form.append("file", new Blob([Buffer.from(audio)], { type: mimeType }), `speech.${audioFileExtension(mimeType)}`);
     form.append("model", "whisper-1");
-    const response = await fetch(url, { method: "POST", headers: apiKey ? { authorization: `Bearer ${apiKey}` } : {}, body: form });
+    const response = await fetch(url, { method: "POST", headers: apiKey ? { authorization: `Bearer ${apiKey}` } : {}, body: form, ...(signal ? { signal } : {}) });
     if (!response.ok) throw new Error(`Transcription failed with HTTP ${response.status}.`);
     const parsed = await response.json() as { text?: string };
     return typeof parsed.text === "string" ? parsed.text : "";
@@ -169,6 +169,14 @@ export class PluginAiGateway {
     });
     return { text };
   }
+}
+
+function audioFileExtension(mimeType: string): string {
+  const baseType = mimeType.toLowerCase().split(";", 1)[0] ?? "";
+  if (baseType.includes("ogg")) return "ogg";
+  if (baseType.includes("wav")) return "wav";
+  if (baseType.includes("mp4")) return "mp4";
+  return "webm";
 }
 
 function openAiBase(baseUrl: string | undefined, provider: "openai" | "ollama" | "minimax"): string {

--- a/apps/desktop/src/plugin-host-capabilities.ts
+++ b/apps/desktop/src/plugin-host-capabilities.ts
@@ -21,7 +21,7 @@ import {
 import { motionStop } from "./pet-motion-engine.js";
 import { PluginSecretsStore } from "./plugin-secrets.js";
 import { showPluginToast } from "./plugin-toast.js";
-import { pluginVoiceListen, pluginVoiceSpeak } from "./plugin-voice.js";
+import { cancelPluginVoiceListen, pluginVoiceListen, pluginVoiceSpeak, shutdownPluginVoice } from "./plugin-voice.js";
 import { registerDelivery, stopDeliverySystem, teardownPluginDeliveries } from "./plugin-delivery.js";
 import type { PluginHostCapabilities, PluginPickedFileHost } from "./plugin-sdk-bridge.js";
 import { maxUserSoundBytes, UserSoundStore, userSoundMimeByExtension } from "./plugin-user-sound-store.js";
@@ -67,7 +67,7 @@ export type ElectronPluginHostCapabilities = PluginHostCapabilities & {
   readonly secretsStore: PluginSecretsStore;
   readonly aiGateway: PluginAiGateway;
   /** Tear down everything a plugin owns on stop/reload. */
-  clearPlugin(pluginId: string): void;
+  clearPlugin(pluginId: string): Promise<void>;
   shutdown(): void;
 };
 
@@ -208,7 +208,7 @@ export function createElectronPluginHostCapabilities(userDataPath: string): Elec
     },
     voice: {
       speak: async (text, opts) => { try { await pluginVoiceSpeak(text, opts); } catch (error) { warn("plugin", "voice speak failed", { reason: error instanceof Error ? error.message : "unknown", errorCode: classifyPluginError(error) }); throw error; } },
-      listen: async (opts) => { try { return await pluginVoiceListen(aiGateway, { timeoutMs: opts.timeoutMs ?? 10_000 }); } catch (error) { warn("plugin", "voice listen failed", { reason: error instanceof Error ? error.message : "unknown", errorCode: classifyPluginError(error) }); throw error; } },
+      listen: async (opts) => { try { return await pluginVoiceListen(aiGateway, { timeoutMs: opts.timeoutMs ?? 10_000, pluginId: opts.pluginId }); } catch (error) { warn("plugin", "voice listen failed", { reason: error instanceof Error ? error.message : "unknown", errorCode: classifyPluginError(error) }); throw error; } },
     },
     auth: {
       oauth: async (pluginId, config) => { try { return await oauthBroker.oauth(pluginId, config); } catch (error) { warn("plugin", "oauth failed", { pluginId, provider: config.provider, reason: error instanceof Error ? error.message : "unknown", errorCode: classifyPluginError(error) }); throw error; } },
@@ -290,7 +290,8 @@ export function createElectronPluginHostCapabilities(userDataPath: string): Elec
       listenAllowed: () => getPluginPlatformSettings().allowMicrophone,
       inQuietHours: () => isInQuietHours(),
     },
-    clearPlugin(pluginId: string) {
+    async clearPlugin(pluginId: string) {
+      await cancelPluginVoiceListen(pluginId, "The plugin was stopped.").catch(() => undefined);
       try {
         teardownPluginDeliveries(pluginId);
         clearPluginPetsForPlugin(pluginId);
@@ -302,6 +303,7 @@ export function createElectronPluginHostCapabilities(userDataPath: string): Elec
       motionStop("default");
     },
     shutdown() {
+      void shutdownPluginVoice().catch(() => undefined);
       shutdown();
     },
   };

--- a/apps/desktop/src/plugin-runtime.ts
+++ b/apps/desktop/src/plugin-runtime.ts
@@ -53,6 +53,7 @@ export class PluginRuntime {
   readonly #logger: (level: PluginLogLevel, message: string, fields?: Record<string, unknown>) => void;
   readonly #onPluginRuntimeError?: PluginRuntimeOptions["onPluginRuntimeError"];
   readonly #slots = new Map<string, PluginRuntimeSlot>();
+  readonly #reloads = new Map<string, Promise<void>>();
   #active = false;
 
   constructor(options: PluginRuntimeOptions) {
@@ -75,10 +76,12 @@ export class PluginRuntime {
     logPluginDiagnostic(this.#logger, "debug", "plugin runtime start", { phase: "success" });
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     logPluginDiagnostic(this.#logger, "debug", "plugin runtime stop", { phase: "begin" });
     this.#active = false;
-    for (const id of this.#slots.keys()) this.#cancelPlugin(id);
+    const pendingReloads = [...this.#reloads.values()];
+    await Promise.all([...this.#slots.keys()].map((id) => this.#cancelPlugin(id)));
+    await Promise.all(pendingReloads);
     logPluginDiagnostic(this.#logger, "debug", "plugin runtime stop", { phase: "end" });
   }
 
@@ -90,7 +93,7 @@ export class PluginRuntime {
   resyncSchedules(): void { this.#sdkBridge.resyncSchedules(); }
 
   async reloadAll(): Promise<void> {
-    for (const id of this.#slots.keys()) this.#cancelPlugin(id);
+    await Promise.all([...this.#slots.keys()].map((id) => this.#cancelPlugin(id)));
     const records = this.#stateStore.listRecords();
     const jsIds: string[] = [];
     for (const record of records) {
@@ -101,9 +104,20 @@ export class PluginRuntime {
   }
 
   async reloadPlugin(id: string): Promise<void> {
+    const previous = this.#reloads.get(id) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(() => this.#reloadPlugin(id));
+    this.#reloads.set(id, current);
+    try {
+      await current;
+    } finally {
+      if (this.#reloads.get(id) === current) this.#reloads.delete(id);
+    }
+  }
+
+  async #reloadPlugin(id: string): Promise<void> {
     const started = Date.now();
     logPluginDiagnostic(this.#logger, "debug", "plugin reload", { pluginId: id, phase: "begin" });
-    this.#cancelPlugin(id);
+    await this.#cancelPlugin(id);
     if (!this.#active) { logPluginDiagnostic(this.#logger, "debug", "plugin reload", { pluginId: id, phase: "skip", reason: "runtime-inactive" }); return; }
     const record = this.#stateStore.getRecord(id);
     if (!record || !record.enabled || record.catalogDisabled) { logPluginDiagnostic(this.#logger, "debug", "plugin reload", { pluginId: id, phase: "skip", reason: !record ? "not-installed" : !record.enabled ? "disabled" : "catalog-disabled" }); return; }
@@ -164,6 +178,8 @@ export class PluginRuntime {
     } });
     if (!this.#canCommitReload(record, generation)) {
       host.stop();
+      unregisterPluginLocales(record.id);
+      await this.#clearPlugin(record.id);
       return;
     }
     slot.jsHost = host;
@@ -201,11 +217,11 @@ export class PluginRuntime {
     logPluginDiagnostic(this.#logger, "error", "plugin marked broken", { pluginId: id, reason });
     const record = this.#stateStore.getRecord(id);
     this.#onPluginRuntimeError?.({ plugin_source: record?.bundled ? "bundled" : record?.source, plugin_runtime: record?.runtime, permission_count: record?.approvedPermissions.length, error_code: classifyPluginError(reason) });
-    this.#cancelPlugin(id);
+    void this.#cancelPlugin(id);
     this.#stateStore.setBrokenReason(id, reason);
   }
 
-  #cancelPlugin(id: string): void {
+  async #cancelPlugin(id: string): Promise<void> {
     const slot = this.#slotFor(id);
     if (slot.active || slot.timers.length > 0 || slot.jsHost) logPluginDiagnostic(this.#logger, "debug", "plugin cancel", { pluginId: id, phase: "begin", count: slot.timers.length });
     slot.active = false;
@@ -215,10 +231,16 @@ export class PluginRuntime {
     slot.jsHost?.stop();
     slot.jsHost = undefined;
     unregisterPluginLocales(id);
-    this.#sdkBridge.clearPlugin(id);
-    const teardown = (this.#capabilities as { clearPlugin?: (pluginId: string) => void } | undefined)?.clearPlugin;
-    if (teardown) { try { teardown(id); } catch { /* host teardown is best effort */ } }
+    await this.#clearPlugin(id);
     logPluginDiagnostic(this.#logger, "debug", "plugin cancel", { pluginId: id, phase: "end" });
+  }
+
+  async #clearPlugin(id: string): Promise<void> {
+    this.#sdkBridge.clearPlugin(id);
+    const teardown = (this.#capabilities as { clearPlugin?: (pluginId: string) => void | Promise<void> } | undefined)?.clearPlugin;
+    if (teardown) {
+      try { await teardown(id); } catch { /* host teardown is best effort */ }
+    }
   }
 
   #slotFor(id: string): PluginRuntimeSlot {

--- a/apps/desktop/src/plugin-sdk-bridge.ts
+++ b/apps/desktop/src/plugin-sdk-bridge.ts
@@ -186,7 +186,7 @@ export interface PluginHostCapabilities {
   };
   voice: {
     speak(text: string, opts: { voice?: string; rate?: number }): Promise<void>;
-    listen(opts: { timeoutMs?: number }): Promise<{ text: string }>;
+    listen(opts: { timeoutMs?: number; pluginId?: string }): Promise<{ text: string }>;
   };
   auth: {
     oauth(pluginId: string, config: { provider: "google" | "spotify"; clientId: string; clientSecret?: string; scopes: string[] }): Promise<PluginOauthTokens>;
@@ -213,7 +213,7 @@ export interface PluginHostCapabilities {
     inQuietHours(): boolean;
   };
   /** Trusted host lifecycle hook; not exposed through the plugin SDK. */
-  clearPlugin?(pluginId: string): void;
+  clearPlugin?(pluginId: string): void | Promise<void>;
 }
 
 /**
@@ -350,6 +350,7 @@ export class PluginSdkBridge {
   readonly #logger: PluginRuntimeLogger;
   readonly #capabilities: PluginHostCapabilities;
   readonly #states = new Map<string, PluginRuntimeState>();
+  readonly #apiGenerations = new Map<string, number>();
   readonly #busTopics = new Map<string, Set<PluginBusTopicEntry>>();
 
   constructor(options: { stateStore: PluginStateStore; petApi: PluginPetApi; scheduler: PluginRuntimeScheduler; storage?: PluginStorageStore; onError?: (id: string, reason: string) => void; logger?: PluginRuntimeLogger; capabilities?: PluginHostCapabilities }) {
@@ -368,7 +369,9 @@ export class PluginSdkBridge {
     const state = this.#pluginState(record.id);
     const caps = this.#capabilities;
     const pluginId = record.id;
-    const requirePermission = (permission: PluginPermission) => { if (!approved.has(permission)) throw new Error(`Plugin permission is not approved: ${permission}`); };
+    const apiGeneration = this.#apiGenerations.get(pluginId) ?? 0;
+    const requireActive = () => { if ((this.#apiGenerations.get(pluginId) ?? 0) !== apiGeneration) throw new Error("Plugin is no longer active."); };
+    const requirePermission = (permission: PluginPermission) => { requireActive(); if (!approved.has(permission)) throw new Error(`Plugin permission is not approved: ${permission}`); };
     const runScheduled = async (callback: () => unknown) => { try { await callback(); } catch (error) { this.#onError(pluginId, safeError(error)); } };
     const getConfig = () => ({ ...(this.#stateStore.getRecord(pluginId)?.config ?? {}) }) as PluginConfig;
     const guardCallback = <A extends unknown[]>(fn: (...args: A) => unknown): ((...args: A) => void) => (...args) => { void Promise.resolve().then(() => fn(...args)).catch((error: unknown) => this.#onError(pluginId, safeError(error))); };
@@ -689,7 +692,7 @@ export class PluginSdkBridge {
           check(caps.settings.listenAllowed(), "Microphone access for plugins is disabled in settings.");
           const options = isRecord(opts) ? opts : {};
           const timeoutMs = options.timeoutMs === undefined ? 10_000 : clampNumber(Number(options.timeoutMs), 1_000, 30_000);
-          return caps.voice.listen({ timeoutMs });
+          return caps.voice.listen({ timeoutMs, pluginId });
         },
       },
       auth: {
@@ -829,6 +832,7 @@ export class PluginSdkBridge {
   }
 
   clearPlugin(id: string): void {
+    this.#apiGenerations.set(id, (this.#apiGenerations.get(id) ?? 0) + 1);
     const state = this.#pluginState(id);
     for (const slot of state.schedules.values()) slot.handle.cancel();
     state.schedules.clear();

--- a/apps/desktop/src/plugin-service.ts
+++ b/apps/desktop/src/plugin-service.ts
@@ -147,7 +147,7 @@ export class PluginService {
         try {
           const safeInstall = await resolveSafePluginInstallDir(this.#userDataPath, id, stale.installPath, stale.source);
           this.stateStore.removeRecord(id);
-          this.#capabilities?.clearPlugin?.(id);
+          await this.#capabilities?.clearPlugin?.(id);
           await fs.rm(join(this.#userDataPath, "plugin-user-sounds", id), { recursive: true, force: true }).catch(() => undefined);
           await fs.rm(safeInstall, { recursive: true, force: true });
         } catch (error) {
@@ -168,8 +168,8 @@ export class PluginService {
     }
   }
 
-  stop(): void {
-    this.runtime.stop();
+  async stop(): Promise<void> {
+    await this.runtime.stop();
   }
 
   getLocalSourcePaths(): string[] {
@@ -299,7 +299,7 @@ export class PluginService {
     this.stateStore.removeRecord(id);
     if (record.source === "local" && record.sourcePath) this.#onLocalPluginSourceRemoved?.(record.sourcePath);
     await this.runtime.reloadPlugin(id);
-    try { this.#capabilities?.clearPlugin?.(id); await fs.rm(join(this.#userDataPath, "plugin-user-sounds", id), { recursive: true, force: true }); if (realInstall) await fs.rm(realInstall, { recursive: true, force: true }); await fs.rm(join(this.#userDataPath, "plugin-storage", `${id}.json`), { force: true }); }
+    try { await this.#capabilities?.clearPlugin?.(id); await fs.rm(join(this.#userDataPath, "plugin-user-sounds", id), { recursive: true, force: true }); if (realInstall) await fs.rm(realInstall, { recursive: true, force: true }); await fs.rm(join(this.#userDataPath, "plugin-storage", `${id}.json`), { force: true }); }
     catch (error) { return this.#error(safeError(error)); }
     return { ok: true, snapshot: await this.getSnapshot() };
   }
@@ -403,7 +403,7 @@ export class PluginService {
       if (!isDevRecord) continue;
       this.stateStore.removeRecord(record.id);
       await this.runtime.reloadPlugin(record.id);
-      this.#capabilities?.clearPlugin?.(record.id);
+      await this.#capabilities?.clearPlugin?.(record.id);
       await fs.rm(join(this.#userDataPath, "plugin-user-sounds", record.id), { recursive: true, force: true }).catch(() => undefined);
       await fs.rm(record.installPath, { recursive: true, force: true }).catch(() => undefined);
       await fs.rm(join(this.#userDataPath, "plugin-storage", `${record.id}.json`), { force: true }).catch(() => undefined);
@@ -602,8 +602,8 @@ export async function executeDefaultPetPluginMenuSelect(pluginId: string, itemId
   await appPluginService.runtime.executeMenuSelect(pluginId, itemId);
 }
 
-export function stopPluginService(): void {
-  appPluginService?.stop();
+export async function stopPluginService(): Promise<void> {
+  await appPluginService?.stop();
 }
 
 export function getPluginService(): PluginService {

--- a/apps/desktop/src/plugin-voice.ts
+++ b/apps/desktop/src/plugin-voice.ts
@@ -5,6 +5,7 @@ import { VoiceCaptureService } from "./voice-capture.js";
 import { createElectronVoiceCaptureFactory } from "./voice-capture-electron.js";
 import { createElectronVoicePrivacyIndicator } from "./voice-privacy-indicator-electron.js";
 import { VoiceListeningService } from "./voice-listening-service.js";
+import { VoiceOperationState, type VoiceOperationSnapshot } from "./voice-operation-state.js";
 
 /**
  * Plugin voice (§13.5). TTS speaks through the pet window's renderer
@@ -28,15 +29,26 @@ export function pluginVoiceStop(): void {
 let activeListeningService: VoiceListeningService | null = null;
 let activePluginId: string | undefined;
 let captureService: VoiceCaptureService | null = null;
+const voiceOperationState = new VoiceOperationState();
+
+export function getPluginVoiceOperation(): VoiceOperationSnapshot | null {
+  return voiceOperationState.snapshot();
+}
+
+export function subscribePluginVoiceOperation(listener: () => void): () => void {
+  return voiceOperationState.subscribe(listener);
+}
 
 export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeoutMs: number; pluginId?: string }): Promise<{ text: string }> {
   if (activeListeningService) throw new Error("A voice capture is already in progress.");
   const service = new VoiceListeningService(
     getCaptureService(),
     (capture, signal) => gateway.transcribe(capture.bytes, capture.mimeType, signal),
+    { onPhaseChange: (phase) => voiceOperationState.setPhase(phase) },
   );
   activeListeningService = service;
   activePluginId = opts.pluginId;
+  voiceOperationState.begin(() => service.cancel());
   try {
     return await service.listenOnce(opts.timeoutMs);
   } finally {
@@ -44,6 +56,7 @@ export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeou
       activeListeningService = null;
       activePluginId = undefined;
     }
+    voiceOperationState.settle();
   }
 }
 

--- a/apps/desktop/src/plugin-voice.ts
+++ b/apps/desktop/src/plugin-voice.ts
@@ -1,9 +1,10 @@
-import { BrowserWindow, session } from "electron";
-
 import { getDefaultPetWindowForPlugins } from "./default-pet-controller.js";
-import { debug } from "./logger.js";
 import { speakPetWindowTts, stopPetWindowTts } from "./pet-window.js";
 import type { PluginAiGateway } from "./plugin-ai-gateway.js";
+import { VoiceCaptureService } from "./voice-capture.js";
+import { createElectronVoiceCaptureFactory } from "./voice-capture-electron.js";
+import { createElectronVoicePrivacyIndicator } from "./voice-privacy-indicator-electron.js";
+import { VoiceListeningService } from "./voice-listening-service.js";
 
 /**
  * Plugin voice (§13.5). TTS speaks through the pet window's renderer
@@ -24,61 +25,45 @@ export function pluginVoiceStop(): void {
   if (window) stopPetWindowTts(window);
 }
 
-let listenInProgress = false;
+let activeListeningService: VoiceListeningService | null = null;
+let activePluginId: string | undefined;
+let captureService: VoiceCaptureService | null = null;
 
-export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeoutMs: number }): Promise<{ text: string }> {
-  if (listenInProgress) throw new Error("A voice capture is already in progress.");
-  listenInProgress = true;
+export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeoutMs: number; pluginId?: string }): Promise<{ text: string }> {
+  if (activeListeningService) throw new Error("A voice capture is already in progress.");
+  const service = new VoiceListeningService(
+    getCaptureService(),
+    (capture, signal) => gateway.transcribe(capture.bytes, capture.mimeType, signal),
+  );
+  activeListeningService = service;
+  activePluginId = opts.pluginId;
   try {
-    const audio = await captureMicrophoneClip(opts.timeoutMs);
-    const text = await gateway.transcribe(audio, "audio/webm");
-    return { text };
+    return await service.listenOnce(opts.timeoutMs);
   } finally {
-    listenInProgress = false;
+    if (activeListeningService === service) {
+      activeListeningService = null;
+      activePluginId = undefined;
+    }
   }
 }
 
-async function captureMicrophoneClip(timeoutMs: number): Promise<Uint8Array> {
-  const partition = `openpets-voice-capture:${Date.now()}`;
-  const captureSession = session.fromPartition(partition, { cache: false });
-  // The one and only session where the microphone is allowed, per capture.
-  captureSession.setPermissionRequestHandler((_contents, permission, callback) => callback(permission === "media"));
-  captureSession.setPermissionCheckHandler((_contents, permission) => permission === "media");
+export async function cancelPluginVoiceListen(pluginId?: string, reason = "Voice capture was cancelled."): Promise<void> {
+  if (!activeListeningService) return;
+  if (pluginId && activePluginId && activePluginId !== pluginId) return;
+  await activeListeningService.cancel(reason).catch(() => undefined);
+}
 
-  const window = new BrowserWindow({
-    show: false,
-    width: 1,
-    height: 1,
-    webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, partition },
-  });
-  try {
-    const html = `<!doctype html><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">`;
-    await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-    debug("plugin", "voice capture starting", { timeoutMs });
-    const base64 = await window.webContents.executeJavaScript(`(async () => {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const recorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
-      const chunks = [];
-      recorder.ondataavailable = (event) => { if (event.data.size > 0) chunks.push(event.data); };
-      const stopped = new Promise((resolve) => { recorder.onstop = resolve; });
-      recorder.start();
-      await new Promise((resolve) => setTimeout(resolve, ${Math.min(Math.max(timeoutMs, 1_000), 30_000)}));
-      recorder.stop();
-      await stopped;
-      for (const track of stream.getTracks()) track.stop();
-      const blob = new Blob(chunks, { type: "audio/webm" });
-      const buffer = await blob.arrayBuffer();
-      let binary = "";
-      const bytes = new Uint8Array(buffer);
-      for (let index = 0; index < bytes.length; index += 1) binary += String.fromCharCode(bytes[index]);
-      return btoa(binary);
-    })()`, true) as string;
-    const bytes = Buffer.from(base64, "base64");
-    if (bytes.byteLength < 128) throw new Error("Voice capture produced no audio.");
-    if (bytes.byteLength > 8 * 1024 * 1024) throw new Error("Voice capture is too large.");
-    return bytes;
-  } finally {
-    if (!window.isDestroyed()) window.destroy();
-    void captureSession.clearStorageData().catch(() => undefined);
+export async function shutdownPluginVoice(): Promise<void> {
+  if (activeListeningService) await activeListeningService.shutdown().catch(() => undefined);
+  else await captureService?.shutdown().catch(() => undefined);
+  activeListeningService = null;
+  activePluginId = undefined;
+}
+
+function getCaptureService(): VoiceCaptureService {
+  if (!captureService) {
+    const indicator = createElectronVoicePrivacyIndicator();
+    captureService = new VoiceCaptureService(createElectronVoiceCaptureFactory(), indicator);
   }
+  return captureService;
 }

--- a/apps/desktop/src/tray-voice-menu.ts
+++ b/apps/desktop/src/tray-voice-menu.ts
@@ -1,0 +1,15 @@
+import { t } from "./i18n/index.js";
+import type { VoiceOperationSnapshot } from "./voice-operation-state.js";
+
+export type TrayVoiceMenuItem = {
+  readonly label: string;
+  readonly click: () => void;
+};
+
+export function createVoiceMenuItems(operation: VoiceOperationSnapshot | null): TrayVoiceMenuItem[] {
+  if (!operation) return [];
+  return [{
+    label: operation.phase === "transcribing" ? t("tray.cancelVoiceTranscription") : t("tray.cancelVoiceListening"),
+    click: () => { void operation.cancel().catch(() => undefined); },
+  }];
+}

--- a/apps/desktop/src/tray.ts
+++ b/apps/desktop/src/tray.ts
@@ -8,9 +8,11 @@ import { quitOpenPets } from "./lifecycle.js";
 import { info, openLogsFolder } from "./logger.js";
 import { shellState, togglePaused } from "./state.js";
 import { getUpdateStatus, openUpdateReleasePage } from "./update-checker.js";
+import { getPluginVoiceOperation, subscribePluginVoiceOperation } from "./plugin-voice.js";
 import { openControlCenterWindow } from "./windows.js";
 
 let tray: Tray | null = null;
+let voiceOperationSubscriptionInstalled = false;
 
 export function createAppTray(): Tray {
   if (tray) {
@@ -19,6 +21,10 @@ export function createAppTray(): Tray {
 
   tray = new Tray(createTrayIcon());
   tray.setToolTip("OpenPets");
+  if (!voiceOperationSubscriptionInstalled) {
+    voiceOperationSubscriptionInstalled = true;
+    subscribePluginVoiceOperation(() => refreshTrayMenu());
+  }
   refreshTrayMenu();
   info("tray", "created");
   console.log("OpenPets tray created.");
@@ -42,6 +48,7 @@ export function refreshTrayMenu(): void {
     },
     ...createUpdateMenuItems(),
     { type: "separator" },
+    ...createVoiceMenuItems(),
     {
       label: t("tray.defaultPet", { name: defaultPetName }),
       click: () => openControlCenterWindow("pets"),
@@ -106,6 +113,15 @@ export function refreshTrayMenu(): void {
   ]);
 
   tray.setContextMenu(menu);
+}
+
+function createVoiceMenuItems(): MenuItemConstructorOptions[] {
+  const operation = getPluginVoiceOperation();
+  if (!operation) return [];
+  return [{
+    label: operation.phase === "transcribing" ? t("tray.cancelVoiceTranscription") : t("tray.cancelVoiceListening"),
+    click: () => { void operation.cancel().catch(() => undefined); },
+  }];
 }
 
 function createUpdateMenuItems(): MenuItemConstructorOptions[] {

--- a/apps/desktop/src/tray.ts
+++ b/apps/desktop/src/tray.ts
@@ -9,6 +9,7 @@ import { info, openLogsFolder } from "./logger.js";
 import { shellState, togglePaused } from "./state.js";
 import { getUpdateStatus, openUpdateReleasePage } from "./update-checker.js";
 import { getPluginVoiceOperation, subscribePluginVoiceOperation } from "./plugin-voice.js";
+import { createVoiceMenuItems } from "./tray-voice-menu.js";
 import { openControlCenterWindow } from "./windows.js";
 
 let tray: Tray | null = null;
@@ -48,7 +49,7 @@ export function refreshTrayMenu(): void {
     },
     ...createUpdateMenuItems(),
     { type: "separator" },
-    ...createVoiceMenuItems(),
+    ...createVoiceMenuItems(getPluginVoiceOperation()),
     {
       label: t("tray.defaultPet", { name: defaultPetName }),
       click: () => openControlCenterWindow("pets"),
@@ -113,15 +114,6 @@ export function refreshTrayMenu(): void {
   ]);
 
   tray.setContextMenu(menu);
-}
-
-function createVoiceMenuItems(): MenuItemConstructorOptions[] {
-  const operation = getPluginVoiceOperation();
-  if (!operation) return [];
-  return [{
-    label: operation.phase === "transcribing" ? t("tray.cancelVoiceTranscription") : t("tray.cancelVoiceListening"),
-    click: () => { void operation.cancel().catch(() => undefined); },
-  }];
 }
 
 function createUpdateMenuItems(): MenuItemConstructorOptions[] {

--- a/apps/desktop/src/voice-capture-cancellation.ts
+++ b/apps/desktop/src/voice-capture-cancellation.ts
@@ -1,0 +1,32 @@
+export const VOICE_RENDERER_CANCELLATION_TIMEOUT_MS = 500;
+
+export function createVoiceCaptureCancellation(
+  cancelRenderer: () => Promise<void>,
+  destroyWindow: () => void,
+  rendererCancellationTimeoutMs = VOICE_RENDERER_CANCELLATION_TIMEOUT_MS,
+): () => Promise<void> {
+  let cancellation: Promise<void> | null = null;
+  return () => {
+    if (!cancellation) {
+      cancellation = (async () => {
+        let rendererCancellation: Promise<void>;
+        try {
+          rendererCancellation = Promise.resolve(cancelRenderer()).catch(() => undefined);
+        } catch {
+          rendererCancellation = Promise.resolve();
+        }
+        let timeout: NodeJS.Timeout | undefined;
+        const timeoutPromise = new Promise<void>((resolve) => {
+          timeout = setTimeout(resolve, rendererCancellationTimeoutMs);
+        });
+        try {
+          await Promise.race([rendererCancellation, timeoutPromise]);
+        } finally {
+          if (timeout) clearTimeout(timeout);
+          try { destroyWindow(); } catch { /* the window may already be gone */ }
+        }
+      })();
+    }
+    return cancellation;
+  };
+}

--- a/apps/desktop/src/voice-capture-electron.ts
+++ b/apps/desktop/src/voice-capture-electron.ts
@@ -1,6 +1,10 @@
-import { BrowserWindow, session } from "electron";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { app, BrowserWindow, session } from "electron";
 
 import { debug } from "./logger.js";
+import { createVoiceCaptureCancellation } from "./voice-capture-cancellation.js";
 import {
   VOICE_MAX_AUDIO_BYTES,
   VOICE_MIN_AUDIO_BYTES,
@@ -10,7 +14,7 @@ import {
   type VoiceCaptureResult,
 } from "./voice-capture.js";
 
-const captureHtml = `<!doctype html><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">`;
+const VOICE_CAPTURE_PARTITION = "openpets-voice-capture";
 
 const acquireScript = `(async () => {
   const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -72,22 +76,21 @@ function recordScript(durationMs: number): string {
   })()`;
 }
 
-type ElectronCaptureAttempt = VoiceCaptureAttempt & {
-  readonly partition: string;
-};
-
 export function createElectronVoiceCaptureFactory(): VoiceCaptureFactory {
   return (durationMs, onLive) => {
-    const partition = `openpets-voice-capture:${Date.now()}:${Math.random().toString(36).slice(2)}`;
-    const captureSession = session.fromPartition(partition, { cache: false });
-    captureSession.setPermissionRequestHandler((_contents, permission, callback) => callback(permission === "media"));
-    captureSession.setPermissionCheckHandler((_contents, permission) => permission === "media");
+    const captureHtmlPath = join(app.getAppPath(), "assets", "voice-capture.html");
+    const captureUrl = pathToFileURL(captureHtmlPath).toString();
+    const captureSession = session.fromPartition(VOICE_CAPTURE_PARTITION, { cache: false });
+    captureSession.setPermissionRequestHandler((contents, permission, callback) => callback(permission === "media" && contents?.getURL() === captureUrl));
+    captureSession.setPermissionCheckHandler((contents, permission) => permission === "media" && contents?.getURL() === captureUrl);
     const window = new BrowserWindow({
       show: false,
       width: 1,
       height: 1,
-      webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, partition },
+      webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, partition: VOICE_CAPTURE_PARTITION },
     });
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.webContents.on("will-navigate", (event) => event.preventDefault());
     let cancelled = false;
     let disposed = false;
     let recording: VoiceCaptureRecording | null = null;
@@ -99,11 +102,14 @@ export function createElectronVoiceCaptureFactory(): VoiceCaptureFactory {
     const destroyWindow = (): void => {
       if (!window.isDestroyed()) window.destroy();
     };
+    const cancelCapture = createVoiceCaptureCancellation(async () => {
+      cancelled = true;
+      await execute<boolean>(cancelScript).catch(() => false);
+    }, destroyWindow);
 
-    const attempt: ElectronCaptureAttempt = {
-      partition,
+    const attempt: VoiceCaptureAttempt = {
       async acquire() {
-        await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(captureHtml)}`);
+        await window.loadFile(captureHtmlPath);
         const acquired = await execute<boolean>(acquireScript);
         if (!acquired || cancelled || !onLive()) {
           await attempt.cancel();
@@ -126,29 +132,19 @@ export function createElectronVoiceCaptureFactory(): VoiceCaptureFactory {
             await execute<boolean>(stopScript).catch(() => false);
             return recordingResult;
           },
-          cancel: async () => {
-            cancelled = true;
-            destroyWindow();
-            await execute<boolean>(cancelScript).catch(() => false);
-          },
-          close: async () => {
-            cancelled = true;
-            destroyWindow();
-            await execute<boolean>(cancelScript).catch(() => false);
-          },
+          cancel: cancelCapture,
+          close: cancelCapture,
         };
         return recording;
       },
       async cancel() {
-        cancelled = true;
-        destroyWindow();
-        await execute<boolean>(cancelScript).catch(() => false);
+        await cancelCapture();
         if (recording) await recording.cancel().catch(() => undefined);
       },
       async dispose() {
         if (disposed) return;
         disposed = true;
-        destroyWindow();
+        await cancelCapture();
         await captureSession.clearStorageData().catch(() => undefined);
       },
     };

--- a/apps/desktop/src/voice-capture-electron.ts
+++ b/apps/desktop/src/voice-capture-electron.ts
@@ -1,0 +1,157 @@
+import { BrowserWindow, session } from "electron";
+
+import { debug } from "./logger.js";
+import {
+  VOICE_MAX_AUDIO_BYTES,
+  VOICE_MIN_AUDIO_BYTES,
+  type VoiceCaptureAttempt,
+  type VoiceCaptureFactory,
+  type VoiceCaptureRecording,
+  type VoiceCaptureResult,
+} from "./voice-capture.js";
+
+const captureHtml = `<!doctype html><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">`;
+
+const acquireScript = `(async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  if (globalThis.__openPetsVoiceCaptureCancelled === true) {
+    for (const track of stream.getTracks()) track.stop();
+    return false;
+  }
+  const state = { stream, recorder: null, chunks: [], stopped: false, resolveStopped: null };
+  globalThis.__openPetsVoiceCapture = state;
+  return true;
+})()`;
+
+const cancelScript = `(() => {
+  globalThis.__openPetsVoiceCaptureCancelled = true;
+  const state = globalThis.__openPetsVoiceCapture;
+  if (state) {
+    state.cancelled = true;
+    if (state.recorder && state.recorder.state !== "inactive") state.recorder.stop();
+    for (const track of state.stream.getTracks()) track.stop();
+    state.resolveStopped?.();
+  }
+  return true;
+})()`;
+
+const stopScript = `(() => {
+  const state = globalThis.__openPetsVoiceCapture;
+  if (!state) return false;
+  if (state.recorder && state.recorder.state !== "inactive") state.recorder.stop();
+  else state.resolveStopped?.();
+  return true;
+})()`;
+
+function recordScript(durationMs: number): string {
+  return `(async () => {
+    const state = globalThis.__openPetsVoiceCapture;
+    if (!state || globalThis.__openPetsVoiceCaptureCancelled === true) return "";
+    const requestedMimeType = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "";
+    state.recorder = requestedMimeType ? new MediaRecorder(state.stream, { mimeType: requestedMimeType }) : new MediaRecorder(state.stream);
+    state.chunks = [];
+    const stopped = new Promise((resolve) => {
+      state.resolveStopped = resolve;
+      state.recorder.onstop = resolve;
+    });
+    state.recorder.ondataavailable = (event) => { if (event.data.size > 0) state.chunks.push(event.data); };
+    state.recorder.start();
+    const timer = setTimeout(() => {
+      if (state.recorder && state.recorder.state !== "inactive") state.recorder.stop();
+      else state.resolveStopped?.();
+    }, ${durationMs});
+    await stopped;
+    clearTimeout(timer);
+    for (const track of state.stream.getTracks()) track.stop();
+    if (state.cancelled || globalThis.__openPetsVoiceCaptureCancelled === true) return "";
+    const mimeType = state.recorder.mimeType || "audio/webm";
+    const bytes = new Uint8Array(await new Blob(state.chunks, { type: mimeType }).arrayBuffer());
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += 0x8000) binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+    return JSON.stringify({ base64: btoa(binary), mimeType });
+  })()`;
+}
+
+type ElectronCaptureAttempt = VoiceCaptureAttempt & {
+  readonly partition: string;
+};
+
+export function createElectronVoiceCaptureFactory(): VoiceCaptureFactory {
+  return (durationMs, onLive) => {
+    const partition = `openpets-voice-capture:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+    const captureSession = session.fromPartition(partition, { cache: false });
+    captureSession.setPermissionRequestHandler((_contents, permission, callback) => callback(permission === "media"));
+    captureSession.setPermissionCheckHandler((_contents, permission) => permission === "media");
+    const window = new BrowserWindow({
+      show: false,
+      width: 1,
+      height: 1,
+      webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, partition },
+    });
+    let cancelled = false;
+    let disposed = false;
+    let recording: VoiceCaptureRecording | null = null;
+
+    const execute = async <T>(script: string): Promise<T> => {
+      if (window.isDestroyed()) throw new Error("Voice capture window closed unexpectedly.");
+      return window.webContents.executeJavaScript(script, true) as Promise<T>;
+    };
+    const destroyWindow = (): void => {
+      if (!window.isDestroyed()) window.destroy();
+    };
+
+    const attempt: ElectronCaptureAttempt = {
+      partition,
+      async acquire() {
+        await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(captureHtml)}`);
+        const acquired = await execute<boolean>(acquireScript);
+        if (!acquired || cancelled || !onLive()) {
+          await attempt.cancel();
+          throw new Error("Voice capture was cancelled before microphone acquisition.");
+        }
+        debug("plugin", "voice microphone acquired", { durationMs });
+        const recordingResult = execute<string>(recordScript(durationMs)).then((encoded) => {
+          let payload: { base64?: unknown; mimeType?: unknown } = {};
+          try { payload = JSON.parse(encoded) as { base64?: unknown; mimeType?: unknown }; } catch { /* treat malformed output as empty audio */ }
+          const base64 = typeof payload.base64 === "string" ? payload.base64 : "";
+          const mimeType = typeof payload.mimeType === "string" && /^audio\/[A-Za-z0-9.+-]+(?:;[A-Za-z0-9=.+_-]+)*$/.test(payload.mimeType) ? payload.mimeType : "audio/webm";
+          const bytes = Buffer.from(base64, "base64");
+          if (bytes.byteLength < VOICE_MIN_AUDIO_BYTES) throw new Error("Voice capture produced no audio.");
+          if (bytes.byteLength > VOICE_MAX_AUDIO_BYTES) throw new Error("Voice capture is too large.");
+          return { bytes, mimeType } satisfies VoiceCaptureResult;
+        });
+        recording = {
+          result: recordingResult,
+          stop: async () => {
+            await execute<boolean>(stopScript).catch(() => false);
+            return recordingResult;
+          },
+          cancel: async () => {
+            cancelled = true;
+            destroyWindow();
+            await execute<boolean>(cancelScript).catch(() => false);
+          },
+          close: async () => {
+            cancelled = true;
+            destroyWindow();
+            await execute<boolean>(cancelScript).catch(() => false);
+          },
+        };
+        return recording;
+      },
+      async cancel() {
+        cancelled = true;
+        destroyWindow();
+        await execute<boolean>(cancelScript).catch(() => false);
+        if (recording) await recording.cancel().catch(() => undefined);
+      },
+      async dispose() {
+        if (disposed) return;
+        disposed = true;
+        destroyWindow();
+        await captureSession.clearStorageData().catch(() => undefined);
+      },
+    };
+    return attempt;
+  };
+}

--- a/apps/desktop/src/voice-capture.ts
+++ b/apps/desktop/src/voice-capture.ts
@@ -1,0 +1,259 @@
+import type { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
+
+export const VOICE_ACQUISITION_TIMEOUT_MS = 15_000;
+export const VOICE_MIN_RECORDING_DURATION_MS = 1_000;
+export const VOICE_MAX_RECORDING_DURATION_MS = 30_000;
+export const VOICE_MIN_AUDIO_BYTES = 128;
+export const VOICE_MAX_AUDIO_BYTES = 8 * 1024 * 1024;
+
+export type VoiceCaptureResult = {
+  readonly bytes: Uint8Array;
+  readonly mimeType: string;
+};
+
+export interface VoiceCaptureRecording {
+  readonly result: Promise<VoiceCaptureResult>;
+  stop(): Promise<VoiceCaptureResult>;
+  cancel(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface VoiceCaptureAttempt {
+  acquire(): Promise<VoiceCaptureRecording>;
+  cancel(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export type VoiceCaptureFactory = (durationMs: number, onAcquired: () => boolean) => VoiceCaptureAttempt;
+
+export class VoiceCaptureCancelledError extends Error {
+  constructor(message = "Voice capture was cancelled.") {
+    super(message);
+    this.name = "VoiceCaptureCancelledError";
+  }
+}
+
+type Deferred<T> = {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+};
+
+type ActiveCapture = {
+  attempt: VoiceCaptureAttempt;
+  readonly result: Deferred<VoiceCaptureResult>;
+  readonly done: Deferred<void>;
+  readonly rejectCancel: (error: unknown) => void;
+  readonly cancelPromise: Promise<never>;
+  recording?: VoiceCaptureRecording;
+  indicatorLive: boolean;
+  cancelled: boolean;
+  cancelError: Error | null;
+  acquisitionTimer: NodeJS.Timeout | null;
+  recordingTimer: NodeJS.Timeout | null;
+  finishing: Promise<VoiceCaptureResult> | null;
+  cleaned: boolean;
+};
+
+export type VoiceCaptureServiceOptions = {
+  readonly acquisitionTimeoutMs?: number;
+};
+
+export class VoiceCaptureService {
+  readonly #factory: VoiceCaptureFactory;
+  readonly #indicator: VoicePrivacyIndicator;
+  readonly #acquisitionTimeoutMs: number;
+  #active: ActiveCapture | null = null;
+
+  constructor(factory: VoiceCaptureFactory, indicator: VoicePrivacyIndicator, options: VoiceCaptureServiceOptions = {}) {
+    this.#factory = factory;
+    this.#indicator = indicator;
+    this.#acquisitionTimeoutMs = options.acquisitionTimeoutMs ?? VOICE_ACQUISITION_TIMEOUT_MS;
+  }
+
+  async start(timeoutMs: number): Promise<{
+    readonly result: Promise<VoiceCaptureResult>;
+    stop(): Promise<VoiceCaptureResult>;
+    cancel(reason?: string): Promise<void>;
+  }> {
+    if (this.#active) throw new Error("A voice capture is already in progress.");
+
+    const durationMs = normalizeRecordingDuration(timeoutMs);
+    const result = deferred<VoiceCaptureResult>();
+    const done = deferred<void>();
+    let rejectCancel!: (error: unknown) => void;
+    const cancelPromise = new Promise<never>((_resolve, reject) => { rejectCancel = reject; });
+    const active: ActiveCapture = {
+      attempt: undefined as unknown as VoiceCaptureAttempt,
+      result,
+      done,
+      rejectCancel,
+      cancelPromise,
+      indicatorLive: false,
+      cancelled: false,
+      cancelError: null,
+      acquisitionTimer: null,
+      recordingTimer: null,
+      finishing: null,
+      cleaned: false,
+    };
+
+    try {
+      active.attempt = this.#factory(durationMs, () => {
+        if (active.cancelled || this.#active !== active) return false;
+        active.indicatorLive = true;
+        this.#indicator.trackStarted();
+        return true;
+      });
+    } catch (error) {
+      done.resolve(undefined);
+      throw normalizeError(error);
+    }
+    this.#active = active;
+    // The promise is intentionally kept rejected on failed acquisition, so make
+    // its rejection observed even when no capture handle reaches the caller.
+    void result.promise.catch(() => undefined);
+
+    const acquisition = Promise.resolve().then(() => active.attempt.acquire());
+    void acquisition.then((recording) => {
+      if (active.cancelled || this.#active !== active) {
+        void recording.cancel().catch(() => undefined);
+        void recording.close().catch(() => undefined);
+      }
+    }).catch(() => undefined);
+
+    try {
+      active.acquisitionTimer = setTimeout(() => {
+        this.#requestCancel(active, new Error("Microphone acquisition timed out."));
+      }, this.#acquisitionTimeoutMs);
+
+      const recording = await Promise.race([acquisition, active.cancelPromise]);
+      if (active.cancelled) throw active.cancelError ?? new VoiceCaptureCancelledError();
+      if (active.acquisitionTimer) clearTimeout(active.acquisitionTimer);
+      active.acquisitionTimer = null;
+      active.recording = recording;
+      active.recordingTimer = setTimeout(() => {
+        this.#requestCancel(active, new Error("Voice recording timed out."));
+        void this.#finish(active, { kind: "cancel" }).catch(() => undefined);
+      }, durationMs + 1_000);
+      active.recordingTimer.unref?.();
+
+      void recording.result.then(
+        (capture) => { void this.#finish(active, { kind: "result", capture }).catch(() => undefined); },
+        (error: unknown) => { void this.#finish(active, { kind: "error", error }).catch(() => undefined); },
+      );
+
+      return {
+        result: result.promise,
+        stop: () => this.#finish(active, { kind: "stop" }),
+        cancel: (reason = "Voice capture was cancelled.") => this.#cancelHandle(active, reason),
+      };
+    } catch (error) {
+      await this.#cleanup(active);
+      throw normalizeError(error);
+    }
+  }
+
+  async captureOneShot(timeoutMs: number): Promise<VoiceCaptureResult> {
+    const handle = await this.start(timeoutMs);
+    return handle.result;
+  }
+
+  async cancelActive(reason = "Voice capture was cancelled."): Promise<void> {
+    const active = this.#active;
+    if (!active) return;
+    this.#requestCancel(active, new VoiceCaptureCancelledError(reason));
+    if (active.recording) void this.#finish(active, { kind: "cancel" }).catch(() => undefined);
+    await active.done.promise;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.cancelActive("OpenPets is shutting down.");
+    this.#indicator.shutdown();
+  }
+
+  #requestCancel(active: ActiveCapture, error: Error): void {
+    if (active.cancelled) return;
+    active.cancelled = true;
+    active.cancelError = error;
+    active.rejectCancel(error);
+    if (!active.recording) void active.attempt.cancel().catch(() => undefined);
+  }
+
+  async #cancelHandle(active: ActiveCapture, reason: string): Promise<void> {
+    this.#requestCancel(active, new VoiceCaptureCancelledError(reason));
+    if (active.recording) void this.#finish(active, { kind: "cancel" }).catch(() => undefined);
+    await active.done.promise;
+  }
+
+  #finish(active: ActiveCapture, outcome: { kind: "result"; capture: VoiceCaptureResult } | { kind: "error"; error: unknown } | { kind: "stop" } | { kind: "cancel" }): Promise<VoiceCaptureResult> {
+    if (active.finishing) return active.finishing;
+    active.finishing = (async () => {
+      let capture: VoiceCaptureResult | undefined;
+      let failure: Error | undefined;
+      try {
+        if (active.cancelled || outcome.kind === "cancel") {
+          await active.recording?.cancel().catch(() => undefined);
+          throw active.cancelError ?? new VoiceCaptureCancelledError();
+        }
+        if (outcome.kind === "error") throw normalizeError(outcome.error);
+        capture = outcome.kind === "result" || outcome.kind === "stop"
+          ? outcome.kind === "result" ? outcome.capture : await active.recording!.stop()
+          : undefined;
+        if (!capture) throw new Error("Voice capture produced no audio.");
+        if (active.cancelled) throw active.cancelError ?? new VoiceCaptureCancelledError();
+      } catch (error) {
+        failure = normalizeError(error);
+      }
+      await this.#cleanup(active);
+      if (failure) {
+        active.result.reject(failure);
+        throw failure;
+      }
+      if (!capture) {
+        const missing = new Error("Voice capture produced no audio.");
+        active.result.reject(missing);
+        throw missing;
+      }
+      active.result.resolve(capture);
+      return capture;
+    })();
+    return active.finishing;
+  }
+
+  async #cleanup(active: ActiveCapture): Promise<void> {
+    if (active.cleaned) return active.done.promise;
+    active.cleaned = true;
+    if (active.acquisitionTimer) clearTimeout(active.acquisitionTimer);
+    active.acquisitionTimer = null;
+    if (active.recordingTimer) clearTimeout(active.recordingTimer);
+    active.recordingTimer = null;
+    try {
+      await active.recording?.close().catch(() => undefined);
+      await active.attempt.cancel().catch(() => undefined);
+      await active.attempt.dispose().catch(() => undefined);
+    } finally {
+      if (active.indicatorLive) {
+        active.indicatorLive = false;
+        this.#indicator.trackStopped();
+      }
+      if (this.#active === active) this.#active = null;
+      active.done.resolve(undefined);
+    }
+  }
+}
+
+export function normalizeRecordingDuration(timeoutMs: number): number {
+  return Math.min(VOICE_MAX_RECORDING_DURATION_MS, Math.max(VOICE_MIN_RECORDING_DURATION_MS, Math.round(timeoutMs)));
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolveValue!: (value: T) => void;
+  let rejectValue!: (error: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => { resolveValue = resolve; rejectValue = reject; });
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/desktop/src/voice-listening-service.ts
+++ b/apps/desktop/src/voice-listening-service.ts
@@ -1,0 +1,142 @@
+import type { VoiceCaptureResult, VoiceCaptureService } from "./voice-capture.js";
+
+export const VOICE_TRANSCRIPTION_TIMEOUT_MS = 30_000;
+export const VOICE_EMPTY_TRANSCRIPT_ERROR = "Voice transcription returned no text.";
+export const VOICE_TRANSCRIPTION_TIMEOUT_ERROR = "Voice transcription timed out. Try again.";
+export const VOICE_TRANSCRIPTION_CANCELLED_ERROR = "Voice transcription was cancelled.";
+export const VOICE_CAPTURE_CANCELLED_ERROR = "Voice capture was cancelled.";
+
+export type VoiceTranscriber = (capture: VoiceCaptureResult, signal: AbortSignal) => Promise<string>;
+
+type Deferred<T> = {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+};
+
+type ActiveListen = {
+  readonly done: Deferred<void>;
+  readonly rejectCancel: (error: unknown) => void;
+  readonly cancelPromise: Promise<never>;
+  capturePhase: "acquisition" | "recording" | "transcription";
+  cancelled: boolean;
+  cancelError: Error | null;
+  transcriptionController: AbortController | null;
+  transcriptionTimedOut: boolean;
+};
+
+export type VoiceListeningServiceOptions = {
+  readonly transcriptionTimeoutMs?: number;
+};
+
+export class VoiceListeningService {
+  readonly #capture: VoiceCaptureService;
+  readonly #transcriber: VoiceTranscriber;
+  readonly #transcriptionTimeoutMs: number;
+  #active: ActiveListen | null = null;
+
+  constructor(capture: VoiceCaptureService, transcriber: VoiceTranscriber, options: VoiceListeningServiceOptions = {}) {
+    this.#capture = capture;
+    this.#transcriber = transcriber;
+    this.#transcriptionTimeoutMs = options.transcriptionTimeoutMs ?? VOICE_TRANSCRIPTION_TIMEOUT_MS;
+  }
+
+  listenOnce(recordingDurationMs: number): Promise<{ text: string }> {
+    if (this.#active) throw new Error("A voice capture is already in progress.");
+    const done = deferred<void>();
+    let rejectCancel!: (error: unknown) => void;
+    const cancelPromise = new Promise<never>((_resolve, reject) => { rejectCancel = reject; });
+    const active: ActiveListen = {
+      done,
+      rejectCancel,
+      cancelPromise,
+      capturePhase: "acquisition" as const,
+      cancelled: false,
+      cancelError: null,
+      transcriptionController: null,
+      transcriptionTimedOut: false,
+    };
+    this.#active = active;
+    const run = this.#run(active, recordingDurationMs).finally(async () => {
+      await this.#capture.cancelActive(active.cancelError?.message ?? "Voice listening finished.").catch(() => undefined);
+      if (this.#active === active) this.#active = null;
+      active.done.resolve(undefined);
+    });
+    return run;
+  }
+
+  async cancel(reason = VOICE_CAPTURE_CANCELLED_ERROR): Promise<void> {
+    const active = this.#active;
+    if (!active) return;
+    if (!active.cancelled) {
+      active.cancelled = true;
+      active.cancelError = new Error(active.capturePhase === "transcription" ? VOICE_TRANSCRIPTION_CANCELLED_ERROR : reason);
+      active.rejectCancel(active.cancelError);
+      active.transcriptionController?.abort();
+    }
+    await this.#capture.cancelActive(reason).catch(() => undefined);
+    await active.done.promise;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.cancel("OpenPets is shutting down.");
+    await this.#capture.shutdown();
+  }
+
+  async #run(active: ActiveListen, recordingDurationMs: number): Promise<{ text: string }> {
+    try {
+      const startPromise = this.#capture.start(recordingDurationMs);
+      void startPromise.catch(() => undefined);
+      const handle = await Promise.race([startPromise, active.cancelPromise]);
+      active.capturePhase = "recording";
+      const capturePromise = handle.result;
+      void capturePromise.catch(() => undefined);
+      const capture = await Promise.race([capturePromise, active.cancelPromise]);
+
+      active.capturePhase = "transcription";
+      const controller = new AbortController();
+      active.transcriptionController = controller;
+      let timeout: NodeJS.Timeout | null = null;
+      const transcriptionPromise = Promise.resolve().then(() => this.#transcriber(capture, controller.signal));
+      void transcriptionPromise.catch(() => undefined);
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          active.transcriptionTimedOut = true;
+          controller.abort();
+          reject(new Error(VOICE_TRANSCRIPTION_TIMEOUT_ERROR));
+        }, this.#transcriptionTimeoutMs);
+      });
+      try {
+        const raw = await Promise.race([transcriptionPromise, active.cancelPromise, timeoutPromise]);
+        if (active.cancelled) throw active.cancelError ?? new Error(VOICE_TRANSCRIPTION_CANCELLED_ERROR);
+        if (controller.signal.aborted) throw new Error(VOICE_TRANSCRIPTION_TIMEOUT_ERROR);
+        const text = raw.trim();
+        if (!text) throw new Error(VOICE_EMPTY_TRANSCRIPT_ERROR);
+        return { text };
+      } finally {
+        if (timeout) clearTimeout(timeout);
+        active.transcriptionController = null;
+      }
+    } catch (error) {
+      if (active.cancelled) throw active.cancelError ?? new Error(VOICE_CAPTURE_CANCELLED_ERROR);
+      if (active.transcriptionTimedOut) throw new Error(VOICE_TRANSCRIPTION_TIMEOUT_ERROR);
+      if (isAbortError(error)) throw new Error(VOICE_TRANSCRIPTION_CANCELLED_ERROR);
+      throw normalizeError(error);
+    }
+  }
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolveValue!: (value: T) => void;
+  let rejectValue!: (error: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => { resolveValue = resolve; rejectValue = reject; });
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}

--- a/apps/desktop/src/voice-listening-service.ts
+++ b/apps/desktop/src/voice-listening-service.ts
@@ -7,6 +7,7 @@ export const VOICE_TRANSCRIPTION_CANCELLED_ERROR = "Voice transcription was canc
 export const VOICE_CAPTURE_CANCELLED_ERROR = "Voice capture was cancelled.";
 
 export type VoiceTranscriber = (capture: VoiceCaptureResult, signal: AbortSignal) => Promise<string>;
+export type VoiceListeningPhase = "acquiring" | "recording" | "transcribing";
 
 type Deferred<T> = {
   readonly promise: Promise<T>;
@@ -27,18 +28,21 @@ type ActiveListen = {
 
 export type VoiceListeningServiceOptions = {
   readonly transcriptionTimeoutMs?: number;
+  readonly onPhaseChange?: (phase: VoiceListeningPhase) => void;
 };
 
 export class VoiceListeningService {
   readonly #capture: VoiceCaptureService;
   readonly #transcriber: VoiceTranscriber;
   readonly #transcriptionTimeoutMs: number;
+  readonly #onPhaseChange?: (phase: VoiceListeningPhase) => void;
   #active: ActiveListen | null = null;
 
   constructor(capture: VoiceCaptureService, transcriber: VoiceTranscriber, options: VoiceListeningServiceOptions = {}) {
     this.#capture = capture;
     this.#transcriber = transcriber;
     this.#transcriptionTimeoutMs = options.transcriptionTimeoutMs ?? VOICE_TRANSCRIPTION_TIMEOUT_MS;
+    this.#onPhaseChange = options.onPhaseChange;
   }
 
   listenOnce(recordingDurationMs: number): Promise<{ text: string }> {
@@ -57,6 +61,7 @@ export class VoiceListeningService {
       transcriptionTimedOut: false,
     };
     this.#active = active;
+    this.#onPhaseChange?.("acquiring");
     const run = this.#run(active, recordingDurationMs).finally(async () => {
       await this.#capture.cancelActive(active.cancelError?.message ?? "Voice listening finished.").catch(() => undefined);
       if (this.#active === active) this.#active = null;
@@ -89,11 +94,13 @@ export class VoiceListeningService {
       void startPromise.catch(() => undefined);
       const handle = await Promise.race([startPromise, active.cancelPromise]);
       active.capturePhase = "recording";
+      this.#onPhaseChange?.("recording");
       const capturePromise = handle.result;
       void capturePromise.catch(() => undefined);
       const capture = await Promise.race([capturePromise, active.cancelPromise]);
 
       active.capturePhase = "transcription";
+      this.#onPhaseChange?.("transcribing");
       const controller = new AbortController();
       active.transcriptionController = controller;
       let timeout: NodeJS.Timeout | null = null;

--- a/apps/desktop/src/voice-operation-state.ts
+++ b/apps/desktop/src/voice-operation-state.ts
@@ -1,0 +1,45 @@
+export type VoiceOperationPhase = "acquiring" | "recording" | "transcribing";
+
+export type VoiceOperationSnapshot = {
+  readonly phase: VoiceOperationPhase;
+  readonly cancel: () => Promise<void>;
+};
+
+export class VoiceOperationState {
+  #operation: { phase: VoiceOperationPhase; cancel: () => Promise<void> } | null = null;
+  readonly #listeners = new Set<() => void>();
+
+  begin(cancel: () => Promise<void>): void {
+    if (this.#operation) throw new Error("A voice operation is already in progress.");
+    this.#operation = { phase: "acquiring", cancel };
+    this.#notify();
+  }
+
+  setPhase(phase: VoiceOperationPhase): void {
+    if (!this.#operation || this.#operation.phase === phase) return;
+    this.#operation.phase = phase;
+    this.#notify();
+  }
+
+  settle(): void {
+    if (!this.#operation) return;
+    this.#operation = null;
+    this.#notify();
+  }
+
+  snapshot(): VoiceOperationSnapshot | null {
+    if (!this.#operation) return null;
+    return { phase: this.#operation.phase, cancel: this.#operation.cancel };
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  #notify(): void {
+    for (const listener of this.#listeners) {
+      try { listener(); } catch { /* host observers must not affect voice cleanup */ }
+    }
+  }
+}

--- a/apps/desktop/src/voice-privacy-indicator-electron.ts
+++ b/apps/desktop/src/voice-privacy-indicator-electron.ts
@@ -1,0 +1,79 @@
+import { BrowserWindow } from "electron";
+
+import { createAppIcon } from "./assets.js";
+import { debug } from "./logger.js";
+import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "./voice-privacy-indicator.js";
+
+const indicatorHtml = `<!doctype html><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><style>html,body{margin:0;background:transparent;font:600 13px system-ui;color:white}.badge{margin:4px;padding:9px 13px;border-radius:18px;background:rgba(153,27,27,.94);box-shadow:0 4px 18px rgba(0,0,0,.25)}.dot{display:inline-block;width:9px;height:9px;border-radius:50%;background:#fecaca;margin-right:8px}</style><div class="badge"><span class="dot"></span>OpenPets is listening</div>`;
+
+class ElectronVoicePrivacyIndicatorSurface implements VoicePrivacyIndicatorSurface {
+  #window: BrowserWindow | null = null;
+  #visible = false;
+  #topmostTimer: NodeJS.Timeout | null = null;
+
+  show(): void {
+    this.#visible = true;
+    let window = this.#window;
+    if (!window || window.isDestroyed()) {
+      const created = new BrowserWindow({
+        width: 176,
+        height: 42,
+        show: false,
+        frame: false,
+        transparent: true,
+        resizable: false,
+        focusable: false,
+        skipTaskbar: true,
+        alwaysOnTop: true,
+        icon: createAppIcon(),
+        webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true },
+      });
+      created.setAlwaysOnTop(true, process.platform === "linux" ? "screen-saver" : "floating");
+      created.setIgnoreMouseEvents(true);
+      if (process.platform === "darwin") created.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+      else if (process.platform === "linux") created.setVisibleOnAllWorkspaces(true);
+      created.once("closed", () => {
+        this.#window = null;
+        this.#visible = false;
+        if (this.#topmostTimer) clearInterval(this.#topmostTimer);
+        this.#topmostTimer = null;
+      });
+      this.#window = created;
+      window = created;
+      void created.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(indicatorHtml)}`).then(() => {
+        if (this.#visible && this.#window === created && !created.isDestroyed()) created.showInactive();
+      }).catch(() => undefined);
+    }
+    if (!this.#topmostTimer) {
+      this.#topmostTimer = setInterval(() => {
+        if (!this.#visible || !this.#window || this.#window.isDestroyed()) return;
+        this.#window.setAlwaysOnTop(false);
+        this.#window.setAlwaysOnTop(true, process.platform === "linux" ? "screen-saver" : "floating");
+      }, 1_000);
+      this.#topmostTimer.unref?.();
+    }
+    if (window && !window.isDestroyed()) window.showInactive();
+    debug("app", "voice privacy indicator shown");
+  }
+
+  hide(): void {
+    this.#visible = false;
+    if (this.#topmostTimer) clearInterval(this.#topmostTimer);
+    this.#topmostTimer = null;
+    if (this.#window && !this.#window.isDestroyed()) this.#window.hide();
+    debug("app", "voice privacy indicator hidden");
+  }
+
+  destroy(): void {
+    const window = this.#window;
+    this.#window = null;
+    this.#visible = false;
+    if (this.#topmostTimer) clearInterval(this.#topmostTimer);
+    this.#topmostTimer = null;
+    if (window && !window.isDestroyed()) window.destroy();
+  }
+}
+
+export function createElectronVoicePrivacyIndicator(): VoicePrivacyIndicator {
+  return new VoicePrivacyIndicator(() => new ElectronVoicePrivacyIndicatorSurface());
+}

--- a/apps/desktop/src/voice-privacy-indicator.ts
+++ b/apps/desktop/src/voice-privacy-indicator.ts
@@ -1,0 +1,46 @@
+export interface VoicePrivacyIndicatorSurface {
+  show(): void;
+  hide(): void;
+  destroy(): void;
+}
+
+/** Tracks live microphone ownership without coupling lifecycle tests to Electron. */
+export class VoicePrivacyIndicator {
+  readonly #createSurface: () => VoicePrivacyIndicatorSurface;
+  #surface: VoicePrivacyIndicatorSurface | null = null;
+  #liveTracks = 0;
+
+  constructor(createSurface: () => VoicePrivacyIndicatorSurface) {
+    this.#createSurface = createSurface;
+  }
+
+  get liveTracks(): number {
+    return this.#liveTracks;
+  }
+
+  trackStarted(): void {
+    this.#liveTracks += 1;
+    if (this.#liveTracks !== 1) return;
+    try {
+      this.#surface ??= this.#createSurface();
+      this.#surface.show();
+    } catch {
+      // A privacy surface must not prevent microphone cleanup or transcription.
+    }
+  }
+
+  trackStopped(): void {
+    if (this.#liveTracks === 0) return;
+    this.#liveTracks -= 1;
+    if (this.#liveTracks !== 0) return;
+    try { this.#surface?.hide(); } catch { /* best effort */ }
+  }
+
+  shutdown(): void {
+    this.#liveTracks = 0;
+    const surface = this.#surface;
+    this.#surface = null;
+    if (!surface) return;
+    try { surface.destroy(); } catch { /* best effort */ }
+  }
+}

--- a/apps/desktop/tests/plugin-ai-gateway.test.ts
+++ b/apps/desktop/tests/plugin-ai-gateway.test.ts
@@ -20,6 +20,9 @@ try {
   const gateway = new PluginAiGateway(secrets);
   globalThis.fetch = async (input, init) => {
     fetchCalls.push({ input, init });
+    if (String(input).includes("/audio/transcriptions")) {
+      return new Response(JSON.stringify({ text: "transcribed" }), { status: 200 });
+    }
     return new Response(JSON.stringify({ choices: [{ message: { content: "MiniMax says hello" } }] }), { status: 200 });
   };
 
@@ -44,6 +47,13 @@ try {
     },
   );
   assert.equal(fetchCalls.length, 0);
+
+  updatePluginPlatformSettings({ ai: { provider: "openai", model: "" } });
+  fetchCalls.length = 0;
+  const controller = new AbortController();
+  assert.equal(await gateway.transcribe(new Uint8Array([1, 2, 3]), "audio/webm", controller.signal), "transcribed");
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0]?.init?.signal, controller.signal);
 } finally {
   globalThis.fetch = previousFetch;
   updatePluginPlatformSettings(previousSettings);

--- a/apps/desktop/tests/plugin-runtime.test.ts
+++ b/apps/desktop/tests/plugin-runtime.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { OPENPETS_PLUGIN_MANIFEST_FILENAME, type OpenPetsDeclarativePluginManifest, type OpenPetsJavascriptPluginManifest } from "../src/plugin-manifest.js";
 import { type PluginPetApi } from "../src/plugin-pet-api.js";
 import { PluginRuntime, type PluginRuntimeScheduler, type PluginTimerHandle } from "../src/plugin-runtime.js";
+import { createDefaultPluginHostCapabilities } from "../src/plugin-sdk-bridge.js";
 import type { PluginJsHost, PluginJsHostInstance, PluginJsHostStartOptions } from "../src/plugin-js-host.js";
 import { initializePluginState, type PluginStateStore, type PluginStateRecord } from "../src/plugin-state.js";
 
@@ -265,6 +266,39 @@ await scenario("javascript stop cancels host", async ({ store }) => {
   assert.equal(jsHost.instances[0].stopped, true);
 });
 
+await scenario("stop drains in-flight javascript startup", async ({ store }) => {
+  addPlugin(store, { manifestVersion: 3, runtime: "javascript", sdkVersion: "3.0.0", approvedPermissions: ["voice:listen"] }, jsManifest({ manifestVersion: 3, sdkVersion: "3.0.0", permissions: ["voice:listen"] }));
+  let releaseStart!: () => void;
+  let startupStarted!: () => void;
+  let hostStopped = false;
+  let voiceCalls = 0;
+  let staleVoiceError = "";
+  const startup = new Promise<void>((resolve) => { startupStarted = resolve; });
+  const startGate = new Promise<void>((resolve) => { releaseStart = resolve; });
+  const capabilities = createDefaultPluginHostCapabilities(new FakePetApi());
+  capabilities.settings = { ...capabilities.settings, listenAllowed: () => true };
+  capabilities.voice = { ...capabilities.voice, listen: async () => { voiceCalls += 1; return { text: "late" }; } };
+  const jsHost: PluginJsHost = {
+    async startPlugin(options) {
+      startupStarted();
+      await startGate;
+      await options.sdk?.voice.listen({ timeoutMs: 1_000 }).catch((error: unknown) => { staleVoiceError = error instanceof Error ? error.message : String(error); });
+      return { stop: () => { hostStopped = true; } };
+    },
+  };
+  const rt = new PluginRuntime({ stateStore: store, petApi: new FakePetApi(), scheduler: new FakeScheduler(), allowedPluginRoots: [currentRoot], jsHost, capabilities });
+  const start = rt.start();
+  await startup;
+  let stopSettled = false;
+  const stop = rt.stop().then(() => { stopSettled = true; });
+  assert.equal(stopSettled, false);
+  releaseStart();
+  await Promise.all([start, stop]);
+  assert.equal(voiceCalls, 0);
+  assert.equal(staleVoiceError, "Plugin is no longer active.");
+  assert.equal(hostStopped, true);
+});
+
 await scenario("javascript startup failure marks broken", async ({ store }) => {
   const jsHost = new FakeJsHost();
   jsHost.fail = true;
@@ -384,6 +418,48 @@ await scenario("reload cancels stale timer", async ({ store, scheduler, petApi }
   scheduler.fire(1);
   await Promise.resolve();
   assert.deepEqual(petApi.events, ["speak:Stretch"]);
+});
+
+await scenario("reload waits for host teardown", async ({ store, scheduler }) => {
+  addPlugin(store);
+  let blockTeardown = false;
+  let releaseTeardown!: () => void;
+  let teardownStartedResolve!: () => void;
+  const teardownStarted = new Promise<void>((resolve) => { teardownStartedResolve = resolve; });
+  const capabilities = createDefaultPluginHostCapabilities(new FakePetApi());
+  (capabilities as { clearPlugin?: () => Promise<void> }).clearPlugin = () => blockTeardown ? new Promise<void>((resolve) => { teardownStartedResolve(); releaseTeardown = resolve; }) : Promise.resolve();
+  const rt = new PluginRuntime({ stateStore: store, petApi: new FakePetApi(), scheduler, allowedPluginRoots: [currentRoot], capabilities });
+  await rt.start();
+  blockTeardown = true;
+
+  const reload = rt.reloadPlugin("plug");
+  await teardownStarted;
+  assert.equal(scheduler.activeCount(), 0);
+  releaseTeardown();
+  await reload;
+  assert.equal(scheduler.activeCount(), 1);
+});
+
+await scenario("concurrent reloads are serialized", async ({ store, scheduler }) => {
+  addPlugin(store);
+  let blockTeardown = false;
+  let releaseTeardown!: () => void;
+  let teardownStartedResolve!: () => void;
+  const teardownStarted = new Promise<void>((resolve) => { teardownStartedResolve = resolve; });
+  const capabilities = createDefaultPluginHostCapabilities(new FakePetApi());
+  (capabilities as { clearPlugin?: () => Promise<void> }).clearPlugin = () => blockTeardown ? new Promise<void>((resolve) => { teardownStartedResolve(); releaseTeardown = resolve; }) : Promise.resolve();
+  const rt = new PluginRuntime({ stateStore: store, petApi: new FakePetApi(), scheduler, allowedPluginRoots: [currentRoot], capabilities });
+  await rt.start();
+  blockTeardown = true;
+
+  const first = rt.reloadPlugin("plug");
+  const second = rt.reloadPlugin("plug");
+  await teardownStarted;
+  assert.equal(scheduler.activeCount(), 0);
+  releaseTeardown();
+  blockTeardown = false;
+  await Promise.all([first, second]);
+  assert.equal(scheduler.activeCount(), 1);
 });
 
 await scenario("path outside install/root and oversized rejected", async ({ root, store }) => {

--- a/apps/desktop/tests/tray-voice.test.ts
+++ b/apps/desktop/tests/tray-voice.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+
+import { createVoiceMenuItems } from "../src/tray-voice-menu.js";
+import { VoiceOperationState } from "../src/voice-operation-state.js";
+
+const state = new VoiceOperationState();
+const menu = () => createVoiceMenuItems(state.snapshot());
+
+assert.deepEqual(menu(), [], "no voice menu item should appear without an active operation");
+
+let cancelCount = 0;
+state.begin(async () => { cancelCount += 1; });
+assert.equal(menu()[0]?.label, "Stop microphone listening", "acquisition should offer microphone cancellation");
+
+state.setPhase("recording");
+assert.equal(menu()[0]?.label, "Stop microphone listening", "recording should offer microphone cancellation");
+
+state.setPhase("transcribing");
+assert.equal(menu()[0]?.label, "Cancel transcription", "transcription should offer transcription cancellation");
+
+menu()[0]?.click();
+assert.equal(cancelCount, 1, "clicking the voice menu item should cancel once");
+
+state.settle();
+assert.deepEqual(menu(), [], "settling should remove the voice menu item");
+
+console.log("Tray voice cancellation behavior verified.");

--- a/apps/desktop/tests/voice-bridge.test.ts
+++ b/apps/desktop/tests/voice-bridge.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PluginSdkBridge, type PluginHostCapabilities } from "../src/plugin-sdk-bridge.js";
+import type { OpenPetsJavascriptPluginManifest } from "../src/plugin-manifest.js";
+import { PluginStateStore, type PluginStateRecord } from "../src/plugin-state.js";
+import { pluginSdkQuotas } from "../src/plugin-sdk-quotas.js";
+
+const root = mkdtempSync(join(tmpdir(), "openpets-voice-bridge-"));
+try {
+  const store = new PluginStateStore({ statePath: join(root, "state.json") });
+  store.initialize();
+  const record: PluginStateRecord = {
+    id: "plug",
+    version: "1.0.0",
+    manifestPath: join(root, "openpets.plugin.json"),
+    installPath: root,
+    source: "local",
+    manifestVersion: 3,
+    runtime: "javascript",
+    sdkVersion: "3.0.0",
+    enabled: true,
+    approvedPermissions: ["voice:listen"],
+    config: {},
+  };
+  store.upsertRecord(record);
+  const requests: Array<{ timeoutMs?: number; pluginId?: string }> = [];
+  const capabilities = createCapabilities(requests);
+  const bridge = new PluginSdkBridge({
+    stateStore: store,
+    petApi: { speak() {}, react() {}, moveBy() {}, wander() {}, moveToHome() {} },
+    scheduler: { setTimeout: () => ({ cancel() {} }) },
+    capabilities,
+  });
+  const api = bridge.createApi(record, manifest(["voice:listen"]));
+  const unapproved = bridge.createApi(record, manifest([]));
+
+  await assert.rejects(() => unapproved.voice.listen({ timeoutMs: 5_000 }), /voice:listen/);
+  capabilities.settings.listenAllowed = () => false;
+  await assert.rejects(() => api.voice.listen({ timeoutMs: 5_000 }), /Microphone access for plugins is disabled in settings\./);
+  capabilities.settings.listenAllowed = () => true;
+
+  await api.voice.listen({ timeoutMs: 1 });
+  for (let index = 1; index < pluginSdkQuotas.voicePerMinute - 1; index += 1) await api.voice.listen({ timeoutMs: 60_000 });
+  assert.equal(requests[0]?.timeoutMs, 1_000);
+  assert.equal(requests[0]?.pluginId, "plug");
+  assert.equal(requests.at(-1)?.timeoutMs, 30_000);
+  await assert.rejects(() => api.voice.listen({ timeoutMs: 5_000 }), /Plugin voice quota exceeded\./);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function createCapabilities(requests: Array<{ timeoutMs?: number; pluginId?: string }>): PluginHostCapabilities {
+  return {
+    bubbles: { show: async () => ({ id: "bubble", update: async () => undefined, dismiss: async () => undefined, pin: async () => undefined, unpin: async () => undefined }) },
+    audio: { play: async () => undefined, importUserSound: async () => ({ kind: "user-sound", id: "0".repeat(32) }), forgetUserSound: async () => undefined, stop: async () => undefined },
+    events: { subscribe: () => () => undefined },
+    pets: {
+      list: () => [], spawn: async () => "pet", close: async () => undefined, show: async () => undefined, hide: async () => undefined,
+      react: async () => undefined, setAnimation: async () => undefined, setScale: async () => undefined, setStatusReaction: async () => undefined,
+      moveBy: async () => undefined, wander: async () => undefined, moveToHome: async () => undefined, moveTo: async () => undefined,
+      followCursor: async () => undefined, physics: async () => undefined, getState: async () => ({ position: { x: 0, y: 0 }, bounds: { x: 0, y: 0, width: 0, height: 0 }, currentAnimation: "idle", visible: true, dragging: false }),
+      onTick: () => () => undefined, onChange: () => () => undefined,
+    },
+    toast: async () => undefined,
+    notify: async () => undefined,
+    panels: { open: async () => ({ id: "panel", show: async () => undefined, hide: async () => undefined, postMessage: async () => undefined, close: async () => undefined }) },
+    delivery: { register: async () => ({ dismiss: () => undefined, onDismiss: () => undefined }), teardown: () => undefined },
+    secrets: { get: async () => undefined, set: async () => undefined, delete: async () => undefined, has: async () => false },
+    ai: { available: async () => false, complete: async () => ({ text: "" }), stream: async () => ({ text: "" }) },
+    voice: { speak: async () => undefined, listen: async (opts) => { requests.push(opts); return { text: "ok" }; } },
+    auth: { oauth: async () => ({ accessToken: "" }), refresh: async () => ({ accessToken: "" }), signOut: async () => undefined },
+    files: { pick: async () => [], read: async () => "", save: async () => undefined },
+    system: { info: async () => ({ platform: "win", locale: "en-US", timezone: "UTC", theme: "light", appVersion: "0.0.0", online: true }), metrics: async () => ({ cpuPercent: 0, memUsedPercent: 0 }), openExternal: async () => undefined, readClipboardText: async () => "", writeClipboardText: async () => undefined },
+    settings: { audioAllowed: () => true, dynamicSpeechAllowed: () => false, voiceAllowed: () => true, listenAllowed: () => true, inQuietHours: () => false },
+  };
+}
+
+function manifest(permissions: OpenPetsJavascriptPluginManifest["permissions"]): OpenPetsJavascriptPluginManifest {
+  return {
+    manifestVersion: 3,
+    id: "plug",
+    name: "Plug",
+    version: "1.0.0",
+    runtime: "javascript",
+    sdkVersion: "3.0.0",
+    entry: "index.js",
+    permissions,
+  };
+}
+
+console.log("Voice bridge behavior verified.");

--- a/apps/desktop/tests/voice-lifecycle.test.ts
+++ b/apps/desktop/tests/voice-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   type VoiceCaptureRecording,
   type VoiceCaptureResult,
 } from "../src/voice-capture.js";
+import { createVoiceCaptureCancellation } from "../src/voice-capture-cancellation.js";
 import {
   VOICE_CAPTURE_CANCELLED_ERROR,
   VOICE_EMPTY_TRANSCRIPT_ERROR,
@@ -18,6 +19,7 @@ import {
   VoiceListeningService,
 } from "../src/voice-listening-service.js";
 import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
+import { VoiceOperationState } from "../src/voice-operation-state.js";
 
 class FakeSurface implements VoicePrivacyIndicatorSurface {
   showCount = 0;
@@ -121,7 +123,7 @@ type Fixture = {
 
 function fixture(
   transcriber: (capture: VoiceCaptureResult, signal: AbortSignal) => Promise<string> = async () => "  hello  ",
-  options: { acquisitionTimeoutMs?: number; transcriptionTimeoutMs?: number } = {},
+  options: { acquisitionTimeoutMs?: number; transcriptionTimeoutMs?: number; onPhaseChange?: (phase: "acquiring" | "recording" | "transcribing") => void } = {},
 ): Fixture {
   const surface = new FakeSurface();
   const indicator = new VoicePrivacyIndicator(() => surface);
@@ -130,7 +132,7 @@ function fixture(
     attempt = new ControlledAttempt(onAcquired);
     return attempt;
   }, indicator, { acquisitionTimeoutMs: options.acquisitionTimeoutMs });
-  const listening = new VoiceListeningService(capture, transcriber, { transcriptionTimeoutMs: options.transcriptionTimeoutMs });
+  const listening = new VoiceListeningService(capture, transcriber, { transcriptionTimeoutMs: options.transcriptionTimeoutMs, onPhaseChange: options.onPhaseChange });
   return { surface, indicator, capture, listening, getAttempt: () => attempt! };
 }
 
@@ -142,6 +144,54 @@ assert.equal(VOICE_ACQUISITION_TIMEOUT_MS, 15_000);
 assert.equal(VOICE_TRANSCRIPTION_TIMEOUT_MS, 30_000);
 assert.equal(VOICE_MIN_RECORDING_DURATION_MS, 1_000);
 assert.equal(VOICE_MAX_RECORDING_DURATION_MS, 30_000);
+
+{
+  const state = new VoiceOperationState();
+  const phases: Array<string | null> = [];
+  let cancelCount = 0;
+  state.subscribe(() => phases.push(state.snapshot()?.phase ?? null));
+  state.begin(async () => { cancelCount += 1; });
+  state.setPhase("recording");
+  state.setPhase("transcribing");
+  await state.snapshot()!.cancel();
+  state.settle();
+  assert.equal(cancelCount, 1);
+  assert.deepEqual(phases, ["acquiring", "recording", "transcribing", null]);
+}
+
+{
+  const events: string[] = [];
+  let releaseRenderer!: () => void;
+  const renderer = new Promise<void>((resolve) => { releaseRenderer = resolve; });
+  const cancel = createVoiceCaptureCancellation(async () => {
+    events.push("renderer-start");
+    await renderer;
+    events.push("renderer-end");
+  }, () => events.push("window-destroy"));
+  const first = cancel();
+  const second = cancel();
+  assert.equal(first, second);
+  assert.deepEqual(events, ["renderer-start"]);
+  releaseRenderer();
+  await first;
+  assert.deepEqual(events, ["renderer-start", "renderer-end", "window-destroy"]);
+}
+
+{
+  const events: string[] = [];
+  let releaseRenderer!: () => void;
+  const renderer = new Promise<void>((resolve) => { releaseRenderer = resolve; });
+  const cancel = createVoiceCaptureCancellation(async () => {
+    events.push("renderer-start");
+    await renderer;
+    events.push("renderer-end");
+  }, () => events.push("window-destroy"), 1);
+  await cancel();
+  assert.deepEqual(events, ["renderer-start", "window-destroy"]);
+  releaseRenderer();
+  await flush();
+  assert.deepEqual(events, ["renderer-start", "window-destroy", "renderer-end"]);
+}
 
 {
   const surface = new FakeSurface();
@@ -159,15 +209,19 @@ assert.equal(VOICE_MAX_RECORDING_DURATION_MS, 30_000);
 }
 
 {
-  const current = fixture();
+  const phases: string[] = [];
+  const current = fixture(async () => "  hello  ", { onPhaseChange: (phase) => phases.push(phase) });
   const pending = current.listening.listenOnce(45_000);
   await flush();
   assert.equal(current.surface.showCount, 0, "the indicator stays hidden while acquisition is pending");
+  assert.deepEqual(phases, ["acquiring"]);
   current.getAttempt().resolveAcquisition();
   await flush();
   assert.equal(current.surface.showCount, 1, "the indicator starts only after microphone acquisition");
+  assert.deepEqual(phases, ["acquiring", "recording"]);
   current.getAttempt().recording.resolveCapture();
   assert.deepEqual(await pending, { text: "hello" });
+  assert.deepEqual(phases, ["acquiring", "recording", "transcribing"]);
   assert.equal(current.surface.hideCount, 1);
   assert.equal(current.getAttempt().recording.closeCount, 1);
   assert.equal(current.getAttempt().disposeCount, 1);

--- a/apps/desktop/tests/voice-lifecycle.test.ts
+++ b/apps/desktop/tests/voice-lifecycle.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+
+import {
+  VOICE_ACQUISITION_TIMEOUT_MS,
+  VOICE_MAX_RECORDING_DURATION_MS,
+  VOICE_MIN_RECORDING_DURATION_MS,
+  VoiceCaptureService,
+  type VoiceCaptureAttempt,
+  type VoiceCaptureRecording,
+  type VoiceCaptureResult,
+} from "../src/voice-capture.js";
+import {
+  VOICE_CAPTURE_CANCELLED_ERROR,
+  VOICE_EMPTY_TRANSCRIPT_ERROR,
+  VOICE_TRANSCRIPTION_CANCELLED_ERROR,
+  VOICE_TRANSCRIPTION_TIMEOUT_ERROR,
+  VOICE_TRANSCRIPTION_TIMEOUT_MS,
+  VoiceListeningService,
+} from "../src/voice-listening-service.js";
+import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
+
+class FakeSurface implements VoicePrivacyIndicatorSurface {
+  showCount = 0;
+  hideCount = 0;
+  destroyCount = 0;
+
+  show(): void { this.showCount += 1; }
+  hide(): void { this.hideCount += 1; }
+  destroy(): void { this.destroyCount += 1; }
+}
+
+class FakeRecording implements VoiceCaptureRecording {
+  readonly result: Promise<VoiceCaptureResult>;
+  stopCount = 0;
+  cancelCount = 0;
+  closeCount = 0;
+  #resolve!: (capture: VoiceCaptureResult) => void;
+  #reject!: (error: unknown) => void;
+
+  constructor() {
+    this.result = new Promise<VoiceCaptureResult>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+    void this.result.catch(() => undefined);
+  }
+
+  resolveCapture(): void {
+    this.#resolve({ bytes: new Uint8Array(128), mimeType: "audio/webm" });
+  }
+
+  rejectCapture(error = new Error("capture failed")): void {
+    this.#reject(error);
+  }
+
+  async stop(): Promise<VoiceCaptureResult> {
+    this.stopCount += 1;
+    this.resolveCapture();
+    return this.result;
+  }
+
+  async cancel(): Promise<void> {
+    this.cancelCount += 1;
+    this.#reject(new Error("capture cancelled"));
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+class ControlledAttempt implements VoiceCaptureAttempt {
+  readonly recording = new FakeRecording();
+  cancelCount = 0;
+  disposeCount = 0;
+  #resolveAcquire!: (recording: VoiceCaptureRecording) => void;
+  #rejectAcquire!: (error: unknown) => void;
+  #cancelled = false;
+  readonly #onAcquired: () => boolean;
+  readonly acquirePromise: Promise<VoiceCaptureRecording>;
+
+  constructor(onAcquired: () => boolean) {
+    this.#onAcquired = onAcquired;
+    this.acquirePromise = new Promise<VoiceCaptureRecording>((resolve, reject) => {
+      this.#resolveAcquire = resolve;
+      this.#rejectAcquire = reject;
+    });
+  }
+
+  acquire(): Promise<VoiceCaptureRecording> {
+    return this.acquirePromise;
+  }
+
+  resolveAcquisition(): void {
+    if (this.#cancelled || !this.#onAcquired()) {
+      void this.recording.cancel();
+      void this.recording.close();
+      this.#rejectAcquire(new Error("late acquisition was rejected"));
+      return;
+    }
+    this.#resolveAcquire(this.recording);
+  }
+
+  async cancel(): Promise<void> {
+    this.cancelCount += 1;
+    this.#cancelled = true;
+  }
+
+  async dispose(): Promise<void> {
+    this.disposeCount += 1;
+  }
+}
+
+type Fixture = {
+  readonly surface: FakeSurface;
+  readonly indicator: VoicePrivacyIndicator;
+  readonly capture: VoiceCaptureService;
+  readonly listening: VoiceListeningService;
+  getAttempt(): ControlledAttempt;
+};
+
+function fixture(
+  transcriber: (capture: VoiceCaptureResult, signal: AbortSignal) => Promise<string> = async () => "  hello  ",
+  options: { acquisitionTimeoutMs?: number; transcriptionTimeoutMs?: number } = {},
+): Fixture {
+  const surface = new FakeSurface();
+  const indicator = new VoicePrivacyIndicator(() => surface);
+  let attempt: ControlledAttempt | undefined;
+  const capture = new VoiceCaptureService((_, onAcquired) => {
+    attempt = new ControlledAttempt(onAcquired);
+    return attempt;
+  }, indicator, { acquisitionTimeoutMs: options.acquisitionTimeoutMs });
+  const listening = new VoiceListeningService(capture, transcriber, { transcriptionTimeoutMs: options.transcriptionTimeoutMs });
+  return { surface, indicator, capture, listening, getAttempt: () => attempt! };
+}
+
+async function flush(): Promise<void> {
+  for (let index = 0; index < 20; index += 1) await Promise.resolve();
+}
+
+assert.equal(VOICE_ACQUISITION_TIMEOUT_MS, 15_000);
+assert.equal(VOICE_TRANSCRIPTION_TIMEOUT_MS, 30_000);
+assert.equal(VOICE_MIN_RECORDING_DURATION_MS, 1_000);
+assert.equal(VOICE_MAX_RECORDING_DURATION_MS, 30_000);
+
+{
+  const surface = new FakeSurface();
+  const indicator = new VoicePrivacyIndicator(() => surface);
+  indicator.trackStarted();
+  indicator.trackStarted();
+  indicator.trackStopped();
+  indicator.trackStopped();
+  indicator.trackStopped();
+  indicator.shutdown();
+  assert.equal(surface.showCount, 1);
+  assert.equal(surface.hideCount, 1);
+  assert.equal(surface.destroyCount, 1);
+  assert.equal(indicator.liveTracks, 0);
+}
+
+{
+  const current = fixture();
+  const pending = current.listening.listenOnce(45_000);
+  await flush();
+  assert.equal(current.surface.showCount, 0, "the indicator stays hidden while acquisition is pending");
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  assert.equal(current.surface.showCount, 1, "the indicator starts only after microphone acquisition");
+  current.getAttempt().recording.resolveCapture();
+  assert.deepEqual(await pending, { text: "hello" });
+  assert.equal(current.surface.hideCount, 1);
+  assert.equal(current.getAttempt().recording.closeCount, 1);
+  assert.equal(current.getAttempt().disposeCount, 1);
+}
+
+{
+  const current = fixture();
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  await current.listening.cancel();
+  await assert.rejects(pending, new RegExp(VOICE_CAPTURE_CANCELLED_ERROR));
+  assert.equal(current.surface.showCount, 0);
+  assert.ok(current.getAttempt().cancelCount >= 1);
+  assert.equal(current.getAttempt().disposeCount, 1);
+
+  // A late getUserMedia resolution must be rejected and cleaned without
+  // resurrecting the indicator or the cancelled listen operation.
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  assert.equal(current.surface.showCount, 0);
+  assert.ok(current.getAttempt().recording.cancelCount >= 1);
+  assert.ok(current.getAttempt().recording.closeCount >= 1);
+}
+
+{
+  const current = fixture();
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  assert.equal(current.surface.showCount, 1);
+  await current.listening.cancel("The plugin was stopped.");
+  await assert.rejects(pending, /The plugin was stopped\./);
+  assert.ok(current.getAttempt().recording.cancelCount >= 1);
+  assert.equal(current.surface.hideCount, 1);
+  assert.equal(current.getAttempt().disposeCount, 1);
+}
+
+{
+  let resolveTranscription!: (text: string) => void;
+  let signal: AbortSignal | undefined;
+  const current = fixture((_capture, nextSignal) => {
+    signal = nextSignal;
+    return new Promise<string>((resolve) => { resolveTranscription = resolve; });
+  });
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  current.getAttempt().recording.resolveCapture();
+  await flush();
+  assert.ok(signal);
+  await current.listening.cancel();
+  await assert.rejects(pending, new RegExp(VOICE_TRANSCRIPTION_CANCELLED_ERROR));
+  assert.equal(signal?.aborted, true);
+  resolveTranscription("late text");
+  await flush();
+  assert.equal(current.surface.hideCount, 1);
+}
+
+{
+  const current = fixture(async () => "ok", { acquisitionTimeoutMs: 10 });
+  const pending = current.listening.listenOnce(5_000);
+  await assert.rejects(pending, /Microphone acquisition timed out\./);
+  assert.ok(current.getAttempt().cancelCount >= 1);
+  assert.equal(current.getAttempt().disposeCount, 1);
+  assert.equal(current.surface.showCount, 0);
+}
+
+{
+  let signal: AbortSignal | undefined;
+  const current = fixture((_capture, nextSignal) => {
+    signal = nextSignal;
+    return new Promise<string>(() => undefined);
+  }, { transcriptionTimeoutMs: 10 });
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  current.getAttempt().recording.resolveCapture();
+  await assert.rejects(pending, new RegExp(VOICE_TRANSCRIPTION_TIMEOUT_ERROR));
+  assert.equal(signal?.aborted, true);
+  assert.equal(current.surface.hideCount, 1);
+}
+
+{
+  const current = fixture(async () => " \t\n ");
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  current.getAttempt().recording.resolveCapture();
+  await assert.rejects(pending, (error: unknown) => error instanceof Error && error.message === VOICE_EMPTY_TRANSCRIPT_ERROR);
+}
+
+{
+  const current = fixture();
+  const first = current.listening.listenOnce(5_000);
+  await flush();
+  assert.throws(() => current.listening.listenOnce(5_000), /A voice capture is already in progress\./);
+  await current.listening.cancel();
+  await assert.rejects(first, /Voice capture was cancelled\./);
+}
+
+{
+  const current = fixture();
+  const pending = current.listening.listenOnce(5_000);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  await flush();
+  await current.listening.shutdown();
+  await assert.rejects(pending, /OpenPets is shutting down\./);
+  assert.equal(current.surface.destroyCount, 1);
+  assert.equal(current.getAttempt().disposeCount, 1);
+}
+
+console.log("Voice capture lifecycle behavior verified.");

--- a/codemap.md
+++ b/codemap.md
@@ -64,7 +64,7 @@ OpenPets is a pnpm/TypeScript monorepo for an Electron desktop companion app plu
 2. Agent integrations (`packages/claude`, `packages/opencode`, `packages/cursor`, `packages/pi`, and `packages/mcp`) configure agents or emit pet commands through `@open-pets/client`.
 3. The client discovers Unix sockets, Windows named pipes, or TCP endpoints for WSL cross-platform access.
 4. The desktop IPC server routes commands through lease-managed controllers so default and agent pets can coexist safely.
-5. The plugin service loads approved catalog or local `openpets.plugin.json` manifests, persists plugin state/config, schedules declarative timers, and bridges SDK v3 calls through permission-checked host modules for UI, audio, events, storage, AI, OAuth, voice, panels, and pet control.
+5. The plugin service loads approved catalog or local `openpets.plugin.json` manifests, persists plugin state/config, schedules declarative timers, and bridges SDK v3 calls through permission-checked host modules for UI, audio, events, storage, AI, OAuth, voice, panels, and pet control. Voice input remains one-shot, visibly indicated, cancellable, timeout-bounded, and never ambient.
 6. Pet windows render reaction-driven animations, localized speech, host-rendered bubbles/alerts/HUDs, and status reactions using desktop state plus reaction mapping metadata.
 7. Pet assets are resolved from built-in assets, locally developed Codex pets, or remotely downloaded catalog ZIPs.
 8. Workspace packages share TypeScript/ESM build conventions and are wired together through pnpm `workspace:*` dependencies.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,10 @@ These are the flows worth holding in memory. Each links to the doc that details 
   or local), the runtime starts a sandboxed JS host, and the SDK bridge applies
   permission-checked calls to pet/schedule/storage/UI/etc. See [plugins.md](plugins.md)
   and [sdk.md](sdk.md).
+- **Listening through a plugin.** `voice.listen()` performs one bounded capture in
+  a host-owned temporary session, shows the privacy indicator only after microphone
+  acquisition succeeds, transcribes through the configured provider, and cleans up
+  on success, cancellation, timeout, teardown, or shutdown. It is never ambient.
 - **Configuring an agent.** The CLI or Control Center detects the agent, writes
   MCP config + hooks/rules atomically, and installs a memory/instructions file.
   See [agent-integrations.md](agent-integrations.md).
@@ -102,6 +106,9 @@ These hold everywhere; the rest of the docs assume them.
 - **Least privilege.** Renderers are sandboxed with narrow preload bridges and a
   strict CSP; plugins run in a permission-gated sandbox; IPC over TCP is
   restricted to private/loopback addresses.
+- **Voice is bounded and visible.** Listening is one-shot, one-at-a-time,
+  explicitly cancellable, visibly indicated while a media track is live, and
+  bounded by separate microphone-acquisition and transcription timeouts.
 
 ## Glossary
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -186,6 +186,17 @@ runtime, the sandboxed JS host, the permission-checked SDK bridge, catalog/local
 install, assets, panels, diagnostics, and platform settings. Fully documented in
 [plugins.md](plugins.md) and [sdk.md](sdk.md).
 
+The plugin voice foundation is deliberately smaller than a conversation platform.
+`voice-capture-electron.ts` owns a hidden, sandboxed, per-capture microphone
+session; `voice-capture.ts` owns exactly-once cleanup and cancellation; and
+`voice-privacy-indicator-electron.ts` shows the host-owned **OpenPets is listening**
+surface only after `getUserMedia()` succeeds. A capture is one-shot and one-at-a-
+time, with a 15-second acquisition timeout, a separate 30-second transcription
+timeout, and an explicit host cancellation path. Plugin teardown and app shutdown
+cancel the active capture, abort transcription, stop tracks, destroy the capture
+window, clear its temporary session data, and hide the indicator. No ambient or
+wake-word listening is implemented.
+
 The plugin subsystem also owns **display deliveries**: a lazy, transparent,
 host-owned surface used by `ctx.ui.delivery`. A delivery is rendered as a single
 courier-and-banner surface on the cursor display, rather than as a spawned pet

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -187,15 +187,18 @@ install, assets, panels, diagnostics, and platform settings. Fully documented in
 [plugins.md](plugins.md) and [sdk.md](sdk.md).
 
 The plugin voice foundation is deliberately smaller than a conversation platform.
-`voice-capture-electron.ts` owns a hidden, sandboxed, per-capture microphone
-session; `voice-capture.ts` owns exactly-once cleanup and cancellation; and
+`voice-capture-electron.ts` owns a hidden, sandboxed microphone window and
+isolated session; `voice-capture.ts` owns exactly-once cleanup and cancellation; and
 `voice-privacy-indicator-electron.ts` shows the host-owned **OpenPets is listening**
 surface only after `getUserMedia()` succeeds. A capture is one-shot and one-at-a-
 time, with a 15-second acquisition timeout, a separate 30-second transcription
 timeout, and an explicit host cancellation path. Plugin teardown and app shutdown
 cancel the active capture, abort transcription, stop tracks, destroy the capture
 window, clear its temporary session data, and hide the indicator. No ambient or
-wake-word listening is implemented.
+wake-word listening is implemented. While active, the existing tray menu exposes
+**Stop microphone listening** during acquisition/recording and **Cancel
+transcription** while provider transcription is pending; the control disappears
+when the operation settles.
 
 The plugin subsystem also owns **display deliveries**: a lazy, transparent,
 host-owned surface used by `ctx.ui.delivery`. A delivery is rendered as a single

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -147,7 +147,7 @@ through this path. MiniMax supports OpenAI-compatible chat completions and
 streaming; choose OpenAI or Ollama when a plugin needs `voice.listen`.
 
 `voice.listen` is one-shot push-to-talk, never ambient. The host captures in a
-temporary per-request session and displays **OpenPets is listening** only after
+hidden, isolated microphone window and displays **OpenPets is listening** only after
 microphone acquisition succeeds. It accepts only one active capture, clamps the
 recording duration to 1-30 seconds, times microphone acquisition out after 15
 seconds, and bounds transcription separately at 30 seconds. The host can cancel
@@ -155,6 +155,9 @@ during acquisition, recording, or transcription; cancellation stops media tracks
 aborts transcription, closes the capture window, clears temporary session data,
 and prevents late renderer events from reviving the request. Whitespace-only
 transcripts fail with `Voice transcription returned no text.`
+The host-owned tray menu provides **Stop microphone listening** during
+acquisition/recording and **Cancel transcription** while transcription is
+pending; cancellation is not a public plugin SDK method.
 
 ### Display deliveries
 
@@ -218,6 +221,9 @@ mirror of all this is the SDK in [sdk.md](sdk.md).
   facade and host-owned transcription/cancellation lifecycle.
 - `voice-capture.ts` + `voice-capture-electron.ts` — bounded capture state and
   the temporary Electron microphone session.
+- `voice-capture-cancellation.ts` — idempotent renderer-cancel/window-destroy
+  ordering.
+- `voice-operation-state.ts` — internal tray cancellation state and phase tracking.
 - `voice-privacy-indicator-electron.ts` — the host-owned listening indicator.
 - `plugin-user-sound-store.ts` — stores imported user sounds as opaque refs, not
   raw filesystem paths.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -146,6 +146,16 @@ so it cannot be used for `voice.listen`. Anthropic is not transcription-capable
 through this path. MiniMax supports OpenAI-compatible chat completions and
 streaming; choose OpenAI or Ollama when a plugin needs `voice.listen`.
 
+`voice.listen` is one-shot push-to-talk, never ambient. The host captures in a
+temporary per-request session and displays **OpenPets is listening** only after
+microphone acquisition succeeds. It accepts only one active capture, clamps the
+recording duration to 1-30 seconds, times microphone acquisition out after 15
+seconds, and bounds transcription separately at 30 seconds. The host can cancel
+during acquisition, recording, or transcription; cancellation stops media tracks,
+aborts transcription, closes the capture window, clears temporary session data,
+and prevents late renderer events from reviving the request. Whitespace-only
+transcripts fail with `Voice transcription returned no text.`
+
 ### Display deliveries
 
 `ui:delivery` is a dedicated permission for the generic, host-owned delivery
@@ -204,6 +214,11 @@ mirror of all this is the SDK in [sdk.md](sdk.md).
   the inspector and health UI.
 - `plugin-platform-settings.ts` — global gates for audio, voice, speech,
   microphone, quiet hours, and AI provider choices.
+- `plugin-voice.ts` + `voice-listening-service.ts` — the plugin-facing one-shot
+  facade and host-owned transcription/cancellation lifecycle.
+- `voice-capture.ts` + `voice-capture-electron.ts` — bounded capture state and
+  the temporary Electron microphone session.
+- `voice-privacy-indicator-electron.ts` — the host-owned listening indicator.
 - `plugin-user-sound-store.ts` — stores imported user sounds as opaque refs, not
   raw filesystem paths.
 - `plugin-i18n.ts` — resolves plugin locales, manifest `$t:`, and `ctx.t()`.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -72,6 +72,16 @@ still use public-host checks). `network:write` unlocks non-GET on `ctx.net` only
 Legacy `ctx.http.fetch` stays GET-only public HTTPS and never inherits local or
 write access.
 
+### `ctx.voice.listen`
+
+`ctx.voice.listen()` is a single, host-owned push-to-talk capture. It is visibly
+indicated only after microphone acquisition succeeds, never listens ambiently,
+and rejects concurrent requests. The host bounds acquisition at 15 seconds and
+transcription at 30 seconds, trims the returned text, and rejects empty output
+with `Voice transcription returned no text.` The host cancellation path is used
+when a plugin is stopped or OpenPets shuts down; plugin code does not receive raw
+audio, credentials, or a renderer handle for the privacy surface.
+
 Commands time out after five seconds by default. A command that deliberately
 waits for user interaction, such as host-mediated OAuth, may declare a bounded
 `timeoutMs` between one second and five minutes.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -33,7 +33,9 @@ dist checks. Three buckets:
 
 - **Behavior** (`apps/desktop/tests/*.test.ts`): lease manager, app state,
   version checking, ZIP safety, Codex pets, Claude memory, reaction-animation
-  mapping. Compiled to `.test-dist/`.
+  mapping, plugin bridge/gateway guards, and `voice-lifecycle.test.ts` for the
+  privacy indicator, capture cancellation/cleanup races, separate timeouts,
+  empty transcripts, and shutdown behavior. Compiled to `.test-dist/`.
 - **Contract** (`apps/desktop/contracts/*.contract.ts`): the public boundaries —
   - `catalog-fixture.contract.ts` — catalog validation against fixture data.
   - `local-ipc-protocol.contract.ts` — IPC request/response parsing


### PR DESCRIPTION
## Summary

* Harden one-shot plugin voice capture with host-owned privacy indication, bounded acquisition, recording and transcription, cancellation, cleanup, and plugin/app teardown.
* Add phase-aware tray controls for stopping microphone capture or cancelling transcription.
* Propagate plugin ownership and transcription abort signals, with stale-start guards and reload/shutdown sequencing.
* Add focused lifecycle, tray, bridge, gateway, and runtime regression coverage, documentation, and macOS microphone metadata.

## Validation

* `pnpm typecheck` — passed
* `pnpm build` — passed
* Desktop typecheck and build — passed
* Focused tray voice, voice lifecycle, voice bridge, plugin AI gateway, and plugin runtime tests — passed
* `git diff --check` — passed
* Manual Electron smoke confirmed microphone acquisition, transcription cancellation, and privacy-indicator cleanup
* `pnpm --filter @open-pets/desktop test` on this branch remains blocked during compilation by duplicate declarations in `tests/lan-state.test.ts`
* Clean `upstream/main` reaches test execution but encounters the existing Windows symlink `EPERM` failure in `claude-memory.test.js`

Related to #10
