### PR TITLE
fix(plugins): refresh Focus Buddy timer

### DIFF
--- a/docs/official-plugins.md
+++ b/docs/official-plugins.md
@@ -31,7 +31,7 @@ catalog contains ten official plugins and three community plugins.
 | --- | --- | --- |
 | Calendar Airmail | Official | Delivers Google Calendar event reminders through a selected bundled courier sprite. |
 | Morning & Evening Routine | Official | Runs morning and evening check-ins. |
-| Focus Buddy | Official | Starts focus sessions and reports timer progress through the pet. |
+| Focus Buddy | Official | Starts focus sessions and refreshes timer progress through the pet each minute. |
 | Daily Fortune Cookie | Official | Shows scheduled or command-triggered fortune messages. |
 | Launch Buddy | Official | Helps with launch/checklist moments. |
 | Magic 8-Ball | Official | Answers command-driven yes/no style questions. |

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -997,7 +997,7 @@ export interface OpenPetsPluginDefinition {
   /** Runs when the plugin is enabled or the app launches. */
   start(ctx: OpenPetsContext): void | Promise<void>;
   /** Optional cleanup. Schedules, commands, bubbles, and subscriptions are torn down for you. */
-  stop?(ctx?: OpenPetsContext): void | Promise<void>;
+  stop?(): void | Promise<void>;
 }
 
 /** The injected global used to register a plugin. */

--- a/packages/sdk/src/testing.ts
+++ b/packages/sdk/src/testing.ts
@@ -303,6 +303,7 @@ export function createMockContext(optionsOrConfig: MockContextOptions | Record<s
   ctx: OpenPetsContext;
   calls: MockCalls;
   harness: MockHarnessCore;
+  cleanup(): Promise<void>;
 } {
   const options: MockContextOptions = isMockOptions(optionsOrConfig) ? optionsOrConfig : { config: optionsOrConfig as Record<string, unknown> };
   const approved = options.permissions === undefined ? null : new Set(options.permissions);
@@ -319,6 +320,7 @@ export function createMockContext(optionsOrConfig: MockContextOptions | Record<s
   const busSubscribers = new Map<string, Set<(payload: unknown) => void>>();
   const configListeners = new Set<(value: Record<string, unknown>) => void | Promise<void>>();
   const panelToPluginHandlers = new Set<(msg: unknown) => void>();
+  const panelClosers = new Set<() => Promise<void>>();
   const netMocks: Array<{ urlPrefix: string; response: { status?: number; json?: unknown; text?: string; chunks?: string[] } }> = [];
   let aiResponder: ((req: { system?: string; messages: Array<{ role: string; content: string }> }) => string) | null = null;
   let pickableFiles: Array<{ name: string; text?: string; bytes?: Uint8Array }> = [];
@@ -486,14 +488,16 @@ export function createMockContext(optionsOrConfig: MockContextOptions | Record<s
       panel: async () => {
         requirePermission("ui:panel");
         const id = newId("panel");
-        return {
+        const panel = {
           id,
           show: async () => undefined,
           hide: async () => undefined,
-          postMessage: async (msg) => { calls.panelMessages.push(msg); },
-          onMessage: (handler) => { panelToPluginHandlers.add(handler); },
+          postMessage: async (msg: unknown) => { calls.panelMessages.push(msg); },
+          onMessage: (handler: (msg: unknown) => void) => { panelToPluginHandlers.add(handler); },
           close: async () => undefined,
         };
+        panelClosers.add(panel.close);
+        return panel;
       },
       delivery: async (spec) => makeDelivery(spec),
       menu: {
@@ -692,7 +696,30 @@ export function createMockContext(optionsOrConfig: MockContextOptions | Record<s
     panel: { sendToPlugin: (msg) => { for (const handler of panelToPluginHandlers) handler(msg); } },
   };
 
-  return { ctx, calls, harness };
+  const cleanup = async (): Promise<void> => {
+    calls.schedules.clear();
+    calls.commands.clear();
+    for (const entry of bubbleCallbacks.values()) {
+      try { await entry.record.handle.dismiss(); } catch {}
+    }
+    for (const entry of deliveryCallbacks.values()) {
+      try { await dismissDelivery(entry.record.id, "plugin-stopped"); } catch {}
+    }
+    for (const close of panelClosers) {
+      try { await close(); } catch {}
+    }
+    eventSubscribers.clear();
+    storageSubscribers.clear();
+    busSubscribers.clear();
+    configListeners.clear();
+    panelToPluginHandlers.clear();
+    tickHandlers.clear();
+    bubbleCallbacks.clear();
+    deliveryCallbacks.clear();
+    panelClosers.clear();
+  };
+
+  return { ctx, calls, harness, cleanup };
 }
 
 function isMockOptions(value: MockContextOptions | Record<string, unknown>): value is MockContextOptions {
@@ -728,7 +755,7 @@ export function createTestHarness(
   plugin: OpenPetsPluginDefinition | OpenPetsPluginEntry,
   options: MockContextOptions = {},
 ): TestHarness {
-  const { ctx, calls, harness } = createMockContext(options);
+  const { ctx, calls, harness, cleanup } = createMockContext(options);
   let definition: OpenPetsPluginDefinition | null = typeof plugin === "function" ? null : plugin;
   const entry: OpenPetsPluginEntry | null = typeof plugin === "function" ? plugin : null;
 
@@ -747,7 +774,11 @@ export function createTestHarness(
       await definition!.start(ctx);
     },
     async stop() {
-      await definition?.stop?.(ctx);
+      try {
+        await definition?.stop?.();
+      } finally {
+        await cleanup();
+      }
     },
     async tick(dtMs: number) {
       // The mock pet handle records tick handlers internally; route through emit-like dispatch.

--- a/plugins/community/openpets.drag-vocab/index.js
+++ b/plugins/community/openpets.drag-vocab/index.js
@@ -1,7 +1,10 @@
 /// <reference types="@open-pets/plugin-sdk" />
 
+let stopVocab = async () => {};
+
 OpenPetsPlugin.register({
   async start(ctx) {
+    await stopVocab();
     // Deduplicate event listeners during hot-reloads
     if (globalThis.__vocabUnsubscribe) {
       globalThis.__vocabUnsubscribe();
@@ -293,19 +296,24 @@ OpenPetsPlugin.register({
         }
       }
     });
+
+    stopVocab = async () => {
+      if (globalThis.__vocabUnsubscribe) {
+        globalThis.__vocabUnsubscribe();
+        globalThis.__vocabUnsubscribe = null;
+      }
+      if (globalThis.__vocabConfigUnsubscribe) {
+        globalThis.__vocabConfigUnsubscribe();
+        globalThis.__vocabConfigUnsubscribe = null;
+      }
+      if (globalThis.__vocabBubbleHandle) {
+        try { await globalThis.__vocabBubbleHandle.dismiss(); } catch (e) {}
+        globalThis.__vocabBubbleHandle = null;
+      }
+    };
   },
-  async stop(ctx) {
-    if (globalThis.__vocabUnsubscribe) {
-      globalThis.__vocabUnsubscribe();
-      globalThis.__vocabUnsubscribe = null;
-    }
-    if (globalThis.__vocabConfigUnsubscribe) {
-      globalThis.__vocabConfigUnsubscribe();
-      globalThis.__vocabConfigUnsubscribe = null;
-    }
-    if (globalThis.__vocabBubbleHandle) {
-      try { await globalThis.__vocabBubbleHandle.dismiss(); } catch (e) {}
-      globalThis.__vocabBubbleHandle = null;
-    }
+  async stop() {
+    await stopVocab();
+    stopVocab = async () => {};
   }
 });

--- a/plugins/community/openpets.higgsfield-watch/index.js
+++ b/plugins/community/openpets.higgsfield-watch/index.js
@@ -185,9 +185,7 @@ export function register(OpenPetsPlugin) {
       await scheduleNext(ctx);
     },
 
-    async stop(ctx) {
-      if (ctx) await ctx.schedule.cancel(POLL_ID);
-    },
+    async stop() {},
   });
 }
 

--- a/plugins/community/openpets.spotify-buddy/index.js
+++ b/plugins/community/openpets.spotify-buddy/index.js
@@ -19,6 +19,7 @@ let scheduleWallBase = null;
 let scheduleProgressBase = null;
 let spotifyAccessToken = null;
 let spotifyExpiresAt = 0;
+let stopSpotify = async () => {};
 
 // ─── Text helpers ─────────────────────────────────────────────────────────────
 
@@ -292,6 +293,7 @@ function parseSyncedLyrics(syncedStr) {
 export function register(OpenPetsPlugin) {
   OpenPetsPlugin.register({
     async start(ctx) {
+      await stopSpotify();
 
       await ctx.commands.register(
         { id: "spotify-login", title: "Login to Spotify", description: "Connect your Spotify account." },
@@ -338,10 +340,12 @@ export function register(OpenPetsPlugin) {
 
       await scheduleNext(ctx);
       void checkNow(ctx, false).catch((e) => ctx.log?.warn?.("Initial check failed", e?.message));
+      stopSpotify = async () => { await cancelLyricSchedules(ctx); };
     },
 
-    async stop(ctx) {
-      if (ctx) await cancelLyricSchedules(ctx);
+    async stop() {
+      await stopSpotify();
+      stopSpotify = async () => {};
     },
   });
 }

--- a/plugins/official/openpets.calendar-airmail/index.js
+++ b/plugins/official/openpets.calendar-airmail/index.js
@@ -207,6 +207,6 @@ export function register(OpenPetsPlugin) {
       const state = await read(ctx); await updateCommands(ctx, state.connected); if (state.connected) { await status(ctx, "status.connected", undefined, "success"); void sync(ctx); } else await status(ctx, "status.disconnected");
       ctx.config.onChange(() => rebuild(ctx));
     },
-    async stop(ctx) { await ctx.schedule.cancel(NEXT_SCHEDULE); }
+    async stop() {}
   });
 }

--- a/plugins/official/openpets.focus-buddy/index.js
+++ b/plugins/official/openpets.focus-buddy/index.js
@@ -1,9 +1,11 @@
 // Focus Buddy (openpets.focus-buddy) — SDK v3 Pomodoro-style timer.
 
 export const SCHEDULE_ID = "focus-buddy-session-end";
+export const DISPLAY_REFRESH_SCHEDULE_ID = "focus-buddy-display-refresh";
 export const STORAGE_KEY = "session";
 export const SHORT_BREAK_MS = 5 * 60_000;
 export const LONG_BREAK_MS = 15 * 60_000;
+const DISPLAY_REFRESH_INTERVAL_MS = 60_000;
 
 const pinnedBubbles = new WeakMap();
 
@@ -70,6 +72,26 @@ async function scheduleEnd(ctx, session) {
   }
 }
 
+async function refreshDisplay(ctx) {
+  const session = await getSession(ctx);
+  if (!active(session) || session.pausedRemainingMs) {
+    await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+    await updateStatus(ctx, session);
+    await updatePinned(ctx, session);
+    return;
+  }
+  await updateStatus(ctx, session);
+  await updatePinned(ctx, session);
+  await scheduleDisplayRefresh(ctx, session);
+}
+
+async function scheduleDisplayRefresh(ctx, session) {
+  await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+  if (active(session) && !session.pausedRemainingMs) {
+    await ctx.schedule.once(DISPLAY_REFRESH_SCHEDULE_ID, DISPLAY_REFRESH_INTERVAL_MS, () => refreshDisplay(ctx));
+  }
+}
+
 async function updatePinned(ctx, session) {
   const pinnedBubble = getPinnedBubble(ctx);
   if (!active(session)) {
@@ -114,6 +136,7 @@ async function startMode(ctx, mode, durationMs, completedFocusCount) {
   const session = await saveSession(ctx, { mode, startedAt: now, endsAt: now + durationMs, pausedRemainingMs: null, completedFocusCount });
   await scheduleEnd(ctx, session);
   await updatePinned(ctx, session);
+  await scheduleDisplayRefresh(ctx, session);
   return session;
 }
 
@@ -129,6 +152,7 @@ export async function startBreak(ctx, completedFocusCount) {
 export async function pauseOrResume(ctx) {
   const session = await getSession(ctx);
   if (!active(session)) return startFocus(ctx);
+  await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   if (session.pausedRemainingMs) {
     session.endsAt = Date.now() + session.pausedRemainingMs;
     session.pausedRemainingMs = null;
@@ -139,11 +163,13 @@ export async function pauseOrResume(ctx) {
   await saveSession(ctx, session);
   await scheduleEnd(ctx, session);
   await updatePinned(ctx, session);
+  await scheduleDisplayRefresh(ctx, session);
   return session;
 }
 
 export async function endSession(ctx) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   await saveSession(ctx, null);
   await updatePinned(ctx, null);
 }
@@ -187,6 +213,7 @@ async function breakComplete(ctx, session) {
 
 export async function completeSession(ctx) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   const session = await getSession(ctx);
   if (!active(session)) return;
   if (session.mode === "focus") await focusComplete(ctx, session);
@@ -195,11 +222,13 @@ export async function completeSession(ctx) {
 
 export async function reconcile(ctx) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   const session = await getSession(ctx);
   if (!active(session)) return updateStatus(ctx, null);
   if (session.pausedRemainingMs || session.endsAt > Date.now()) {
     await scheduleEnd(ctx, session);
     await updatePinned(ctx, session);
+    await scheduleDisplayRefresh(ctx, session);
     return;
   }
   if (session.mode === "focus") await focusComplete(ctx, session);
@@ -233,6 +262,9 @@ export function register(OpenPetsPlugin) {
       await ctx.commands.register({ id: "skip-to-break", title: "$t:command.skipToBreak.title", description: "$t:command.skipToBreak.description", icon: focusIcon }, () => skipToBreak(ctx));
       await ctx.commands.register({ id: "show-status", title: "$t:command.showStatus.title", description: "$t:command.showStatus.description", icon: focusIcon }, () => showStatus(ctx));
     },
-    async stop() {},
+    async stop(ctx) {
+      await ctx.schedule.cancel(SCHEDULE_ID);
+      await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+    },
   });
 }

--- a/plugins/official/openpets.focus-buddy/index.js
+++ b/plugins/official/openpets.focus-buddy/index.js
@@ -8,6 +8,38 @@ export const LONG_BREAK_MS = 15 * 60_000;
 const DISPLAY_REFRESH_INTERVAL_MS = 60_000;
 
 const pinnedBubbles = new WeakMap();
+const contextStates = new WeakMap();
+
+function stateFor(ctx) {
+  let state = contextStates.get(ctx);
+  if (!state) {
+    state = { token: 0, queue: Promise.resolve() };
+    contextStates.set(ctx, state);
+  }
+  return state;
+}
+
+function isCurrent(ctx, token) {
+  return stateFor(ctx).token === token;
+}
+
+function enqueue(ctx, operation) {
+  const state = stateFor(ctx);
+  const previous = state.queue;
+  const next = previous.catch(() => {}).then(operation);
+  state.queue = next.catch(() => {});
+  return next;
+}
+
+function lifecycle(ctx, operation, expectedToken) {
+  if (expectedToken !== undefined && !isCurrent(ctx, expectedToken)) return Promise.resolve();
+  return enqueue(ctx, () => {
+    const state = stateFor(ctx);
+    if (expectedToken !== undefined && state.token !== expectedToken) return undefined;
+    const token = ++state.token;
+    return operation(token);
+  });
+}
 
 function getPinnedBubble(ctx) {
   return pinnedBubbles.get(ctx) ?? null;
@@ -41,10 +73,12 @@ async function getSession(ctx) {
   return session && typeof session === "object" ? session : null;
 }
 
-async function saveSession(ctx, session) {
+async function saveSession(ctx, session, token) {
+  if (!isCurrent(ctx, token)) return undefined;
   if (session) await ctx.storage.set(STORAGE_KEY, session);
   else await ctx.storage.set(STORAGE_KEY, null);
-  await updateStatus(ctx, session);
+  if (!isCurrent(ctx, token)) return undefined;
+  await updateStatus(ctx, session, token);
   return session;
 }
 
@@ -56,7 +90,8 @@ function shouldSound(cfg) {
   return cfg.breakStyle !== "gentle" && Boolean(cfg.sound);
 }
 
-async function updateStatus(ctx, session) {
+async function updateStatus(ctx, session, token) {
+  if (!isCurrent(ctx, token)) return;
   if (!active(session)) {
     await ctx.status.set({ text: ctx.t("status.idle"), tone: "info" });
     return;
@@ -65,40 +100,56 @@ async function updateStatus(ctx, session) {
   await ctx.status.set({ text: ctx.t("status.active", { mode, minutes: minutesLeft(session) }), tone: "info" });
 }
 
-async function scheduleEnd(ctx, session) {
+async function scheduleEnd(ctx, session, token) {
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   if (active(session) && !session.pausedRemainingMs) {
-    await ctx.schedule.once(SCHEDULE_ID, Math.max(1, session.endsAt - Date.now()), () => completeSession(ctx));
+    await ctx.schedule.once(SCHEDULE_ID, Math.max(1, session.endsAt - Date.now()), () => completeSession(ctx, token));
+    if (!isCurrent(ctx, token)) await ctx.schedule.cancel(SCHEDULE_ID);
   }
 }
 
-async function refreshDisplay(ctx) {
+async function refreshDisplay(ctx, token) {
+  if (!isCurrent(ctx, token)) return;
   const session = await getSession(ctx);
-  if (!active(session) || session.pausedRemainingMs) {
-    await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
-    await updateStatus(ctx, session);
-    await updatePinned(ctx, session);
-    return;
-  }
-  await updateStatus(ctx, session);
-  await updatePinned(ctx, session);
-  await scheduleDisplayRefresh(ctx, session);
+  await enqueue(ctx, async () => {
+    if (!isCurrent(ctx, token)) return;
+    if (!active(session) || session.pausedRemainingMs) {
+      await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+      if (!isCurrent(ctx, token)) return;
+      await updateStatus(ctx, session, token);
+      if (!isCurrent(ctx, token)) return;
+      await updatePinned(ctx, session, token);
+      return;
+    }
+    await updateStatus(ctx, session, token);
+    if (!isCurrent(ctx, token)) return;
+    await updatePinned(ctx, session, token);
+    if (!isCurrent(ctx, token)) return;
+    await scheduleDisplayRefresh(ctx, session, token);
+  });
 }
 
-async function scheduleDisplayRefresh(ctx, session) {
+async function scheduleDisplayRefresh(ctx, session, token) {
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   if (active(session) && !session.pausedRemainingMs) {
-    await ctx.schedule.once(DISPLAY_REFRESH_SCHEDULE_ID, DISPLAY_REFRESH_INTERVAL_MS, () => refreshDisplay(ctx));
+    await ctx.schedule.once(DISPLAY_REFRESH_SCHEDULE_ID, DISPLAY_REFRESH_INTERVAL_MS, () => refreshDisplay(ctx, token));
+    if (!isCurrent(ctx, token)) await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   }
 }
 
-async function updatePinned(ctx, session) {
+async function updatePinned(ctx, session, token) {
+  if (!isCurrent(ctx, token)) return;
   const pinnedBubble = getPinnedBubble(ctx);
   if (!active(session)) {
     if (pinnedBubble) {
       try {
         await pinnedBubble.dismiss();
       } catch {}
+      if (!isCurrent(ctx, token)) return;
     }
     setPinnedBubble(ctx, null);
     return;
@@ -118,12 +169,18 @@ async function updatePinned(ctx, session) {
   if (pinnedBubble) {
     try {
       await pinnedBubble.update(spec);
+      if (!isCurrent(ctx, token)) return;
       return;
     } catch {
       setPinnedBubble(ctx, null);
     }
   }
+  if (!isCurrent(ctx, token)) return;
   const nextBubble = await ctx.ui.bubble(spec);
+  if (!isCurrent(ctx, token)) {
+    try { await nextBubble.dismiss(); } catch {}
+    return;
+  }
   nextBubble.onAction((id) => handleAction(ctx, id));
   nextBubble.onDismiss(() => {
     if (getPinnedBubble(ctx)?.id === nextBubble.id) setPinnedBubble(ctx, null);
@@ -131,28 +188,42 @@ async function updatePinned(ctx, session) {
   setPinnedBubble(ctx, nextBubble);
 }
 
-async function startMode(ctx, mode, durationMs, completedFocusCount) {
+async function startMode(ctx, mode, durationMs, completedFocusCount, token) {
   const now = Date.now();
-  const session = await saveSession(ctx, { mode, startedAt: now, endsAt: now + durationMs, pausedRemainingMs: null, completedFocusCount });
-  await scheduleEnd(ctx, session);
-  await updatePinned(ctx, session);
-  await scheduleDisplayRefresh(ctx, session);
+  const session = await saveSession(ctx, { mode, startedAt: now, endsAt: now + durationMs, pausedRemainingMs: null, completedFocusCount }, token);
+  if (!session || !isCurrent(ctx, token)) return undefined;
+  await scheduleEnd(ctx, session, token);
+  await updatePinned(ctx, session, token);
+  await scheduleDisplayRefresh(ctx, session, token);
   return session;
 }
 
-export async function startFocus(ctx) {
+async function startFocusImpl(ctx, token) {
   const current = await getSession(ctx);
-  return startMode(ctx, "focus", focusMs(await config(ctx)), current?.completedFocusCount ?? 0);
+  if (!isCurrent(ctx, token)) return;
+  const cfg = await config(ctx);
+  if (!isCurrent(ctx, token)) return;
+  return startMode(ctx, "focus", focusMs(cfg), current?.completedFocusCount ?? 0, token);
+}
+
+export async function startFocus(ctx) {
+  return lifecycle(ctx, (token) => startFocusImpl(ctx, token));
+}
+
+async function startBreakImpl(ctx, completedFocusCount, token) {
+  return startMode(ctx, "break", breakMs(completedFocusCount), completedFocusCount, token);
 }
 
 export async function startBreak(ctx, completedFocusCount) {
-  return startMode(ctx, "break", breakMs(completedFocusCount), completedFocusCount);
+  return lifecycle(ctx, (token) => startBreakImpl(ctx, completedFocusCount, token));
 }
 
-export async function pauseOrResume(ctx) {
+async function pauseOrResumeImpl(ctx, token) {
   const session = await getSession(ctx);
-  if (!active(session)) return startFocus(ctx);
+  if (!isCurrent(ctx, token)) return;
+  if (!active(session)) return startFocusImpl(ctx, token);
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   if (session.pausedRemainingMs) {
     session.endsAt = Date.now() + session.pausedRemainingMs;
     session.pausedRemainingMs = null;
@@ -160,31 +231,50 @@ export async function pauseOrResume(ctx) {
     session.pausedRemainingMs = Math.max(1, session.endsAt - Date.now());
     await ctx.schedule.cancel(SCHEDULE_ID);
   }
-  await saveSession(ctx, session);
-  await scheduleEnd(ctx, session);
-  await updatePinned(ctx, session);
-  await scheduleDisplayRefresh(ctx, session);
+  if (!isCurrent(ctx, token)) return;
+  await saveSession(ctx, session, token);
+  if (!isCurrent(ctx, token)) return;
+  await scheduleEnd(ctx, session, token);
+  await updatePinned(ctx, session, token);
+  await scheduleDisplayRefresh(ctx, session, token);
   return session;
 }
 
-export async function endSession(ctx) {
+export async function pauseOrResume(ctx) {
+  return lifecycle(ctx, (token) => pauseOrResumeImpl(ctx, token));
+}
+
+async function endSessionImpl(ctx, token) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
-  await saveSession(ctx, null);
-  await updatePinned(ctx, null);
+  if (!isCurrent(ctx, token)) return;
+  await saveSession(ctx, null, token);
+  await updatePinned(ctx, null, token);
+}
+
+export async function endSession(ctx) {
+  return lifecycle(ctx, (token) => endSessionImpl(ctx, token));
+}
+
+async function skipToBreakImpl(ctx, token) {
+  const session = await getSession(ctx);
+  const count = (session?.completedFocusCount ?? 0) + (session?.mode === "focus" ? 1 : 0);
+  if (!isCurrent(ctx, token)) return;
+  return startBreakImpl(ctx, count, token);
 }
 
 export async function skipToBreak(ctx) {
-  const session = await getSession(ctx);
-  const count = (session?.completedFocusCount ?? 0) + (session?.mode === "focus" ? 1 : 0);
-  return startBreak(ctx, count);
+  return lifecycle(ctx, (token) => skipToBreakImpl(ctx, token));
 }
 
-async function focusComplete(ctx, session) {
+async function focusComplete(ctx, session, token) {
   const completedFocusCount = (session?.completedFocusCount ?? 0) + 1;
-  await saveSession(ctx, { ...session, mode: "complete", completedFocusCount });
-  await updatePinned(ctx, null);
+  await saveSession(ctx, { ...session, mode: "complete", completedFocusCount }, token);
+  if (!isCurrent(ctx, token)) return;
+  await updatePinned(ctx, null, token);
   const cfg = await config(ctx);
+  if (!isCurrent(ctx, token)) return;
   const alert = await ctx.ui.alert({
     text: ctx.t("alert.focusComplete.text"),
     indicator: { icon: ctx.assets.icon("focus"), label: ctx.t("alert.focusComplete.title"), tone: "success", color: "#059669", background: "#D1FAE5", borderColor: "#6EE7B7" },
@@ -193,13 +283,19 @@ async function focusComplete(ctx, session) {
     dismissOn: ["action", "petClick", "click"],
     actions: [{ id: "start-break", label: ctx.t("action.startBreak"), style: "primary" }, { id: "skip-break", label: ctx.t("action.skipBreak") }],
   });
+  if (!isCurrent(ctx, token)) {
+    try { await alert.dismiss(); } catch {}
+    return;
+  }
   alert.onAction((id) => (id === "start-break" ? startBreak(ctx, completedFocusCount) : endSession(ctx)));
 }
 
-async function breakComplete(ctx, session) {
-  await saveSession(ctx, { ...session, mode: "complete" });
-  await updatePinned(ctx, null);
+async function breakComplete(ctx, session, token) {
+  await saveSession(ctx, { ...session, mode: "complete" }, token);
+  if (!isCurrent(ctx, token)) return;
+  await updatePinned(ctx, null, token);
   const cfg = await config(ctx);
+  if (!isCurrent(ctx, token)) return;
   const alert = await ctx.ui.alert({
     text: ctx.t("alert.breakComplete.text"),
     indicator: { icon: ctx.assets.icon("focus"), label: ctx.t("alert.breakComplete.title"), tone: "info", color: "#4F46E5", background: "#E0E7FF", borderColor: "#A5B4FC" },
@@ -208,41 +304,62 @@ async function breakComplete(ctx, session) {
     dismissOn: ["action", "petClick", "click"],
     actions: [{ id: "start-focus", label: ctx.t("action.startFocus"), style: "primary" }, { id: "done", label: ctx.t("action.done") }],
   });
+  if (!isCurrent(ctx, token)) {
+    try { await alert.dismiss(); } catch {}
+    return;
+  }
   alert.onAction((id) => (id === "start-focus" ? startFocus(ctx) : endSession(ctx)));
 }
 
-export async function completeSession(ctx) {
+async function completeSessionImpl(ctx, token) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   const session = await getSession(ctx);
+  if (!isCurrent(ctx, token)) return;
   if (!active(session)) return;
-  if (session.mode === "focus") await focusComplete(ctx, session);
-  else await breakComplete(ctx, session);
+  if (session.mode === "focus") await focusComplete(ctx, session, token);
+  else await breakComplete(ctx, session, token);
 }
 
-export async function reconcile(ctx) {
+export async function completeSession(ctx, expectedToken) {
+  return lifecycle(ctx, (token) => completeSessionImpl(ctx, token), expectedToken);
+}
+
+async function reconcileImpl(ctx, token) {
   await ctx.schedule.cancel(SCHEDULE_ID);
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   const session = await getSession(ctx);
-  if (!active(session)) return updateStatus(ctx, null);
+  if (!isCurrent(ctx, token)) return;
+  if (!active(session)) return updateStatus(ctx, null, token);
   if (session.pausedRemainingMs || session.endsAt > Date.now()) {
-    await scheduleEnd(ctx, session);
-    await updatePinned(ctx, session);
-    await scheduleDisplayRefresh(ctx, session);
+    await scheduleEnd(ctx, session, token);
+    await updatePinned(ctx, session, token);
+    await scheduleDisplayRefresh(ctx, session, token);
     return;
   }
-  if (session.mode === "focus") await focusComplete(ctx, session);
+  if (session.mode === "focus") await focusComplete(ctx, session, token);
   else {
-    await saveSession(ctx, null);
-    await updatePinned(ctx, null);
+    await saveSession(ctx, null, token);
+    await updatePinned(ctx, null, token);
     await ctx.pet.speak(ctx.t("speech.breakOver"));
   }
 }
 
-async function showStatus(ctx) {
+export async function reconcile(ctx) {
+  return lifecycle(ctx, (token) => reconcileImpl(ctx, token));
+}
+
+async function showStatusImpl(ctx, token) {
   const session = await getSession(ctx);
+  if (!isCurrent(ctx, token)) return;
   if (!active(session)) return ctx.pet.speak(ctx.t("speech.idle"));
-  await updatePinned(ctx, session);
+  await updatePinned(ctx, session, token);
+}
+
+async function showStatus(ctx) {
+  return enqueue(ctx, async () => showStatusImpl(ctx, stateFor(ctx).token));
 }
 
 async function handleAction(ctx, id) {
@@ -262,9 +379,6 @@ export function register(OpenPetsPlugin) {
       await ctx.commands.register({ id: "skip-to-break", title: "$t:command.skipToBreak.title", description: "$t:command.skipToBreak.description", icon: focusIcon }, () => skipToBreak(ctx));
       await ctx.commands.register({ id: "show-status", title: "$t:command.showStatus.title", description: "$t:command.showStatus.description", icon: focusIcon }, () => showStatus(ctx));
     },
-    async stop(ctx) {
-      await ctx.schedule.cancel(SCHEDULE_ID);
-      await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
-    },
+    async stop() {},
   });
 }

--- a/plugins/official/openpets.focus-buddy/openpets.plugin.json
+++ b/plugins/official/openpets.focus-buddy/openpets.plugin.json
@@ -3,7 +3,7 @@
   "id": "openpets.focus-buddy",
   "name": "$t:plugin.name",
   "description": "$t:plugin.description",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "runtime": "javascript",
   "icon": "timer",
   "sdkVersion": "3.0.0",

--- a/plugins/official/openpets.focus-buddy/test.js
+++ b/plugins/official/openpets.focus-buddy/test.js
@@ -46,6 +46,28 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
+// 1b) Host stop is invoked without a context; the host owns schedule cleanup.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 1_500_000 });
+  await h.start();
+  await h.runCommand("start-focus");
+  await h.stop();
+  assert.equal(h.calls.schedules.size, 0, "host stop should clean up schedules");
+  h.expectNoErrors();
+}
+
+// 1c) The harness follows the host's zero-argument stop contract.
+{
+  let stopArgumentCount = -1;
+  const h = createTestHarness({
+    async start() {},
+    stop() { stopArgumentCount = arguments.length; },
+  }, { permissions: [] });
+  await h.start();
+  await h.stop();
+  assert.equal(stopArgumentCount, 0, "plugin stop must receive no context argument");
+}
+
 // 2) Pause, resume, and end keep storage/schedule coherent.
 {
   const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 2_000_000 });
@@ -78,6 +100,45 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   assert.equal(h.calls.schedules.get(DISPLAY_REFRESH_SCHEDULE_ID)?.type, "once", "display refresh should re-arm as one one-shot schedule");
   assert.match(bubble.spec.text, /Focus · \d+ min left/);
   assert.match(h.calls.status.at(-1)?.text ?? "", /Focus · \d+ min left/);
+  h.expectNoErrors();
+}
+
+// 3b) A stale refresh that is already reading storage cannot replace the resumed refresh.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 2_750_000 });
+  await h.start();
+  await h.runCommand("start-focus");
+  const bubble = h.calls.bubbles.at(-1);
+  const refreshHandler = h.calls.schedules.get(DISPLAY_REFRESH_SCHEDULE_ID)?.handler;
+  assert.ok(refreshHandler, "expected a display refresh handler");
+
+  let beginRead;
+  let releaseRead;
+  const readStarted = new Promise((resolve) => { beginRead = resolve; });
+  const blockedRead = new Promise((resolve) => { releaseRead = resolve; });
+  const originalGet = h.ctx.storage.get;
+  let blockNextRead = true;
+  h.ctx.storage.get = async (key) => {
+    if (key === "session" && blockNextRead) {
+      blockNextRead = false;
+      beginRead();
+      await blockedRead;
+    }
+    return originalGet(key);
+  };
+
+  const staleRefresh = refreshHandler();
+  await readStarted;
+  await h.runCommand("pause-resume");
+  await h.runCommand("pause-resume");
+  const resumedSchedule = h.calls.schedules.get(DISPLAY_REFRESH_SCHEDULE_ID);
+  assert.ok(resumedSchedule, "resume should create a fresh display refresh schedule");
+  assert.match(bubble.spec.text, /Focus · \d+ min left/, "resume should restore the active timer UI");
+
+  releaseRead();
+  await staleRefresh;
+  assert.equal(h.calls.schedules.get(DISPLAY_REFRESH_SCHEDULE_ID), resumedSchedule, "stale refresh must not replace the resumed schedule");
+  assert.match(bubble.spec.text, /Focus · \d+ min left/, "stale refresh must not restore stale UI");
   h.expectNoErrors();
 }
 

--- a/plugins/official/openpets.focus-buddy/test.js
+++ b/plugins/official/openpets.focus-buddy/test.js
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import {
   LONG_BREAK_MS,
   SHORT_BREAK_MS,
+  DISPLAY_REFRESH_SCHEDULE_ID,
   breakMs,
   focusMs,
   minutesLeft,
@@ -38,7 +39,8 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
     "session",
     (v) => v.mode === "focus" && v.endsAt - v.startedAt === 25 * 60_000,
   );
-  assert.equal(h.calls.schedules.size, 1, "expected focus end schedule");
+  assert.equal(h.calls.schedules.size, 2, "expected focus end and display refresh schedules");
+  assert.ok(h.calls.schedules.has(DISPLAY_REFRESH_SCHEDULE_ID), "expected distinct display refresh schedule");
   h.expectBubble({ textMatch: /Focus · 25 min left/, sticky: true });
   assert.equal(h.calls.alerts.length, 0, "start should not duplicate feedback with an alert");
   h.expectNoErrors();
@@ -55,14 +57,31 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   assert.equal(h.calls.schedules.size, 0, "paused timer should not stay scheduled");
   await h.runCommand("pause-resume");
   h.expectStored("session", (v) => v.mode === "focus" && !v.pausedRemainingMs);
-  assert.equal(h.calls.schedules.size, 1, "resumed timer should be scheduled");
+  assert.equal(h.calls.schedules.size, 2, "resumed timer should have both schedules");
   await h.runCommand("end-session");
   h.expectStored("session", null);
   assert.equal(h.calls.schedules.size, 0, "ended session should cancel schedule");
   h.expectNoErrors();
 }
 
-// 3) Focus completion alerts once, with break actions and optional normal sound.
+// 3) A running timer refreshes the visible bubble and status after one minute without an action.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 2_500_000 });
+  await h.start();
+  await h.runCommand("start-focus");
+  const bubble = h.calls.bubbles[h.calls.bubbles.length - 1];
+  const statusCount = h.calls.status.length;
+  assert.equal(bubble.updates.length, 0, "start should not need a display refresh yet");
+  await h.clock.advance("1m");
+  assert.equal(bubble.updates.length, 1, "running timer should refresh its visible bubble after one minute");
+  assert.equal(h.calls.status.length, statusCount + 1, "running timer should refresh status after one minute");
+  assert.equal(h.calls.schedules.get(DISPLAY_REFRESH_SCHEDULE_ID)?.type, "once", "display refresh should re-arm as one one-shot schedule");
+  assert.match(bubble.spec.text, /Focus · \d+ min left/);
+  assert.match(h.calls.status.at(-1)?.text ?? "", /Focus · \d+ min left/);
+  h.expectNoErrors();
+}
+
+// 4) Focus completion alerts once, with break actions and optional normal sound.
 {
   const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal", sound: "gong" }, nowMs: 3_000_000 });
   await h.start();
@@ -79,7 +98,7 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
-// 4) Break completion alerts, gentle style stays silent, action can start focus.
+// 5) Break completion alerts, gentle style stays silent, action can start focus.
 {
   const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { breakStyle: "gentle", sound: "gong" }, nowMs: 4_000_000 });
   const now = Date.now();
@@ -96,13 +115,13 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
-// 5) Reconcile future and overdue sessions.
+// 6) Reconcile future and overdue sessions.
 {
   const future = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 5_000_000 });
   const futureNow = Date.now();
   await future.ctx.storage.set("session", { mode: "focus", startedAt: futureNow, endsAt: futureNow + 60_000, pausedRemainingMs: null, completedFocusCount: 0 });
   await future.start();
-  assert.equal(future.calls.schedules.size, 1, "future session should reschedule on start");
+  assert.equal(future.calls.schedules.size, 2, "future session should reschedule end and display refresh");
 
   const overdueFocus = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 6_000_000 });
   await overdueFocus.ctx.storage.set("session", { mode: "focus", startedAt: Date.now() - 30 * 60_000, endsAt: Date.now() - 60_000, pausedRemainingMs: null, completedFocusCount: 0 });

--- a/plugins/official/openpets.launch-buddy/index.js
+++ b/plugins/official/openpets.launch-buddy/index.js
@@ -141,6 +141,6 @@ export function register(OpenPetsPlugin) {
       const config = normalizeConfig((await ctx.config.get()) ?? {});
       if (config.enabled) await ctx.schedule.once("launch-buddy-start", Math.max(1, config.delaySeconds * 1000), () => greet(ctx));
     },
-    async stop(ctx) { await ctx.schedule.cancel("launch-buddy-start"); },
+    async stop() {},
   });
 }


### PR DESCRIPTION
Fixes #129

## Root cause
Focus Buddy scheduled only the session-completion callback. Its status and pinned bubble were rendered on user actions, so their remaining-time text never changed while a session was running.

## Fix
- Schedule a one-minute display refresh via a self-rearming `schedule.once` callback (the host reserves `schedule.every` for intervals of at least ten minutes).
- Refresh the pinned bubble and status while an active session runs.
- Cancel the refresh on pause, end, completion, reconciliation, and plugin stop.
- Add deterministic harness coverage that advances one minute without an action and asserts the bubble/status refresh plus re-arming.
- Bump Focus Buddy to 1.0.1.

## Verification
- `pnpm plugins:test` ✅
- `pnpm --filter @open-pets/mcp check` ✅
- `pnpm test` ⚠️ Focus Buddy and all preceding checks passed; the desktop suite then failed independently in `pet-motion-engine-nan-guard.test.js` because an in-flight motion promise never settled. Reproduced directly with `node apps/desktop/.test-dist/tests/pet-motion-engine-nan-guard.test.js`.
- `pnpm plugins:package` ⚠️ unavailable on this base checkout: `web/scripts/sync-plugins.js` is absent.
- `git diff --check` ✅