### PR TITLE
feat(desktop): support Codex V2 pets

### DIFF
--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -205,7 +205,7 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `renderer/`: Vite React/Tailwind Control Center shell for Dashboard, Pets, Integrations, Plugins, and Settings.
 
 **Pets**:
-- `pet-window.ts`: Window creation (transparent, frameless, always-on-top), HTML/CSS generation, sprite animation states, speech bubbles, status badges, transient displays
+- `pet-window.ts`: Window creation (transparent, frameless, always-on-top), HTML/CSS generation, sprite animation states, speech bubbles, status badges, transient displays, and validated V1/V2 installed-atlas layout selection
 - `default-pet-controller.ts`: Default pet visibility, position persistence, transient reactions, status badges, logging
 - `agent-pet-controller.ts`: Lease-triggered pet windows, dismissal tracking, transient displays, status badges, logging
 - `pet-motion-engine.ts`: Interpolated movement vector/tick engine for plugin-driven pet motion and target-following behavior
@@ -223,8 +223,9 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 **Installation**:
 - `pet-installation.ts`: ZIP download, yauzl extraction with safety limits, pet validation
 - `pet-paths.ts`: Safe path resolution for pet directories
+- `pet-file-safety.ts`: Bounded, no-follow regular-file reads shared by pet import and installed-pet rendering
 - `codex-pets.ts`: Import from `~/.codex/pets/` with validation
-- `codex-pets-core.ts`: Codex metadata validation constants
+- `codex-pets-core.ts`: Codex V1/V2 metadata, exact V2 atlas, and neutral-pose layout validation
 - `catalog.ts`: Remote catalog fetch with V3 pagination support, search, fixture fallback
 - `catalog-validation.ts`: CatalogV2/V3 schema validation
 - `zip-safety.ts`: ZIP entry path validation (traversal prevention, case collision detection)
@@ -282,7 +283,7 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `update-version.ts`: Version parsing and comparison
 
 **Tests** (excluded from detailed codemap coverage per repository conventions):
-- Behavior tests live in `tests/*.test.ts` (compiled to `.test-dist/tests/`)
+- Behavior tests live in `tests/*.test.ts` (compiled to `.test-dist/tests/`); `codex-pets.test.ts` asserts released V1/V2 metadata fixtures and strict V2 atlas contracts
 - Contract tests live in `contracts/*.contract.ts` (compiled to `.test-dist/contracts/`)
 - Runtime checks (`check-*.ts`) remain in `src/` for packaging/validation (compiled to `dist/`)
 

--- a/apps/desktop/src/codex-pets-core.ts
+++ b/apps/desktop/src/codex-pets-core.ts
@@ -86,18 +86,22 @@ export async function validateCodexPetSpritesheet(spritesheet: Buffer, metadata:
   if (layout.version === 1) return;
 
   let imageMetadata: sharp.Metadata;
+  const image = sharp(spritesheet, { animated: true, failOn: "error", limitInputPixels: 50_000_000 });
   try {
-    const image = sharp(spritesheet, { animated: true, failOn: "error", limitInputPixels: 50_000_000 });
     imageMetadata = await image.metadata();
-    if (imageMetadata.format !== "webp") throw new Error("Codex V2 spritesheet must be WebP.");
-    if (!imageMetadata.hasAlpha) throw new Error("Codex V2 spritesheet must include transparency.");
-    if ((imageMetadata.pages ?? 1) !== 1) throw new Error("Codex V2 spritesheet must contain exactly one image.");
-    await image.raw().toBuffer();
   } catch {
-    throw new Error("Codex V2 spritesheet must be a fully decodable RGBA WebP image.");
+    throw new Error("Codex V2 spritesheet metadata is invalid.");
   }
+  if (imageMetadata.format !== "webp") throw new Error("Codex V2 spritesheet must be WebP.");
+  if (!imageMetadata.hasAlpha) throw new Error("Codex V2 spritesheet must include transparency.");
+  if ((imageMetadata.pages ?? 1) !== 1) throw new Error("Codex V2 spritesheet must contain exactly one image.");
   if (imageMetadata.width !== layout.frameWidth * layout.columns || imageMetadata.height !== layout.frameHeight * layout.rows) {
     throw new Error(`Codex V2 spritesheet must be exactly ${layout.frameWidth * layout.columns}x${layout.frameHeight * layout.rows}.`);
+  }
+  try {
+    await image.raw().toBuffer();
+  } catch {
+    throw new Error("Codex V2 spritesheet must be fully decodable.");
   }
 }
 

--- a/apps/desktop/src/codex-pets-core.ts
+++ b/apps/desktop/src/codex-pets-core.ts
@@ -1,3 +1,5 @@
+import sharp from "sharp";
+
 export const maxCodexPetJsonBytes = 128 * 1024;
 export const maxCodexSpritesheetBytes = 100 * 1024 * 1024;
 export const maxCodexThumbnailSourceBytes = 24 * 1024 * 1024;
@@ -8,11 +10,49 @@ export interface CodexPetMetadata {
   readonly displayName: string;
   readonly description: string;
   readonly spritesheetPath: "spritesheet.webp";
+  readonly spriteVersionNumber?: 2;
 }
+
+export interface CodexPetSpriteLayout {
+  readonly version: 1 | 2;
+  readonly frameWidth: 192;
+  readonly frameHeight: 208;
+  readonly columns: 8;
+  readonly rows: 9 | 11;
+  readonly neutralPose?: {
+    readonly row: 0;
+    readonly column: 6;
+  };
+}
+
+export interface CodexPetSpritePosition {
+  readonly row: number;
+  readonly startColumn: number;
+  readonly endColumn: number;
+  readonly animated: boolean;
+}
+
+export const codexV1SpriteLayout: CodexPetSpriteLayout = {
+  version: 1,
+  frameWidth: 192,
+  frameHeight: 208,
+  columns: 8,
+  rows: 9,
+};
+
+export const codexV2SpriteLayout: CodexPetSpriteLayout = {
+  version: 2,
+  frameWidth: 192,
+  frameHeight: 208,
+  columns: 8,
+  rows: 11,
+  neutralPose: { row: 0, column: 6 },
+};
 
 export function validateCodexPetMetadata(value: unknown, folderName: string): CodexPetMetadata {
   if (!isSafeCodexPetId(folderName)) throw new Error("Codex pet folder name is invalid.");
   if (!isRecord(value)) throw new Error("pet.json must be an object.");
+  const spriteLayout = getCodexPetSpriteLayout(value);
   if (value.id !== folderName || typeof value.id !== "string") throw new Error("Codex pet id must match its folder name.");
   if (!isSafeCodexPetId(value.id)) throw new Error("Codex pet id is invalid.");
   if (typeof value.displayName !== "string" || value.displayName.trim().length === 0 || value.displayName.length > 80) throw new Error("Codex pet displayName is invalid.");
@@ -23,7 +63,42 @@ export function validateCodexPetMetadata(value: unknown, folderName: string): Co
     displayName: value.displayName.trim(),
     description: value.description.trim(),
     spritesheetPath: "spritesheet.webp",
+    ...(spriteLayout.version === 2 ? { spriteVersionNumber: 2 as const } : {}),
   };
+}
+
+export function getCodexPetSpriteLayout(value: unknown): CodexPetSpriteLayout {
+  if (!isRecord(value) || !Object.hasOwn(value, "spriteVersionNumber")) return codexV1SpriteLayout;
+  if (value.spriteVersionNumber === 2) return codexV2SpriteLayout;
+  throw new Error("Codex pet spriteVersionNumber must be 2 when provided.");
+}
+
+export function getCodexPetSpritePosition(layout: CodexPetSpriteLayout, state: { readonly row: number; readonly frames: number }, useNeutralPose = false): CodexPetSpritePosition {
+  const neutralPose = useNeutralPose ? layout.neutralPose : undefined;
+  if (neutralPose && state.row === neutralPose.row) {
+    return { row: neutralPose.row, startColumn: neutralPose.column, endColumn: neutralPose.column, animated: false };
+  }
+  return { row: state.row, startColumn: 0, endColumn: state.frames, animated: true };
+}
+
+export async function validateCodexPetSpritesheet(spritesheet: Buffer, metadata: Pick<CodexPetMetadata, "spriteVersionNumber">): Promise<void> {
+  const layout = getCodexPetSpriteLayout(metadata);
+  if (layout.version === 1) return;
+
+  let imageMetadata: sharp.Metadata;
+  try {
+    const image = sharp(spritesheet, { animated: true, failOn: "error", limitInputPixels: 50_000_000 });
+    imageMetadata = await image.metadata();
+    if (imageMetadata.format !== "webp") throw new Error("Codex V2 spritesheet must be WebP.");
+    if (!imageMetadata.hasAlpha) throw new Error("Codex V2 spritesheet must include transparency.");
+    if ((imageMetadata.pages ?? 1) !== 1) throw new Error("Codex V2 spritesheet must contain exactly one image.");
+    await image.raw().toBuffer();
+  } catch {
+    throw new Error("Codex V2 spritesheet must be a fully decodable RGBA WebP image.");
+  }
+  if (imageMetadata.width !== layout.frameWidth * layout.columns || imageMetadata.height !== layout.frameHeight * layout.rows) {
+    throw new Error(`Codex V2 spritesheet must be exactly ${layout.frameWidth * layout.columns}x${layout.frameHeight * layout.rows}.`);
+  }
 }
 
 function isSafeCodexPetId(value: string): boolean {

--- a/apps/desktop/src/codex-pets.ts
+++ b/apps/desktop/src/codex-pets.ts
@@ -1,12 +1,12 @@
-import { constants } from "node:fs";
-import { lstat, mkdir, mkdtemp, open, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join, resolve, sep } from "node:path";
 
 import sharp from "sharp";
 
 import { getAppStateSnapshot, installPetState, type OpenPetsStateV1 } from "./app-state.js";
-import { maxCodexPetJsonBytes, maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata, type CodexPetMetadata } from "./codex-pets-core.js";
+import { maxCodexPetJsonBytes, maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata, validateCodexPetSpritesheet, type CodexPetMetadata } from "./codex-pets-core.js";
+import { readBoundedRegularFile } from "./pet-file-safety.js";
 import { withPetOperation } from "./pet-installation.js";
 import { assertInsideRoot, assertSafePetId, getInstalledPetDir, getPetsRoot } from "./pet-paths.js";
 
@@ -64,7 +64,8 @@ export async function importCodexPet(petId: string): Promise<OpenPetsStateV1> {
     await assertCodexPetDirectory(root, sourceDir);
     const metadata = await readCodexPetMetadata(root, sourceDir, petId);
     const spritesheetPath = join(sourceDir, metadata.spritesheetPath);
-    const spritesheet = await readRegularFile(spritesheetPath, maxCodexSpritesheetBytes, "spritesheet.webp");
+    const spritesheet = await readBoundedRegularFile(spritesheetPath, maxCodexSpritesheetBytes, "spritesheet.webp");
+    await validateCodexPetSpritesheet(spritesheet, metadata);
 
     const petsRoot = getPetsRoot();
     await mkdir(petsRoot, { recursive: true, mode: 0o700 });
@@ -102,7 +103,7 @@ async function tryReadCodexPet(root: string, dir: string, folderName: string): P
   try {
     const metadata = await readCodexPetMetadata(root, dir, folderName);
     const spritesheetPath = join(dir, metadata.spritesheetPath);
-    await validateSpritesheet(spritesheetPath);
+    await validateSpritesheet(spritesheetPath, metadata);
     const preview = await createCodexThumbnailDataUrl(spritesheetPath);
     return {
       id: metadata.id,
@@ -122,25 +123,23 @@ export async function readCodexPetSpritesheet(petId: string): Promise<Buffer> {
   const root = await validateCodexRoot();
   const sourceDir = resolve(root, petId);
   const metadata = await readCodexPetMetadata(root, sourceDir, petId);
-  return readRegularFile(join(sourceDir, metadata.spritesheetPath), maxCodexSpritesheetBytes, "spritesheet.webp");
+  const spritesheet = await readBoundedRegularFile(join(sourceDir, metadata.spritesheetPath), maxCodexSpritesheetBytes, "spritesheet.webp");
+  await validateCodexPetSpritesheet(spritesheet, metadata);
+  return spritesheet;
 }
 
 async function readCodexPetMetadata(root: string, dir: string, folderName: string): Promise<CodexPetMetadata> {
   await assertCodexPetDirectory(root, dir);
   assertSafePetId(folderName);
   const petJson = join(dir, "pet.json");
-  const parsed = JSON.parse((await readRegularFile(petJson, maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
+  const parsed = JSON.parse((await readBoundedRegularFile(petJson, maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
   const metadata = validateCodexPetMetadata(parsed, folderName);
   assertSafePetId(metadata.id);
   return metadata;
 }
 
-async function validateSpritesheet(path: string): Promise<void> {
-  const spritesheet = await lstat(path);
-  if (spritesheet.isSymbolicLink()) throw new Error("spritesheet.webp cannot be a symlink.");
-  if (!spritesheet.isFile()) throw new Error("spritesheet.webp must be a file.");
-  if (spritesheet.size <= 0) throw new Error("spritesheet.webp is empty.");
-  if (spritesheet.size > maxCodexSpritesheetBytes) throw new Error("spritesheet.webp is too large.");
+async function validateSpritesheet(path: string, metadata: CodexPetMetadata): Promise<void> {
+  await validateCodexPetSpritesheet(await readBoundedRegularFile(path, maxCodexSpritesheetBytes, "spritesheet.webp"), metadata);
 }
 
 async function createCodexThumbnailDataUrl(path: string): Promise<string> {
@@ -187,22 +186,6 @@ async function assertCodexPetDirectory(root: string, target: string): Promise<vo
   if (!dirStats.isDirectory()) throw new Error("Codex pet path must be a directory.");
   const realTarget = await realpath(resolvedTarget);
   if (!realTarget.startsWith(`${root}${sep}`)) throw new Error("Codex pet directory escapes Codex pets root.");
-}
-
-async function readRegularFile(path: string, maxBytes: number, label: string): Promise<Buffer> {
-  const stats = await lstat(path);
-  if (stats.isSymbolicLink()) throw new Error(`${label} cannot be a symlink.`);
-  if (!stats.isFile()) throw new Error(`${label} must be a file.`);
-  if (stats.size <= 0 || stats.size > maxBytes) throw new Error(`${label} size is invalid.`);
-  const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-  try {
-    const openedStats = await file.stat();
-    if (!openedStats.isFile()) throw new Error(`${label} must be a file.`);
-    if (openedStats.size !== stats.size || openedStats.size <= 0 || openedStats.size > maxBytes) throw new Error(`${label} size is invalid.`);
-    return await file.readFile();
-  } finally {
-    await file.close();
-  }
 }
 
 async function validateInstalledRegularFile(path: string): Promise<void> {

--- a/apps/desktop/src/pet-file-safety.ts
+++ b/apps/desktop/src/pet-file-safety.ts
@@ -1,0 +1,19 @@
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export async function readBoundedRegularFile(path: string, maxBytes: number, label: string): Promise<Buffer> {
+  const resolved = resolve(path);
+  const stats = await lstat(resolved);
+  if (stats.isSymbolicLink()) throw new Error(`${label} cannot be a symlink.`);
+  if (!stats.isFile()) throw new Error(`${label} must be a file.`);
+  if (stats.size <= 0 || stats.size > maxBytes) throw new Error(`${label} size is invalid.`);
+  const file = await open(resolved, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedStats = await file.stat();
+    if (!openedStats.isFile() || openedStats.size !== stats.size || openedStats.size <= 0 || openedStats.size > maxBytes) throw new Error(`${label} size is invalid.`);
+    return await file.readFile();
+  } finally {
+    await file.close();
+  }
+}

--- a/apps/desktop/src/pet-installation.ts
+++ b/apps/desktop/src/pet-installation.ts
@@ -1,5 +1,5 @@
-import { constants, createWriteStream } from "node:fs";
-import { lstat, mkdtemp, mkdir, open, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { lstat, mkdtemp, mkdir, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { basename, join, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { Transform } from "node:stream";
@@ -9,8 +9,9 @@ import type { Entry, ZipFile } from "yauzl";
 
 import { getAppStateSnapshot, installPetState, removePetState, setDefaultPet, upsertPetState, type OpenPetsStateV1 } from "./app-state.js";
 import { getCatalogPet } from "./catalog.js";
-import { maxCodexPetJsonBytes, maxCodexSpritesheetBytes, validateCodexPetMetadata, type CodexPetMetadata } from "./codex-pets-core.js";
+import { maxCodexPetJsonBytes, maxCodexSpritesheetBytes, validateCodexPetMetadata, validateCodexPetSpritesheet, type CodexPetMetadata } from "./codex-pets-core.js";
 import { builtInPet } from "./built-in-pet.js";
+import { readBoundedRegularFile } from "./pet-file-safety.js";
 import { assertInsideRoot, assertSafePetId, getInstalledPetDir, getPetsRoot } from "./pet-paths.js";
 import { assertOutputPathInside, hasSupportedZipMagic, ZipEntryPathTracker } from "./zip-safety.js";
 
@@ -82,7 +83,7 @@ export async function installPetFromZipFile(zipPath: string): Promise<OpenPetsSt
 
 export async function installPetFromZipFileWithResult(zipPath: string): Promise<LocalPetInstallResult> {
   return withPetOperation("local-import", async () => {
-    const zip = await readRegularFile(zipPath, maxZipDownloadBytes, "pet zip");
+    const zip = await readBoundedRegularFile(zipPath, maxZipDownloadBytes, "pet zip");
     validateZipMagic(zip);
     const petsRoot = getPetsRoot();
     await mkdir(petsRoot, { recursive: true, mode: 0o700 });
@@ -112,11 +113,12 @@ export async function installPetFromFolderWithResult(folderPath: string): Promis
     if (sourceStats.isSymbolicLink()) throw new Error("Pet folder cannot be a symlink.");
     if (!sourceStats.isDirectory()) throw new Error("Pet folder must be a directory.");
     if (await realpath(sourceDir) !== sourceDir) throw new Error("Pet folder path is not canonical.");
-    const parsed = JSON.parse((await readRegularFile(join(sourceDir, "pet.json"), maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
+    const parsed = JSON.parse((await readBoundedRegularFile(join(sourceDir, "pet.json"), maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
     const parsedId = isRecord(parsed) && typeof parsed.id === "string" ? parsed.id : basename(sourceDir);
     const metadata = validateCodexPetMetadata(parsed, parsedId);
     assertSafePetId(metadata.id);
-    const spritesheet = await readRegularFile(join(sourceDir, metadata.spritesheetPath), maxCodexSpritesheetBytes, "spritesheet.webp");
+    const spritesheet = await readBoundedRegularFile(join(sourceDir, metadata.spritesheetPath), maxCodexSpritesheetBytes, "spritesheet.webp");
+    await validateCodexPetSpritesheet(spritesheet, metadata);
     const petsRoot = getPetsRoot();
     await mkdir(petsRoot, { recursive: true, mode: 0o700 });
     const tempDir = await mkdtemp(join(petsRoot, `.local-import-${metadata.id}-`));
@@ -388,15 +390,13 @@ async function validateExtractedPet(tempDir: string): Promise<CodexPetMetadata> 
   assertOutputPathInside(tempDir, petJsonPath);
   assertOutputPathInside(tempDir, spritesheetPath);
 
-  const parsed = JSON.parse((await readRegularFile(petJsonPath, maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
+  const parsed = JSON.parse((await readBoundedRegularFile(petJsonPath, maxCodexPetJsonBytes, "pet.json")).toString("utf8")) as unknown;
   const parsedId = isRecord(parsed) && typeof parsed.id === "string" ? parsed.id : basename(tempDir);
   const metadata = validateCodexPetMetadata(parsed, parsedId);
   assertSafePetId(metadata.id);
 
-  const spritesheet = await stat(spritesheetPath);
-  if (!spritesheet.isFile()) throw new Error("spritesheet.webp must be a file.");
-  if (spritesheet.size <= 0) throw new Error("spritesheet.webp is empty.");
-  if (spritesheet.size > maxIndividualFileBytes) throw new Error("spritesheet.webp is too large.");
+  const spritesheet = await readBoundedRegularFile(spritesheetPath, maxIndividualFileBytes, "spritesheet.webp");
+  await validateCodexPetSpritesheet(spritesheet, metadata);
   return metadata;
 }
 
@@ -412,22 +412,6 @@ async function finalizeLocalPetInstall(metadata: CodexPetMetadata, tempDir: stri
   } catch (error) {
     await rm(finalDir, { recursive: true, force: true });
     throw error;
-  }
-}
-
-async function readRegularFile(path: string, maxBytes: number, label: string): Promise<Buffer> {
-  const resolved = resolve(path);
-  const stats = await lstat(resolved);
-  if (stats.isSymbolicLink()) throw new Error(`${label} cannot be a symlink.`);
-  if (!stats.isFile()) throw new Error(`${label} must be a file.`);
-  if (stats.size <= 0 || stats.size > maxBytes) throw new Error(`${label} size is invalid.`);
-  const file = await open(resolved, constants.O_RDONLY | constants.O_NOFOLLOW);
-  try {
-    const openedStats = await file.stat();
-    if (!openedStats.isFile() || openedStats.size !== stats.size || openedStats.size <= 0 || openedStats.size > maxBytes) throw new Error(`${label} size is invalid.`);
-    return await file.readFile();
-  } finally {
-    await file.close();
   }
 }
 

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -5,9 +5,11 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { getAppStateSnapshot, markPetBroken, type PetScaleValue } from "./app-state.js";
+import { getCodexPetSpriteLayout, getCodexPetSpritePosition, maxCodexPetJsonBytes, validateCodexPetMetadata, type CodexPetSpriteLayout } from "./codex-pets-core.js";
 import { clampToNearestDisplayIfOffscreen, clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosition, isCrossDisplayRoamingEnabled, type Point } from "./display.js";
 import { builtInPet } from "./built-in-pet.js";
 import { getInstalledPetDir } from "./pet-paths.js";
+import { readBoundedRegularFile } from "./pet-file-safety.js";
 import { getActiveLocale, getActiveLocaleLang, t } from "./i18n/index.js";
 import { defaultMediaDurationMs, type OpenPetsReaction } from "./local-ipc-protocol.js";
 import { pickReactionMessage } from "./reaction-messages.js";
@@ -1028,6 +1030,7 @@ async function createInstalledPetRender(petId: string, displayName: string, paus
   if (!spritesheet.isFile() || spritesheet.size <= 0 || spritesheet.size > 100 * 1024 * 1024) {
     throw new Error("Installed pet spritesheet is missing or too large.");
   }
+  const spriteLayout = await readInstalledPetSpriteLayout(petId);
 
   const imageUrl = pathToFileURL(spritesheetPath).toString();
   const hasPinned = Boolean(pluginBubbles?.pinned);
@@ -1037,7 +1040,7 @@ async function createInstalledPetRender(petId: string, displayName: string, paus
   const stateRows = getConfiguredSpriteStates(waitingAnimationDurationMs);
 
   return {
-    cacheKey: `${cachePrefix}:${paused}:${scale}:${spritesheet.mtimeMs}:${spritesheet.size}:${getConfiguredSpriteCacheKey(waitingAnimationDurationMs)}:${getActiveLocale()}`,
+    cacheKey: `${cachePrefix}:${paused}:${scale}:v${spriteLayout.version}:${spritesheet.mtimeMs}:${spritesheet.size}:${getConfiguredSpriteCacheKey(waitingAnimationDurationMs)}:${getActiveLocale()}`,
     bodyHtml,
     reactionState,
     html: `<!doctype html>
@@ -1049,30 +1052,32 @@ async function createInstalledPetRender(petId: string, displayName: string, paus
           <title>OpenPets Default Pet</title>
           <style>
             ${createPetWindowCss(paused, scale)}
-            .installed-card { width: ${Math.ceil(defaultPetSprite.frameWidth * scale)}px; height: ${Math.ceil(defaultPetSprite.frameHeight * scale)}px; overflow: visible; position: relative; }
+            .installed-card { width: ${Math.ceil(spriteLayout.frameWidth * scale)}px; height: ${Math.ceil(spriteLayout.frameHeight * scale)}px; overflow: visible; position: relative; }
             .installed-sprite {
               position: absolute;
               left: 0;
               top: 0;
-              width: ${defaultPetSprite.frameWidth}px;
-              height: ${defaultPetSprite.frameHeight}px;
+              width: ${spriteLayout.frameWidth}px;
+              height: ${spriteLayout.frameHeight}px;
               background-image: url("${escapeCssUrl(imageUrl)}");
-              background-size: ${defaultPetSprite.frameWidth * defaultPetSprite.columns}px ${defaultPetSprite.frameHeight * defaultPetSprite.rows}px;
+              background-size: ${spriteLayout.frameWidth * spriteLayout.columns}px ${spriteLayout.frameHeight * spriteLayout.rows}px;
               background-repeat: no-repeat;
               --sprite-row-y: 0px;
+              --sprite-offset-x: 0px;
+              --sprite-end-offset-x: 0px;
               --sprite-frames: ${stateRows.idle.frames};
               --sprite-duration: ${stateRows.idle.durationMs}ms;
               --sprite-iterations: ${stateRows.idle.iterations};
-              background-position: 0 var(--sprite-row-y);
-              animation: pet-frames var(--sprite-duration) steps(var(--sprite-frames)) var(--sprite-iterations);
+              background-position: var(--sprite-offset-x) var(--sprite-row-y);
+              animation: var(--sprite-animation, pet-frames var(--sprite-duration) steps(var(--sprite-frames)) var(--sprite-iterations));
               animation-play-state: var(--play-state);
               transform: scale(${scale});
               transform-origin: top left;
             }
-            ${createSpriteStateCss(".installed-sprite", stateRows)}
+            ${createInstalledSpriteStateCss(stateRows, spriteLayout)}
             @keyframes pet-frames {
-              from { background-position: 0 var(--sprite-row-y); }
-              to { background-position: calc(-${defaultPetSprite.frameWidth}px * var(--sprite-frames)) var(--sprite-row-y); }
+              from { background-position: var(--sprite-offset-x) var(--sprite-row-y); }
+              to { background-position: var(--sprite-end-offset-x) var(--sprite-row-y); }
             }
           </style>
         </head>
@@ -1081,6 +1086,15 @@ async function createInstalledPetRender(petId: string, displayName: string, paus
         </body>
       </html>`,
   };
+}
+
+async function readInstalledPetSpriteLayout(petId: string): Promise<CodexPetSpriteLayout> {
+  const metadataPath = join(getInstalledPetDir(petId), "pet.json");
+  const metadata = validateCodexPetMetadata(
+    JSON.parse((await readBoundedRegularFile(metadataPath, maxCodexPetJsonBytes, "Installed pet metadata")).toString("utf8")) as unknown,
+    petId,
+  );
+  return getCodexPetSpriteLayout(metadata);
 }
 
 function createPetBodyMarkup(stageLabel: string, bubble: string, spriteMarkup: string, pinnedBubble = "", hasPinned = false): string {
@@ -1302,18 +1316,35 @@ function createPetWindowCss(paused: boolean, scale: PetScaleValue): string {
   `;
 }
 
-function createSpriteStateCss(selector: ".sprite" | ".installed-sprite", stateRows: Readonly<Record<UniversalSpriteState, SpriteStateDefinition>>): string {
-  const reactionRules = Object.keys(stateRows).map((state) => createSpriteRule(`html[data-reaction-state="${state}"] ${selector}`, state as UniversalSpriteState, stateRows));
+function createSpriteStateCss(selector: ".sprite" | ".installed-sprite", stateRows: Readonly<Record<UniversalSpriteState, SpriteStateDefinition>>, layout: CodexPetSpriteLayout = {
+  version: 1,
+  frameWidth: defaultPetSprite.frameWidth,
+  frameHeight: defaultPetSprite.frameHeight,
+  columns: defaultPetSprite.columns,
+  rows: defaultPetSprite.rows,
+}): string {
+  const reactionRules = Object.keys(stateRows).map((state) => createSpriteRule(`html[data-reaction-state="${state}"] ${selector}`, state as UniversalSpriteState, stateRows, layout, state === "idle" ? layout.neutralPose : undefined));
   const motionRules = (Object.entries(motionToSpriteState) as Array<[PetMotionState, UniversalSpriteState]>)
     .filter(([motion]) => motion !== "idle")
-    .map(([motion, state]) => createSpriteRule(`html[data-motion-state="${motion}"] ${selector}`, state, stateRows));
+    .map(([motion, state]) => createSpriteRule(`html[data-motion-state="${motion}"] ${selector}`, state, stateRows, layout));
   return [...reactionRules, ...motionRules].join("\n");
 }
 
-function createSpriteRule(selector: string, state: UniversalSpriteState, stateRows: Readonly<Record<UniversalSpriteState, SpriteStateDefinition>>): string {
+function createInstalledSpriteStateCss(stateRows: Readonly<Record<UniversalSpriteState, SpriteStateDefinition>>, layout: CodexPetSpriteLayout): string {
+  if (layout.version === 1) return createSpriteStateCss(".installed-sprite", stateRows);
+  return createSpriteStateCss(".installed-sprite", stateRows, layout);
+}
+
+function createSpriteRule(selector: string, state: UniversalSpriteState, stateRows: Readonly<Record<UniversalSpriteState, SpriteStateDefinition>>, layout: CodexPetSpriteLayout, neutralPose?: { readonly row: number; readonly column: number }): string {
   const row = stateRows[state];
   const iterations = "iterations" in row ? row.iterations : "infinite";
-  return `${selector} { --sprite-row-y: -${row.row * defaultPetSprite.frameHeight}px; --sprite-frames: ${row.frames}; --sprite-duration: ${row.durationMs}ms; --sprite-iterations: ${iterations}; }`;
+  const position = getCodexPetSpritePosition(layout, row, neutralPose !== undefined);
+  const startOffset = -(position.startColumn * layout.frameWidth);
+  const endOffset = -(position.endColumn * layout.frameWidth);
+  const animation = position.animated
+    ? " --sprite-animation: pet-frames var(--sprite-duration) steps(var(--sprite-frames)) var(--sprite-iterations);"
+    : " --sprite-animation: none;";
+  return `${selector} { --sprite-row-y: -${row.row * layout.frameHeight}px; --sprite-offset-x: ${startOffset}px; --sprite-end-offset-x: ${endOffset}px; --sprite-frames: ${row.frames}; --sprite-duration: ${row.durationMs}ms; --sprite-iterations: ${iterations};${animation} }`;
 }
 
 function getReactionSpriteState(reaction: OpenPetsReaction | undefined): UniversalSpriteState {

--- a/apps/desktop/tests/codex-pet-fixtures.ts
+++ b/apps/desktop/tests/codex-pet-fixtures.ts
@@ -1,0 +1,19 @@
+/**
+ * Released reference manifests:
+ * V1: https://raw.githubusercontent.com/chenxin-dlut/codex-anime-pets/main/pets/aiko/pet.json
+ * V2: https://raw.githubusercontent.com/mySebbe/malou-codex-pet/v2.0.0/dist/malou/pet.json
+ */
+export const codexV1Fixture = {
+  id: "aiko",
+  displayName: "Aiko",
+  description: "A tiny original Codex digital pet: an auburn-haired chibi scientist girl in a red turtleneck and white lab coat.",
+  spritesheetPath: "spritesheet.webp",
+} as const;
+
+export const codexV2Fixture = {
+  id: "malou",
+  displayName: "Malou",
+  description: "Malou is a clean photo-based brown-and-white dog companion for Codex Desktop, ChatGPT Web, and mobile Codex Pet bubbles, with readable status poses and 16 clockwise look directions.",
+  spritesheetPath: "spritesheet.webp",
+  spriteVersionNumber: 2,
+} as const;

--- a/apps/desktop/tests/codex-pets.test.ts
+++ b/apps/desktop/tests/codex-pets.test.ts
@@ -58,13 +58,13 @@ async function runImageContracts(): Promise<void> {
   const validV2Atlas = await createAtlas(1536, 2288, "webp");
   await validateCodexPetSpritesheet(validV2Atlas, v2);
   await assert.rejects(() => createAtlas(1536, 2080, "webp").then((atlas) => validateCodexPetSpritesheet(atlas, v2)), /exactly 1536x2288/);
-  await assert.rejects(() => createAtlas(1536, 2288, "png").then((atlas) => validateCodexPetSpritesheet(atlas, v2)), /fully decodable RGBA WebP/);
+  await assert.rejects(() => createAtlas(1536, 2288, "png").then((atlas) => validateCodexPetSpritesheet(atlas, v2)), /must be WebP/);
   const opaqueWebp = await sharp({ create: { width: 1536, height: 2288, channels: 3, background: { r: 0, g: 0, b: 0 } } }).webp().toBuffer();
-  await assert.rejects(() => validateCodexPetSpritesheet(opaqueWebp, v2), /fully decodable RGBA WebP/);
+  await assert.rejects(() => validateCodexPetSpritesheet(opaqueWebp, v2), /must include transparency/);
   const secondV2Frame = await sharp({ create: { width: 1536, height: 2288, channels: 4, background: { r: 1, g: 0, b: 0, alpha: 0.5 } } }).webp().toBuffer();
   const animatedWebp = await sharp([validV2Atlas, secondV2Frame], { join: { animated: true } }).webp({ delay: [100, 100], loop: 0 }).toBuffer();
-  await assert.rejects(() => validateCodexPetSpritesheet(animatedWebp, v2), /fully decodable RGBA WebP/);
-  await assert.rejects(() => validateCodexPetSpritesheet(Buffer.from("not an image"), v2), /fully decodable RGBA WebP/);
+  await assert.rejects(() => validateCodexPetSpritesheet(animatedWebp, v2), /exactly one image/);
+  await assert.rejects(() => validateCodexPetSpritesheet(Buffer.from("not an image"), v2), /metadata is invalid/);
   await validateCodexPetSpritesheet(Buffer.from("not an image"), valid);
   console.log("Codex pet validation and V2 layout contracts passed.");
 }

--- a/apps/desktop/tests/codex-pets.test.ts
+++ b/apps/desktop/tests/codex-pets.test.ts
@@ -1,18 +1,15 @@
 import assert from "node:assert/strict";
 
-import { maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata } from "../src/codex-pets-core.js";
+import sharp from "sharp";
 
-const valid = validateCodexPetMetadata({
-  id: "fixer",
-  displayName: " Fixer ",
-  description: " Repairs things. ",
-  spritesheetPath: "spritesheet.webp",
-}, "fixer");
+import { codexV2SpriteLayout, getCodexPetSpriteLayout, getCodexPetSpritePosition, maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata, validateCodexPetSpritesheet } from "../src/codex-pets-core.js";
+import { getConfiguredSpriteStates } from "../src/reaction-animation-mapping.js";
+import { codexV1Fixture, codexV2Fixture } from "./codex-pet-fixtures.js";
+
+const valid = validateCodexPetMetadata(codexV1Fixture, "aiko");
 
 assert.deepEqual(valid, {
-  id: "fixer",
-  displayName: "Fixer",
-  description: "Repairs things.",
+  ...codexV1Fixture,
   spritesheetPath: "spritesheet.webp",
 });
 
@@ -26,4 +23,53 @@ assert.equal(maxCodexSpritesheetBytes, 100 * 1024 * 1024);
 assert.equal(maxCodexThumbnailSourceBytes, 24 * 1024 * 1024);
 assert.equal(maxCodexPets, 100);
 
-console.log("Codex pet validation passed.");
+const v2 = validateCodexPetMetadata(codexV2Fixture, "malou");
+
+assert.deepEqual(v2, {
+  ...codexV2Fixture,
+});
+assert.equal(getCodexPetSpriteLayout(valid).rows, 9);
+assert.deepEqual(getCodexPetSpriteLayout(v2), codexV2SpriteLayout);
+assert.equal(codexV2SpriteLayout.rows, 11);
+assert.deepEqual(codexV2SpriteLayout.neutralPose, { row: 0, column: 6 });
+const configuredStates = getConfiguredSpriteStates();
+assert.deepEqual(getCodexPetSpritePosition(codexV2SpriteLayout, configuredStates.idle, true), { row: 0, startColumn: 6, endColumn: 6, animated: false });
+assert.deepEqual(getCodexPetSpritePosition(codexV2SpriteLayout, configuredStates["running-right"]), { row: 1, startColumn: 0, endColumn: 8, animated: true });
+assert.deepEqual(getCodexPetSpritePosition(getCodexPetSpriteLayout(valid), configuredStates.idle), { row: 0, startColumn: 0, endColumn: 6, animated: true });
+
+for (const marker of [1, 3, "2", null, undefined]) {
+  const malformed = { ...codexV2Fixture, spriteVersionNumber: marker };
+  assert.throws(() => validateCodexPetMetadata(malformed, "malou"), `marker ${String(marker)} must be rejected`);
+}
+
+const createAtlas = (width: number, height: number, format: "webp" | "png"): Promise<Buffer> => {
+  const image = sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  });
+  return format === "webp" ? image.webp().toBuffer() : image.png().toBuffer();
+};
+
+async function runImageContracts(): Promise<void> {
+  const validV2Atlas = await createAtlas(1536, 2288, "webp");
+  await validateCodexPetSpritesheet(validV2Atlas, v2);
+  await assert.rejects(() => createAtlas(1536, 2080, "webp").then((atlas) => validateCodexPetSpritesheet(atlas, v2)), /exactly 1536x2288/);
+  await assert.rejects(() => createAtlas(1536, 2288, "png").then((atlas) => validateCodexPetSpritesheet(atlas, v2)), /fully decodable RGBA WebP/);
+  const opaqueWebp = await sharp({ create: { width: 1536, height: 2288, channels: 3, background: { r: 0, g: 0, b: 0 } } }).webp().toBuffer();
+  await assert.rejects(() => validateCodexPetSpritesheet(opaqueWebp, v2), /fully decodable RGBA WebP/);
+  const secondV2Frame = await sharp({ create: { width: 1536, height: 2288, channels: 4, background: { r: 1, g: 0, b: 0, alpha: 0.5 } } }).webp().toBuffer();
+  const animatedWebp = await sharp([validV2Atlas, secondV2Frame], { join: { animated: true } }).webp({ delay: [100, 100], loop: 0 }).toBuffer();
+  await assert.rejects(() => validateCodexPetSpritesheet(animatedWebp, v2), /fully decodable RGBA WebP/);
+  await assert.rejects(() => validateCodexPetSpritesheet(Buffer.from("not an image"), v2), /fully decodable RGBA WebP/);
+  await validateCodexPetSpritesheet(Buffer.from("not an image"), valid);
+  console.log("Codex pet validation and V2 layout contracts passed.");
+}
+
+runImageContracts().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -238,6 +238,27 @@ regenerating the catalog) lives in `web/`'s sync scripts. The contract those
 scripts produce is in [Catalogs](/catalog), with release checks in
 [Testing and validation](/testing-and-validation).
 
+### Codex sprite versions
+
+OpenPets preserves the original Codex V1 package shape: an unmarked
+`spritesheet.webp` with the nine standard `192×208` animation rows. It also
+imports V2 only when `pet.json` has `"spriteVersionNumber": 2` and its source
+asset is a fully decodable, single-image, alpha-enabled WebP with the exact `1536×2288`
+(`8×11`) grid. Any other supplied version marker, a non-WebP/non-alpha image,
+or a mismatched V2 atlas is rejected before the atomic import writes anything.
+
+The V2 adapter uses the unchanged standard rows 0–8 for OpenPets reactions and
+horizontal run motion, and uses V2's neutral pose (row 0, column 6) whenever
+the existing runtime is idle. This matches the released
+[Malou V2 manifest](https://raw.githubusercontent.com/mySebbe/malou-codex-pet/v2.0.0/dist/malou/pet.json)
+and its [8×11 atlas specification](https://raw.githubusercontent.com/mySebbe/malou-codex-pet/v2.0.0/metadata/atlas.json).
+
+V2's sixteen look-direction cells (rows 9–10) are retained in the imported
+atlas but are not individually selected: OpenPets currently emits only idle,
+left-run, and right-run motion, not a two-dimensional gaze target. It therefore
+does not invent directional behavior or claim full gaze support. A future gaze
+API can map those cells directly without changing the import contract.
+
 ## Image protocols & CSP
 
 Pet images are served to renderers through internal protocols


### PR DESCRIPTION
Fixes #134.

## Summary
- Strictly validate V2 `spriteVersionNumber: 2` manifests and single-image, alpha WebP 1536×2288 atlases before import.
- Preserve V1 rendering; use V2 native 11-row geometry and its neutral idle pose while documenting the unavailable 2D gaze directions.
- Share bounded no-follow pet-file reads across import and installed rendering; add released V1/V2 fixture regression coverage.

## Validation
- Focused Codex test, desktop typecheck/build, and packaging contract passed.
- Greptile: no findings after remediation.
- The unrelated `pet-motion-engine-nan-guard.test.ts` remains flaky/failing in this worktree; its failing pending-motion assertion is outside this change.