### PR TITLE
feat: add DeepSeek Harness integration

### DIFF
--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -194,6 +194,35 @@ registers a `/openpets` slash command namespace (`status`, `test`,
 non-blocking; it registers **no** model-callable tools, and never forwards
 prompt/assistant/tool/command text, paths, URLs, or secrets.
 
+## DSH - `@open-pets/dsh`
+
+Install the strict local-only v1 DSH plugin for a DSH profile:
+
+```sh
+dsh plugin --profile <profile> add @open-pets/dsh
+```
+
+The plugin is installed per profile; repeat the command for each profile that
+should receive the integration.
+
+`@open-pets/dsh` is a Cordis bundle that automatically maps DSH lifecycle
+events to OpenPets reactions:
+
+DSH always uses local IPC and the default pet, and ignores remote configuration.
+
+| DSH event | OpenPets reaction |
+|-----------|-------------------|
+| running | thinking |
+| idle | success |
+| error | error |
+| approval/request | waiting |
+
+Automatic dispatch is non-blocking and uses only curated categorical speech.
+The bundle never forwards prompts, tool payloads or results, paths, URLs,
+secrets, or arbitrary event text. Idle/success is briefly suppressed after an
+error so the error state remains visible. DSH adds no model tools or MCP setup;
+the existing OpenPets MCP integration remains separately configurable.
+
 ## The CLI - `@open-pets/cli`
 
 The user-facing front door (`openpets`), and the package that composes the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,12 @@ There are three runtime worlds. Keep them distinct in your head.
    This is the only long-lived process; remote control is disabled by default.
 2. **Agent-side integrations** (`packages/*`) - short-lived code that runs
    inside or alongside a coding agent (Claude Code hooks, the MCP server,
-   OpenCode plugin, Cursor config, Pi extension, the CLI). They translate agent
-   activity into pet commands and send them over local IPC unless an explicit
-   remote endpoint/token configuration selects the separate remote protocol.
+   OpenCode plugin, Cursor config, Pi extension, the DSH Cordis bundle, the
+   CLI). They translate agent activity into pet commands and send them over
+   local IPC unless an explicit remote endpoint/token configuration selects the
+   separate remote protocol.
+   `@open-pets/dsh` is the strict local-only v1 exception: it always uses local
+   IPC and the default pet and ignores all remote configuration.
 3. **The public web origin** (`openpets.dev`, source in `web/`) - static
    catalogs and asset hosting. The app fetches pet/plugin catalogs and downloads
    ZIPs from here. Only the *data* side of `web/` (catalogs, ZIP hosting, pet
@@ -67,13 +70,17 @@ encrypted overlay with its own ACLs; CGNAT addressing alone is not encryption.
 | `@open-pets/cursor` | Cursor MCP config + project rules management | [Agent integrations](/agent-integrations) |
 | `@open-pets/pi` | Pi coding-agent extension + `/openpets` commands | [Agent integrations](/agent-integrations) |
 | `@open-pets/agent-events` | Shared, validated speech pools for agent feedback | [Agent integrations](/agent-integrations) |
+| `@open-pets/dsh` | Strict local-only v1 Cordis bundle for DSH lifecycle reactions | [Agent integrations](/agent-integrations) |
 | `@open-pets/plugin-sdk` | Public SDK v3 type contract + deterministic test harness | [Plugin SDK v3](/sdk) |
 | `install-pet` | Standalone pet installer (works with or without the running app) | [Pets](/pets) |
 | `pet-format` | Tiny marker/identity type for pet packages | - |
 
-The dependency spine: every integration depends on `@open-pets/client`; the
-`cli` composes `claude`, `opencode`, `cursor`, and `mcp`; `claude`/`opencode`/`pi`
-depend on `agent-events` for safe speech.
+The dependency spine: every integration, including `@open-pets/dsh`, depends on
+`@open-pets/client`; the `cli` composes `claude`, `opencode`, `cursor`, and
+`mcp`; `claude`/`opencode`/`pi`/`dsh` use curated speech for safe automatic
+feedback.
+`@open-pets/dsh` is strict local-only v1: it always uses local IPC and the
+default pet and ignores remote configuration.
 
 ## End-to-end flows
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -72,6 +72,9 @@ Each package runs its own `check`/`test`. Notable contract/boundary coverage:
   representative plugin against the test harness to detect drift between the
   published types (`index.ts`), the harness (`testing.ts`), and the desktop
   bridge. Changing the SDK without updating all three fails here. See [Plugin SDK v3](/sdk).
+- `@open-pets/dsh` - package artifact/load smoke: confirm the built or published
+  artifact loads as the DSH Cordis bundle and its automatic dispatch wiring is
+  available without model tools or MCP setup. See [Agent integrations](/agent-integrations).
 - `packages/cursor/src/check-cursor.ts`, `packages/opencode` checks, etc. - validate the safe config-write behavior (status classification, redaction,
   symlink/oversize rejection, atomic writes, uninstall preserving user entries).
   See [Agent integrations](/agent-integrations).
@@ -150,7 +153,8 @@ after to confirm the deploy landed. See [Catalogs](/catalog).
 Before shipping, the relevant gate must be green:
 
 - **A package change** → `pnpm check` + `pnpm test` (incl. contract + conformance
-  checks) pass.
+  checks) pass; for `@open-pets/dsh`, the package artifact/load smoke also
+  passes.
 - **An app change** → desktop behavior + contract + runtime checks pass; if it
   touches packaging/CSP/bundled plugins, `check-packaging-contract.ts` passes.
   A delivery, trusted-asset protocol, or sprite-picker change additionally needs

--- a/packages/client/contracts/client-protocol.contract.ts
+++ b/packages/client/contracts/client-protocol.contract.ts
@@ -140,6 +140,21 @@ restoreEnvironment("OPENPETS_REMOTE_TOKEN", previousRemoteEnvironment.token);
 restoreEnvironment("OPENPETS_REMOTE_CLIENT_ID", previousRemoteEnvironment.clientId);
 restoreEnvironment("OPENPETS_DISCOVERY_FILE", previousRemoteEnvironment.discovery);
 
+process.env.OPENPETS_REMOTE_ENDPOINT = "tcp://8.8.8.8:37645";
+process.env.OPENPETS_REMOTE_TOKEN = "too-short";
+try {
+  const localOnlyClient = createOpenPetsClient({
+    remote: false,
+    remoteEndpoint: "tcp://8.8.8.8:37645",
+    remoteToken: "too-short",
+    remoteClientId: "ignored",
+  });
+  assert.equal(localOnlyClient.transport, "local", "remote: false must override flat and environment remote configuration");
+} finally {
+  restoreEnvironment("OPENPETS_REMOTE_ENDPOINT", previousRemoteEnvironment.endpoint);
+  restoreEnvironment("OPENPETS_REMOTE_TOKEN", previousRemoteEnvironment.token);
+}
+
 await withRemoteServer("timeout", async (endpoint) => {
   const client = createOpenPetsClient({ remote: { endpoint, token: "x".repeat(43) }, responseTimeoutMs: 50 });
   await assert.rejects(client.react("working"), (error: unknown) => error instanceof OpenPetsClientError && error.code === "response_timeout");

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -21,7 +21,7 @@ const SESSION_NONCE = randomUUID();
 export interface OpenPetsClientOptions {
   readonly discoveryPath?: string;
   /** Explicit remote mode. Remote mode never reads the local discovery file. */
-  readonly remote?: OpenPetsRemoteOptions;
+  readonly remote?: OpenPetsRemoteOptions | false;
   readonly remoteEndpoint?: string;
   readonly remoteToken?: string;
   readonly remoteClientId?: string;
@@ -199,6 +199,7 @@ interface ResolvedRemoteOptions {
 }
 
 function resolveRemoteOptions(options: OpenPetsClientOptions): ResolvedRemoteOptions | null {
+  if (options.remote === false) return null;
   const explicit = options.remote;
   const hasFlatRemote = options.remoteEndpoint !== undefined || options.remoteToken !== undefined || options.remoteClientId !== undefined;
   const hasEnvironmentRemote = process.env.OPENPETS_REMOTE_ENDPOINT !== undefined || process.env.OPENPETS_REMOTE_TOKEN !== undefined || process.env.OPENPETS_REMOTE_CLIENT_ID !== undefined;

--- a/packages/dsh/cordis.patch.yml
+++ b/packages/dsh/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: openpets-dsh
+      name: '@open-pets/dsh'

--- a/packages/dsh/package.json
+++ b/packages/dsh/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@open-pets/dsh",
+  "version": "3.3.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alvinunreal/openpets.git",
+    "directory": "packages/dsh"
+  },
+  "type": "module",
+  "keywords": [
+    "dsh",
+    "cordis",
+    "openpets",
+    "coding-agent"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/runtime.d.ts",
+    "dist/runtime.js",
+    "cordis.patch.yml"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "node dist/runtime.test.js && node dist/check-dsh.js",
+    "check": "pnpm typecheck && pnpm build && pnpm test",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@open-pets/agent-events": "workspace:*",
+    "@open-pets/client": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@types/node": "^25.6.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/dsh/src/check-dsh.ts
+++ b/packages/dsh/src/check-dsh.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+import { apply, name } from "./index.js";
+
+assert.equal(name, "@open-pets/dsh");
+assert.equal(typeof apply, "function");
+
+{
+  const packageDirectory = join(import.meta.dirname, "..");
+  const manifest = JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8")) as Record<string, unknown>;
+  assert.equal(manifest.name, "@open-pets/dsh");
+  assert.equal(manifest.version, "3.3.0");
+  assert.deepEqual(manifest.files, [
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/runtime.d.ts",
+    "dist/runtime.js",
+    "cordis.patch.yml",
+  ]);
+  assert.deepEqual(manifest.exports, {
+    ".": { types: "./dist/index.d.ts", default: "./dist/index.js" },
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json",
+  });
+  assert.deepEqual(manifest.dsh, { bundle: { patch: "./cordis.patch.yml" } });
+  assert.equal((manifest.peerDependencies as Record<string, string>)["@deepseek-ai/cordis"], "^4.0.1");
+  for (const output of ["dist/index.js", "dist/index.d.ts", "dist/runtime.js", "dist/runtime.d.ts"]) {
+    assert.equal(existsSync(join(packageDirectory, output)), true);
+  }
+  const patchLines = readFileSync(join(packageDirectory, "cordis.patch.yml"), "utf8").trim().split(/\r?\n/);
+  assert.deepEqual(patchLines.map((line) => line.trim()), [
+    "- insert:",
+    "- id: openpets-dsh",
+    "name: '@open-pets/dsh'",
+  ]);
+  assert.equal(patchLines[0]?.trimStart().startsWith("- "), true, "patch must be a top-level YAML array");
+  assert.equal(patchLines[1]?.trimStart().startsWith("- "), true, "insert value must be a YAML array");
+  assert.equal(createRequire(import.meta.url)("@open-pets/dsh/package.json").name, "@open-pets/dsh");
+}
+
+console.log("DSH package artifact checks passed.");

--- a/packages/dsh/src/check-dsh.ts
+++ b/packages/dsh/src/check-dsh.ts
@@ -12,7 +12,7 @@ assert.equal(typeof apply, "function");
   const packageDirectory = join(import.meta.dirname, "..");
   const manifest = JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8")) as Record<string, unknown>;
   assert.equal(manifest.name, "@open-pets/dsh");
-  assert.equal(manifest.version, "3.3.0");
+  assert.match(manifest.version as string, /^\d+\.\d+\.\d+$/, "package version must use stable semver");
   assert.deepEqual(manifest.files, [
     "dist/index.d.ts",
     "dist/index.js",

--- a/packages/dsh/src/index.ts
+++ b/packages/dsh/src/index.ts
@@ -1,0 +1,23 @@
+import type { Context } from "@deepseek-ai/cordis";
+
+export {
+  classifyDshEvent,
+  createOpenPetsDshClient,
+  createOpenPetsDshRuntime,
+  registerDshListeners,
+  type DshCordisApi,
+  type DshAgentStatus,
+  type DshEventName,
+  type DshEventDecision,
+  type OpenPetsDshOptions,
+  type OpenPetsDshRuntime,
+} from "./runtime.js";
+
+import { registerDshListeners, type OpenPetsDshOptions } from "./runtime.js";
+
+export const name = "@open-pets/dsh";
+
+/** Install the OpenPets listeners into the DSH Cordis context. */
+export function apply(ctx: Context, options: OpenPetsDshOptions = {}): void {
+  registerDshListeners(ctx, options);
+}

--- a/packages/dsh/src/runtime.test.ts
+++ b/packages/dsh/src/runtime.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+
+import { hookSpeechPools } from "@open-pets/agent-events";
+import type { Context } from "@deepseek-ai/cordis";
+
+import { apply, createOpenPetsDshClient } from "./index.js";
+
+type RecordedCall = {
+  readonly message: string;
+  readonly options?: unknown;
+};
+
+const forbiddenContent = [
+  "PRIVATE_PROMPT",
+  "PRIVATE_TOOL_RESULT",
+  "/Users/private/project/file.ts",
+  "https://private.example.test/secret",
+  "token=private-secret",
+];
+
+{
+  const calls: RecordedCall[] = [];
+  const scheduled: Array<() => Promise<void>> = [];
+  const handlers = new Map<string, (...args: readonly unknown[]) => unknown>();
+  const context = {
+    on(eventName: string, listener: (...args: readonly unknown[]) => unknown) {
+      handlers.set(eventName, listener);
+    },
+  } as unknown as Context;
+
+  apply(context, {
+    schedule: (work: () => Promise<void>) => { scheduled.push(work); },
+    clientFactory: () => createMockClient(calls),
+    random: () => 0,
+  });
+
+  const approvalHandler = handlers.get("approval/request");
+  assert.ok(approvalHandler);
+  const nextResult = { approved: true };
+  let nextCalls = 0;
+  const returned = approvalHandler(
+    createPayload(),
+    () => {
+      nextCalls += 1;
+      return nextResult;
+    },
+  );
+  assert.equal(returned, nextResult);
+  assert.equal(nextCalls, 1);
+  assert.equal(scheduled.length, 1, "approval dispatch must only be scheduled");
+  assert.deepEqual(calls, [], "approval must not wait for or call IPC");
+  await scheduled.shift()?.();
+  assert.deepEqual(calls, [{ message: hookSpeechPools.permission[0] ?? "", options: { reaction: "waiting" } }]);
+
+  const statusHandler = handlers.get("agent/status");
+  assert.ok(statusHandler);
+  statusHandler(createPayload({ status: "running" }));
+  assert.equal(scheduled.length, 1);
+  assert.equal(calls.length, 1);
+  await scheduled.shift()?.();
+  assert.deepEqual(calls.at(-1), { message: hookSpeechPools.thinking[0], options: { reaction: "thinking" } });
+  assertNoForbiddenContent(calls);
+}
+
+{
+  let now = 10_000;
+  const scheduled: Array<() => Promise<void>> = [];
+  const calls: RecordedCall[] = [];
+  const handlers = new Map<string, (...args: readonly unknown[]) => unknown>();
+  const context = {
+    on(eventName: string, listener: (...args: readonly unknown[]) => unknown) {
+      handlers.set(eventName, listener);
+    },
+  } as unknown as Context;
+  apply(context, {
+    now: () => now,
+    schedule: (work: () => Promise<void>) => { scheduled.push(work); },
+    clientFactory: () => createMockClient(calls),
+    random: () => 0,
+  });
+
+  handlers.get("agent/error")?.(createPayload());
+  assert.equal(scheduled.length, 1);
+  await scheduled.shift()?.();
+  assert.deepEqual(calls.at(-1), { message: hookSpeechPools.error[0], options: { reaction: "error" } });
+  now += 4_999;
+  handlers.get("agent/status")?.(createPayload({ status: "idle" }));
+  assert.equal(scheduled.length, 0, "idle must be suppressed for five seconds after an error");
+  now += 1;
+  handlers.get("agent/status")?.(createPayload({ status: "idle" }));
+  assert.equal(scheduled.length, 1);
+  await scheduled.shift()?.();
+  assert.deepEqual(calls.at(-1), { message: hookSpeechPools.success[0], options: { reaction: "success" } });
+  assertNoForbiddenContent(calls);
+}
+
+{
+  const previousEndpoint = process.env.OPENPETS_REMOTE_ENDPOINT;
+  const previousToken = process.env.OPENPETS_REMOTE_TOKEN;
+  process.env.OPENPETS_REMOTE_ENDPOINT = "tcp://8.8.8.8:37645";
+  process.env.OPENPETS_REMOTE_TOKEN = "too-short";
+  try {
+    assert.equal(createOpenPetsDshClient().transport, "local");
+  } finally {
+    restoreEnvironment("OPENPETS_REMOTE_ENDPOINT", previousEndpoint);
+    restoreEnvironment("OPENPETS_REMOTE_TOKEN", previousToken);
+  }
+}
+
+console.log("DSH runtime behavior checks passed.");
+
+function createMockClient(calls: RecordedCall[]) {
+  return {
+    hello: async () => ({}),
+    status: async () => ({ ok: true, appRunning: true }),
+    listPets: async () => ({ ok: true as const, defaultPetId: "builtin", pets: [] }),
+    installPet: async () => ({ ok: true as const, petId: "unused", displayName: "Unused", installed: true as const }),
+    installLocalPet: async () => ({ ok: true as const, petId: "unused", displayName: "Unused", installed: true as const }),
+    acquireLease: async () => { throw new Error("leases are not used"); },
+    heartbeatLease: async () => ({ leaseId: "unused", expiresAt: 0 }),
+    releaseLease: async () => ({ released: true }),
+    react: async () => undefined,
+    say: async (message: string, options?: unknown) => { calls.push({ message, options }); },
+    showMedia: async () => ({ ok: true, shown: true }),
+  };
+}
+
+function createPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent: "ignored-agent",
+    status: "idle",
+    prompt: forbiddenContent[0],
+    toolResult: forbiddenContent[1],
+    path: forbiddenContent[2],
+    url: forbiddenContent[3],
+    secret: forbiddenContent[4],
+    ...overrides,
+  };
+}
+
+function assertNoForbiddenContent(calls: readonly RecordedCall[]): void {
+  const serialized = JSON.stringify(calls);
+  for (const content of forbiddenContent) assert.equal(serialized.includes(content), false, `forwarded forbidden content: ${content}`);
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/packages/dsh/src/runtime.ts
+++ b/packages/dsh/src/runtime.ts
@@ -1,0 +1,131 @@
+import { pickHookSpeech, validateHookSpeech, type HookSpeechCategory } from "@open-pets/agent-events";
+import { createOpenPetsClient, type OpenPetsClient, type OpenPetsReaction } from "@open-pets/client";
+import type { Context } from "@deepseek-ai/cordis";
+
+export type DshEventName = "agent/status" | "agent/error" | "approval/request";
+export type DshAgentStatus = "running" | "idle";
+
+export interface DshEventDecision {
+  readonly reaction: OpenPetsReaction;
+  readonly speechCategory: HookSpeechCategory;
+}
+
+export interface OpenPetsDshOptions {
+  readonly clientFactory?: () => OpenPetsClient;
+  readonly schedule?: (work: () => Promise<void>) => void | Promise<void>;
+  readonly random?: () => number;
+  readonly now?: () => number;
+}
+
+export interface OpenPetsDshRuntime {
+  readonly handleStatus: (event: unknown) => void;
+  readonly handleEvent: (eventName: DshEventName, event?: unknown) => void;
+  readonly handleApproval: () => void;
+}
+
+export type DshCordisApi = Pick<Context, "on">;
+
+const automaticTimeoutMs = 500;
+const errorSuccessSuppressionMs = 5_000;
+
+/**
+ * Map only the categorical values defined by DSH. Event payloads are
+ * deliberately not inspected or forwarded. For agent/status, only the
+ * categorical `status` property is read from the event envelope.
+ */
+export function classifyDshEvent(eventName: DshEventName | string, event?: unknown): DshEventDecision | undefined {
+  if (eventName === "agent/status") {
+    const status = typeof event === "string" ? event : getStatusCategory(event);
+    if (status === "running") return { reaction: "thinking", speechCategory: "thinking" };
+    if (status === "idle") return { reaction: "success", speechCategory: "success" };
+    return undefined;
+  }
+  if (eventName === "agent/error") return { reaction: "error", speechCategory: "error" };
+  if (eventName === "approval/request") return { reaction: "waiting", speechCategory: "permission" };
+  return undefined;
+}
+
+export function createOpenPetsDshRuntime(options: OpenPetsDshOptions = {}): OpenPetsDshRuntime {
+  const clientFactory = options.clientFactory ?? createOpenPetsDshClient;
+  const schedule = options.schedule ?? defaultSchedule;
+  let client: OpenPetsClient | undefined;
+  let recentErrorAt = Number.NEGATIVE_INFINITY;
+
+  const getClient = (): OpenPetsClient => {
+    client ??= clientFactory();
+    return client;
+  };
+
+  const dispatch = (decision: DshEventDecision | undefined): void => {
+    if (!decision) return;
+
+    const now = options.now?.() ?? Date.now();
+    if (decision.reaction === "error") {
+      recentErrorAt = now;
+    } else if (decision.reaction === "success" && now - recentErrorAt < errorSuccessSuppressionMs) {
+      return;
+    }
+
+    const work = async (): Promise<void> => {
+      try {
+        const speech = validateHookSpeech(pickHookSpeech(decision.speechCategory, options.random));
+        await getClient().say(speech, { reaction: decision.reaction });
+      } catch {
+        // Automatic agent listeners must never affect the DSH operation.
+      }
+    };
+
+    try {
+      const scheduled = schedule(work);
+      if (isPromiseLike(scheduled)) void scheduled.catch(() => undefined);
+    } catch {
+      // A scheduler supplied by the host is optional infrastructure.
+    }
+  };
+
+  return {
+    handleStatus(event) {
+      dispatch(classifyDshEvent("agent/status", event));
+    },
+    handleEvent(eventName, event) {
+      dispatch(classifyDshEvent(eventName, event));
+    },
+    handleApproval() {
+      dispatch(classifyDshEvent("approval/request"));
+    },
+  };
+}
+
+export function createOpenPetsDshClient(): OpenPetsClient {
+  return createOpenPetsClient({
+    remote: false,
+    connectTimeoutMs: automaticTimeoutMs,
+    responseTimeoutMs: automaticTimeoutMs,
+  });
+}
+
+/** Register the three DSH listeners without taking ownership of their flow. */
+export function registerDshListeners(cordis: DshCordisApi, options: OpenPetsDshOptions = {}): OpenPetsDshRuntime {
+  const runtime = createOpenPetsDshRuntime(options);
+  const on = cordis.on as unknown as (eventName: DshEventName, listener: (...args: readonly unknown[]) => unknown) => unknown;
+  on("agent/status", (event: unknown) => runtime.handleStatus(event));
+  on("agent/error", () => runtime.handleEvent("agent/error"));
+  on("approval/request", (_request: unknown, next: unknown) => {
+    runtime.handleApproval();
+    return typeof next === "function" ? next() : undefined;
+  });
+  return runtime;
+}
+
+function defaultSchedule(work: () => Promise<void>): void {
+  void Promise.resolve().then(work).catch(() => undefined);
+}
+
+function isPromiseLike(value: void | Promise<void>): value is Promise<void> {
+  return typeof value === "object" && value !== null && typeof value.then === "function";
+}
+
+function getStatusCategory(event: unknown): unknown {
+  if (typeof event !== "object" || event === null) return undefined;
+  return (event as { readonly status?: unknown }).status;
+}

--- a/packages/dsh/tsconfig.json
+++ b/packages/dsh/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,25 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/dsh:
+    dependencies:
+      '@open-pets/agent-events':
+        specifier: workspace:*
+        version: link:../agent-events
+      '@open-pets/client':
+        specifier: workspace:*
+        version: link:../client
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: ^4.0.1
+        version: 4.0.1
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/install-pet:
     dependencies:
       '@open-pets/client':
@@ -783,6 +802,21 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@deepseek-ai/cordis@4.0.1':
+    resolution: {integrity: sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==}
+    hasBin: true
+    peerDependencies:
+      '@deepseek-ai/cordis-plugin-include': ^1.0.6
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+    peerDependenciesMeta:
+      '@deepseek-ai/cordis-plugin-include':
+        optional: true
+      '@deepseek-ai/cordis-plugin-loader':
+        optional: true
+
+  '@deepseek-ai/cosmokit@1.8.2':
+    resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -7677,6 +7711,13 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@deepseek-ai/cordis@4.0.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
+  '@deepseek-ai/cosmokit@1.8.2': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -14,6 +14,7 @@ const publishOrder = [
   "packages/sdk",
   "packages/client",
   "packages/agent-events",
+  "packages/dsh",
   "packages/mcp",
   "packages/claude",
   "packages/opencode",
@@ -269,13 +270,14 @@ Packages:
   1. @open-pets/plugin-sdk
   2. @open-pets/client
   3. @open-pets/agent-events
-  4. @open-pets/mcp
-  5. @open-pets/claude
-  6. @open-pets/opencode
-  7. @open-pets/cursor
-  8. @open-pets/pi
-  9. @open-pets/cli
-  10. install-pet
+  4. @open-pets/dsh
+  5. @open-pets/mcp
+  6. @open-pets/claude
+  7. @open-pets/opencode
+  8. @open-pets/cursor
+  9. @open-pets/pi
+  10. @open-pets/cli
+  11. install-pet
 
 Options:
   --yes            publish to npm; without this, runs pnpm publish --dry-run


### PR DESCRIPTION
## Summary
- add the publishable `@open-pets/dsh` Cordis bundle with strict local-only lifecycle reactions
- add focused nonblocking, payload-safety, error-precedence, and local-routing tests
- register DSH in the npm release workflow and document profile-scoped setup

## Validation
- `pnpm --filter @open-pets/dsh check`
- `pnpm --filter @open-pets/client check`
- packed-tarball DSH smoke: `dsh plugin --profile smoke add <tarball>`, `--dump-config`, and installed bundle listener load
- `greptile review --json` (clean)
- `pnpm build && pnpm check && pnpm test` reaches an unrelated existing desktop failure: `pet-motion-engine-nan-guard.test.ts` leaves `motionMoveTo` pending on NaN coordinates; direct retry reproduces it.