### PR TITLE
feat(plugins): add Pet Assistant capabilities

### DIFF
--- a/docs/official-plugins.md
+++ b/docs/official-plugins.md
@@ -61,6 +61,11 @@ Those defaults are defined in `apps/desktop/src/plugin-service.ts`.
 Everything else is installable from the catalog, not preloaded into a fresh app
 install.
 
+Focus Buddy and Quick Reminders also expose typed Pet Assistant capabilities
+when enabled. Their assistant operations use the same durable domain state as
+their pet-menu controls, while the host conversation owns the spoken or chat
+response.
+
 The same file also defines `staleBundledPluginIds`, a cleanup list for old
 bundled plugins that should be removed during upgrade. Keep that list when old
 plugin ids need a clean migration, but do not optimize new runtime behavior for

--- a/docs/openpets_v4.md
+++ b/docs/openpets_v4.md
@@ -146,6 +146,21 @@ then the voice adapters and chat UI; finally history management and the
 pet-owned Talk controls. OpenAI Realtime is an optimized optional adapter, not
 the provider-neutral basis for voice.
 
+## Two-developer GitHub workflow
+
+The [v4 epic](https://github.com/alvinunreal/openpets/issues/142) is the shared
+coordination point for v4 work.
+
+1. Before coding, claim one unclaimed child issue: comment on the epic with the
+   issue number and intended scope, assign the child issue to yourself, and ask
+   for a handoff if another developer has already claimed it.
+2. Work on a branch named for that issue. Keep the PR focused, link it to the
+   child issue, run the relevant checks and review, then commit and push it.
+3. Merge only after the PR is ready. The PR closes its child issue; then comment
+   on the epic with the merged PR link, delivered behavior, and validation.
+4. Update the epic checklist and this delivery tracker only for merged work.
+   Claim the next issue through the epic before starting it.
+
 ## Decisions made for v4
 
 - Text/reasoning, speech-to-text, and text-to-speech providers are selected

--- a/docs/openpets_v4.md
+++ b/docs/openpets_v4.md
@@ -127,7 +127,7 @@ verifiable delivery work:
   Pet Assistant conversation and tool loop (complete; no user surface yet).
 - [#143](https://github.com/alvinunreal/openpets/issues/143) and
   [#144](https://github.com/alvinunreal/openpets/issues/144) — Focus Buddy and
-  Quick Reminders assistant capabilities.
+  Quick Reminders assistant capabilities (complete).
 - [#145](https://github.com/alvinunreal/openpets/issues/145) — independent text,
   speech-to-text, and text-to-speech provider profiles.
 - [#146](https://github.com/alvinunreal/openpets/issues/146) — editable pet
@@ -141,8 +141,8 @@ verifiable delivery work:
   [#150](https://github.com/alvinunreal/openpets/issues/150) — shared
   chat/transcript UI, recent-history management, and pet Talk controls.
 
-With #137 and #138 complete, the next work is #143 and #144; then #145 and
-#146; then the voice adapters and chat UI; finally history management and the
+With #137, #138, #143, and #144 complete, the next work is #145 and #146;
+then the voice adapters and chat UI; finally history management and the
 pet-owned Talk controls. OpenAI Realtime is an optimized optional adapter, not
 the provider-neutral basis for voice.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -138,6 +138,16 @@ Handlers receive a validated clone and must return an object-shaped,
 JSON-compatible, size-bounded result. Unsupported or malformed schemas,
 circular/non-JSON data, and oversized values are rejected.
 
+Focus Buddy and Quick Reminders are the first official examples. Focus Buddy
+registers `focus.start`, `focus.status`, `focus.pause`, `focus.resume`, and
+`focus.end`; its start capability accepts an explicit duration in minutes.
+Quick Reminders registers `reminders.create`, `reminders.list`,
+`reminders.complete`, `reminders.snooze`, and `reminders.remove`.
+`reminders.create` accepts an absolute ISO due time with a `Z` suffix or numeric
+UTC offset, never a guessed local or natural-language date. Both plugins reuse
+their direct-control domain operations but keep assistant calls free of
+command-specific speech and bubble confirmations.
+
 The current v1 quotas are 32 registrations per plugin, 16 KiB per schema,
 schema depth six, 32 properties per object, 128 total schema properties, 32
 array items, 4,096 characters per string, 64 KiB per input or result, and a

--- a/plugins/official/openpets.focus-buddy/index.js
+++ b/plugins/official/openpets.focus-buddy/index.js
@@ -6,6 +6,8 @@ export const STORAGE_KEY = "session";
 export const SHORT_BREAK_MS = 5 * 60_000;
 export const LONG_BREAK_MS = 15 * 60_000;
 const DISPLAY_REFRESH_INTERVAL_MS = 60_000;
+const MIN_ASSISTANT_FOCUS_MINUTES = 1;
+const MAX_ASSISTANT_FOCUS_MINUTES = 120;
 
 const pinnedBubbles = new WeakMap();
 const contextStates = new WeakMap();
@@ -62,6 +64,39 @@ export function breakMs(completedFocusCount = 0) {
 export function minutesLeft(session, now = Date.now()) {
   const ms = session?.pausedRemainingMs ?? Math.max(0, (session?.endsAt ?? now) - now);
   return Math.max(1, Math.ceil(ms / 60_000));
+}
+
+function assistantSessionStatus(session, now = Date.now()) {
+  if (!active(session)) {
+    return {
+      state: "idle",
+      mode: null,
+      minutes: 0,
+      paused: false,
+      completedFocusCount: session?.completedFocusCount ?? 0,
+    };
+  }
+  return {
+    state: session.pausedRemainingMs ? "paused" : "active",
+    mode: session.mode,
+    minutes: minutesLeft(session, now),
+    paused: Boolean(session.pausedRemainingMs),
+    completedFocusCount: session.completedFocusCount ?? 0,
+  };
+}
+
+function assistantSuccess(session) {
+  return { ok: true, ...assistantSessionStatus(session) };
+}
+
+function assistantInvalid(error, session) {
+  return { ok: false, error, ...assistantSessionStatus(session) };
+}
+
+function assistantFocusMinutes(input) {
+  const minutes = input?.minutes;
+  if (!Number.isInteger(minutes) || minutes < MIN_ASSISTANT_FOCUS_MINUTES || minutes > MAX_ASSISTANT_FOCUS_MINUTES) return null;
+  return minutes;
 }
 
 function active(session) {
@@ -188,22 +223,22 @@ async function updatePinned(ctx, session, token) {
   setPinnedBubble(ctx, nextBubble);
 }
 
-async function startMode(ctx, mode, durationMs, completedFocusCount, token) {
+async function startMode(ctx, mode, durationMs, completedFocusCount, token, { showPinned = true } = {}) {
   const now = Date.now();
   const session = await saveSession(ctx, { mode, startedAt: now, endsAt: now + durationMs, pausedRemainingMs: null, completedFocusCount }, token);
   if (!session || !isCurrent(ctx, token)) return undefined;
   await scheduleEnd(ctx, session, token);
-  await updatePinned(ctx, session, token);
+  if (showPinned) await updatePinned(ctx, session, token);
   await scheduleDisplayRefresh(ctx, session, token);
   return session;
 }
 
-async function startFocusImpl(ctx, token) {
+async function startFocusImpl(ctx, token, options) {
   const current = await getSession(ctx);
   if (!isCurrent(ctx, token)) return;
   const cfg = await config(ctx);
   if (!isCurrent(ctx, token)) return;
-  return startMode(ctx, "focus", focusMs(cfg), current?.completedFocusCount ?? 0, token);
+  return startMode(ctx, "focus", focusMs(cfg), current?.completedFocusCount ?? 0, token, options);
 }
 
 export async function startFocus(ctx) {
@@ -218,10 +253,12 @@ export async function startBreak(ctx, completedFocusCount) {
   return lifecycle(ctx, (token) => startBreakImpl(ctx, completedFocusCount, token));
 }
 
-async function pauseOrResumeImpl(ctx, token) {
+async function changePauseStateImpl(ctx, action, token, { showPinned = true } = {}) {
   const session = await getSession(ctx);
   if (!isCurrent(ctx, token)) return;
-  if (!active(session)) return startFocusImpl(ctx, token);
+  if (!active(session)) return { kind: "invalid", session, error: "no_active_session" };
+  if (action === "pause" && session.pausedRemainingMs) return { kind: "invalid", session, error: "already_paused" };
+  if (action === "resume" && !session.pausedRemainingMs) return { kind: "invalid", session, error: "not_paused" };
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   if (!isCurrent(ctx, token)) return;
   if (session.pausedRemainingMs) {
@@ -235,22 +272,32 @@ async function pauseOrResumeImpl(ctx, token) {
   await saveSession(ctx, session, token);
   if (!isCurrent(ctx, token)) return;
   await scheduleEnd(ctx, session, token);
-  await updatePinned(ctx, session, token);
+  if (showPinned) await updatePinned(ctx, session, token);
   await scheduleDisplayRefresh(ctx, session, token);
-  return session;
+  return { kind: "updated", session };
+}
+
+async function pauseOrResumeImpl(ctx, token) {
+  const result = await changePauseStateImpl(ctx, "toggle", token);
+  if (result?.kind === "invalid" && result.error === "no_active_session") return startFocusImpl(ctx, token);
+  return result?.session;
 }
 
 export async function pauseOrResume(ctx) {
   return lifecycle(ctx, (token) => pauseOrResumeImpl(ctx, token));
 }
 
-async function endSessionImpl(ctx, token) {
+async function endSessionImpl(ctx, token, { showPinned = true } = {}) {
+  const session = await getSession(ctx);
+  if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(SCHEDULE_ID);
   if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(DISPLAY_REFRESH_SCHEDULE_ID);
   if (!isCurrent(ctx, token)) return;
-  await saveSession(ctx, null, token);
-  await updatePinned(ctx, null, token);
+  const cleared = await saveSession(ctx, null, token);
+  if (cleared === undefined || !isCurrent(ctx, token)) return;
+  if (showPinned) await updatePinned(ctx, null, token);
+  return session;
 }
 
 export async function endSession(ctx) {
@@ -351,15 +398,87 @@ export async function reconcile(ctx) {
   return lifecycle(ctx, (token) => reconcileImpl(ctx, token));
 }
 
-async function showStatusImpl(ctx, token) {
+async function readStatusImpl(ctx, token, { showPinned = true, speakWhenIdle = true } = {}) {
   const session = await getSession(ctx);
   if (!isCurrent(ctx, token)) return;
-  if (!active(session)) return ctx.pet.speak(ctx.t("speech.idle"));
-  await updatePinned(ctx, session, token);
+  if (showPinned) {
+    if (!active(session) && speakWhenIdle) return ctx.pet.speak(ctx.t("speech.idle"));
+    await updatePinned(ctx, session, token);
+  }
+  return session;
 }
 
 async function showStatus(ctx) {
-  return enqueue(ctx, async () => showStatusImpl(ctx, stateFor(ctx).token));
+  return enqueue(ctx, async () => readStatusImpl(ctx, stateFor(ctx).token));
+}
+
+async function assistantStart(ctx, input) {
+  return lifecycle(ctx, async (token) => {
+    const current = await getSession(ctx);
+    if (!isCurrent(ctx, token)) return;
+    const minutes = assistantFocusMinutes(input);
+    if (minutes === null) return assistantInvalid("invalid_duration", current);
+    const session = await startMode(ctx, "focus", minutes * 60_000, current?.completedFocusCount ?? 0, token, { showPinned: false });
+    return session ? assistantSuccess(session) : assistantInvalid("session_unavailable", current);
+  });
+}
+
+async function assistantStatus(ctx) {
+  return enqueue(ctx, async () => {
+    const session = await readStatusImpl(ctx, stateFor(ctx).token, { showPinned: false, speakWhenIdle: false });
+    return assistantSuccess(session);
+  });
+}
+
+async function assistantPauseOrResume(ctx, action) {
+  return lifecycle(ctx, async (token) => {
+    const result = await changePauseStateImpl(ctx, action, token, { showPinned: false });
+    if (!result || result.kind === "invalid") return assistantInvalid(result?.error ?? "session_unavailable", result?.session);
+    return assistantSuccess(result.session);
+  });
+}
+
+async function assistantEnd(ctx) {
+  return lifecycle(ctx, async (token) => {
+    const current = await getSession(ctx);
+    if (!isCurrent(ctx, token)) return;
+    if (!active(current)) return assistantInvalid("no_active_session", current);
+    const ended = await endSessionImpl(ctx, token, { showPinned: false });
+    return ended ? assistantSuccess(null) : assistantInvalid("session_unavailable", current);
+  });
+}
+
+async function registerAssistantCapabilities(ctx) {
+  await ctx.assistant.registerCapability({
+    id: "focus.start",
+    description: "Start a focus session for an explicit duration in minutes.",
+    inputSchema: {
+      type: "object",
+      properties: { minutes: { type: "integer", minimum: MIN_ASSISTANT_FOCUS_MINUTES, maximum: MAX_ASSISTANT_FOCUS_MINUTES } },
+      required: ["minutes"],
+      additionalProperties: false,
+    },
+  }, (input) => assistantStart(ctx, input));
+  await ctx.assistant.registerCapability({
+    id: "focus.status",
+    description: "Read the current focus session status.",
+    inputSchema: { type: "object", additionalProperties: false },
+  }, () => assistantStatus(ctx));
+  await ctx.assistant.registerCapability({
+    id: "focus.pause",
+    description: "Pause the active focus session.",
+    inputSchema: { type: "object", additionalProperties: false },
+  }, () => assistantPauseOrResume(ctx, "pause"));
+  await ctx.assistant.registerCapability({
+    id: "focus.resume",
+    description: "Resume the paused focus session.",
+    inputSchema: { type: "object", additionalProperties: false },
+  }, () => assistantPauseOrResume(ctx, "resume"));
+  await ctx.assistant.registerCapability({
+    id: "focus.end",
+    description: "End the active focus session.",
+    inputSchema: { type: "object", additionalProperties: false },
+  }, () => assistantEnd(ctx));
 }
 
 async function handleAction(ctx, id) {
@@ -378,6 +497,7 @@ export function register(OpenPetsPlugin) {
       await ctx.commands.register({ id: "end-session", title: "$t:command.endSession.title", description: "$t:command.endSession.description", icon: focusIcon }, () => endSession(ctx));
       await ctx.commands.register({ id: "skip-to-break", title: "$t:command.skipToBreak.title", description: "$t:command.skipToBreak.description", icon: focusIcon }, () => skipToBreak(ctx));
       await ctx.commands.register({ id: "show-status", title: "$t:command.showStatus.title", description: "$t:command.showStatus.description", icon: focusIcon }, () => showStatus(ctx));
+      await registerAssistantCapabilities(ctx);
     },
     async stop() {},
   });

--- a/plugins/official/openpets.focus-buddy/index.js
+++ b/plugins/official/openpets.focus-buddy/index.js
@@ -176,7 +176,7 @@ async function scheduleDisplayRefresh(ctx, session, token) {
   }
 }
 
-async function updatePinned(ctx, session, token) {
+async function updatePinned(ctx, session, token, { create = true } = {}) {
   if (!isCurrent(ctx, token)) return;
   const pinnedBubble = getPinnedBubble(ctx);
   if (!active(session)) {
@@ -211,6 +211,7 @@ async function updatePinned(ctx, session, token) {
     }
   }
   if (!isCurrent(ctx, token)) return;
+  if (!create) return;
   const nextBubble = await ctx.ui.bubble(spec);
   if (!isCurrent(ctx, token)) {
     try { await nextBubble.dismiss(); } catch {}
@@ -223,12 +224,18 @@ async function updatePinned(ctx, session, token) {
   setPinnedBubble(ctx, nextBubble);
 }
 
-async function startMode(ctx, mode, durationMs, completedFocusCount, token, { showPinned = true } = {}) {
+async function updateExistingPinned(ctx, session, token) {
+  if (!getPinnedBubble(ctx)) return;
+  await updatePinned(ctx, session, token, { create: false });
+}
+
+async function startMode(ctx, mode, durationMs, completedFocusCount, token, { showPinned = true, syncExistingPinned = false } = {}) {
   const now = Date.now();
   const session = await saveSession(ctx, { mode, startedAt: now, endsAt: now + durationMs, pausedRemainingMs: null, completedFocusCount }, token);
   if (!session || !isCurrent(ctx, token)) return undefined;
   await scheduleEnd(ctx, session, token);
   if (showPinned) await updatePinned(ctx, session, token);
+  else if (syncExistingPinned) await updateExistingPinned(ctx, session, token);
   await scheduleDisplayRefresh(ctx, session, token);
   return session;
 }
@@ -253,7 +260,7 @@ export async function startBreak(ctx, completedFocusCount) {
   return lifecycle(ctx, (token) => startBreakImpl(ctx, completedFocusCount, token));
 }
 
-async function changePauseStateImpl(ctx, action, token, { showPinned = true } = {}) {
+async function changePauseStateImpl(ctx, action, token, { showPinned = true, syncExistingPinned = false } = {}) {
   const session = await getSession(ctx);
   if (!isCurrent(ctx, token)) return;
   if (!active(session)) return { kind: "invalid", session, error: "no_active_session" };
@@ -273,6 +280,7 @@ async function changePauseStateImpl(ctx, action, token, { showPinned = true } = 
   if (!isCurrent(ctx, token)) return;
   await scheduleEnd(ctx, session, token);
   if (showPinned) await updatePinned(ctx, session, token);
+  else if (syncExistingPinned) await updateExistingPinned(ctx, session, token);
   await scheduleDisplayRefresh(ctx, session, token);
   return { kind: "updated", session };
 }
@@ -287,7 +295,7 @@ export async function pauseOrResume(ctx) {
   return lifecycle(ctx, (token) => pauseOrResumeImpl(ctx, token));
 }
 
-async function endSessionImpl(ctx, token, { showPinned = true } = {}) {
+async function endSessionImpl(ctx, token, { showPinned = true, syncExistingPinned = false } = {}) {
   const session = await getSession(ctx);
   if (!isCurrent(ctx, token)) return;
   await ctx.schedule.cancel(SCHEDULE_ID);
@@ -297,6 +305,7 @@ async function endSessionImpl(ctx, token, { showPinned = true } = {}) {
   const cleared = await saveSession(ctx, null, token);
   if (cleared === undefined || !isCurrent(ctx, token)) return;
   if (showPinned) await updatePinned(ctx, null, token);
+  else if (syncExistingPinned) await updateExistingPinned(ctx, null, token);
   return session;
 }
 
@@ -418,7 +427,7 @@ async function assistantStart(ctx, input) {
     if (!isCurrent(ctx, token)) return;
     const minutes = assistantFocusMinutes(input);
     if (minutes === null) return assistantInvalid("invalid_duration", current);
-    const session = await startMode(ctx, "focus", minutes * 60_000, current?.completedFocusCount ?? 0, token, { showPinned: false });
+    const session = await startMode(ctx, "focus", minutes * 60_000, current?.completedFocusCount ?? 0, token, { showPinned: false, syncExistingPinned: true });
     return session ? assistantSuccess(session) : assistantInvalid("session_unavailable", current);
   });
 }
@@ -432,7 +441,7 @@ async function assistantStatus(ctx) {
 
 async function assistantPauseOrResume(ctx, action) {
   return lifecycle(ctx, async (token) => {
-    const result = await changePauseStateImpl(ctx, action, token, { showPinned: false });
+    const result = await changePauseStateImpl(ctx, action, token, { showPinned: false, syncExistingPinned: true });
     if (!result || result.kind === "invalid") return assistantInvalid(result?.error ?? "session_unavailable", result?.session);
     return assistantSuccess(result.session);
   });
@@ -443,7 +452,7 @@ async function assistantEnd(ctx) {
     const current = await getSession(ctx);
     if (!isCurrent(ctx, token)) return;
     if (!active(current)) return assistantInvalid("no_active_session", current);
-    const ended = await endSessionImpl(ctx, token, { showPinned: false });
+    const ended = await endSessionImpl(ctx, token, { showPinned: false, syncExistingPinned: true });
     return ended ? assistantSuccess(null) : assistantInvalid("session_unavailable", current);
   });
 }

--- a/plugins/official/openpets.focus-buddy/openpets.plugin.json
+++ b/plugins/official/openpets.focus-buddy/openpets.plugin.json
@@ -3,7 +3,7 @@
   "id": "openpets.focus-buddy",
   "name": "$t:plugin.name",
   "description": "$t:plugin.description",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "runtime": "javascript",
   "icon": "timer",
   "sdkVersion": "3.0.0",

--- a/plugins/official/openpets.focus-buddy/test.js
+++ b/plugins/official/openpets.focus-buddy/test.js
@@ -46,7 +46,142 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
-// 1b) Host stop is invoked without a context; the host owns schedule cleanup.
+// 1a) Assistant capabilities expose the focus lifecycle and use state-only feedback.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 1_250_000 });
+  await h.start();
+  assert.deepEqual([...h.calls.assistantCapabilities.keys()], ["focus.start", "focus.status", "focus.pause", "focus.resume", "focus.end"]);
+  assert.deepEqual(h.calls.assistantCapabilities.get("focus.start")?.capability.inputSchema, {
+    type: "object",
+    properties: { minutes: { type: "integer", minimum: 1, maximum: 120 } },
+    required: ["minutes"],
+    additionalProperties: false,
+  });
+  assert.deepEqual(await h.runCapability("focus.start", { minutes: 10 }), {
+    ok: true,
+    state: "active",
+    mode: "focus",
+    minutes: 10,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  h.expectStored("session", (v) => v.mode === "focus" && v.endsAt - v.startedAt === 10 * 60_000);
+  assert.equal(h.calls.bubbles.length, 0, "assistant actions must not emit command speech or bubbles");
+  assert.equal(h.calls.speak.length, 0, "assistant actions must not emit command speech or bubbles");
+  assert.equal(h.calls.schedules.size, 2, "assistant start should use the normal timer schedules");
+  h.expectNoErrors();
+}
+
+// 1b) Assistant lifecycle operations reject invalid states without changing the session.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 1_500_000 });
+  await h.start();
+  assert.deepEqual(await h.runCapability("focus.pause", {}), {
+    ok: false,
+    error: "no_active_session",
+    state: "idle",
+    mode: null,
+    minutes: 0,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.start", { minutes: 12.5 }), {
+    ok: false,
+    error: "invalid_duration",
+    state: "idle",
+    mode: null,
+    minutes: 0,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.equal(h.calls.storage.has("session"), false, "invalid assistant input must not create a session");
+  await h.runCapability("focus.start", { minutes: 12 });
+  assert.deepEqual(await h.runCapability("focus.pause", {}), {
+    ok: true,
+    state: "paused",
+    mode: "focus",
+    minutes: 12,
+    paused: true,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.pause", {}), {
+    ok: false,
+    error: "already_paused",
+    state: "paused",
+    mode: "focus",
+    minutes: 12,
+    paused: true,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.resume", {}), {
+    ok: true,
+    state: "active",
+    mode: "focus",
+    minutes: 12,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.resume", {}), {
+    ok: false,
+    error: "not_paused",
+    state: "active",
+    mode: "focus",
+    minutes: 12,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.end", {}), {
+    ok: true,
+    state: "idle",
+    mode: null,
+    minutes: 0,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.deepEqual(await h.runCapability("focus.end", {}), {
+    ok: false,
+    error: "no_active_session",
+    state: "idle",
+    mode: null,
+    minutes: 0,
+    paused: false,
+    completedFocusCount: 0,
+  });
+  assert.equal(h.calls.bubbles.length, 0, "assistant invalid states must not emit command bubbles");
+  h.expectNoErrors();
+}
+
+// 1c) Assistant capabilities are restored with a persisted session after restart.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, nowMs: 1_750_000 });
+  const now = Date.now();
+  await h.ctx.storage.set("session", { mode: "focus", startedAt: now, endsAt: now + 10 * 60_000, pausedRemainingMs: null, completedFocusCount: 2 });
+  await h.start();
+  assert.equal(h.calls.assistantCapabilities.size, 5);
+  assert.deepEqual(await h.runCapability("focus.status", {}), {
+    ok: true,
+    state: "active",
+    mode: "focus",
+    minutes: 10,
+    paused: false,
+    completedFocusCount: 2,
+  });
+  await h.stop();
+  assert.equal(h.calls.assistantCapabilities.size, 0, "host stop should revoke assistant capabilities");
+  await h.start();
+  assert.equal(h.calls.assistantCapabilities.size, 5, "plugin restart should rediscover assistant capabilities");
+  assert.deepEqual(await h.runCapability("focus.status", {}), {
+    ok: true,
+    state: "active",
+    mode: "focus",
+    minutes: 10,
+    paused: false,
+    completedFocusCount: 2,
+  });
+  h.expectNoErrors();
+}
+
+// 1d) Host stop is invoked without a context; the host owns schedule cleanup.
 {
   const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 1_500_000 });
   await h.start();

--- a/plugins/official/openpets.focus-buddy/test.js
+++ b/plugins/official/openpets.focus-buddy/test.js
@@ -191,7 +191,44 @@ const LOCALES = { en: JSON.parse(await readFile(new URL("./locales/en.json", imp
   h.expectNoErrors();
 }
 
-// 1c) The harness follows the host's zero-argument stop contract.
+// 1e) Assistant actions reconcile an existing direct-control bubble without creating speech or duplicates.
+{
+  const h = createTestHarness(register, { permissions: PERMISSIONS, locales: LOCALES, config: { focusLength: "25", breakStyle: "normal" }, nowMs: 1_900_000 });
+  await h.start();
+  await h.runCommand("start-focus");
+  const bubble = h.calls.bubbles.at(-1);
+  const speechCount = h.calls.speak.length;
+  assert.ok(bubble, "direct start should create a pinned bubble");
+  assert.equal(bubble.updates.length, 0);
+
+  await h.runCapability("focus.start", { minutes: 10 });
+  assert.equal(h.calls.bubbles.length, 1, "assistant start must reuse the existing pinned bubble");
+  assert.equal(h.calls.speak.length, speechCount, "assistant start must not speak");
+  assert.match(bubble.spec.text, /Focus · 10 min left/);
+  assert.equal(bubble.updates.length, 1);
+
+  await h.runCapability("focus.pause", {});
+  assert.equal(h.calls.bubbles.length, 1, "assistant pause must not create a second bubble");
+  assert.equal(h.calls.speak.length, speechCount, "assistant pause must not speak");
+  assert.match(bubble.spec.text, /Focus paused · 10 min left/);
+  assert.equal(bubble.updates.length, 2);
+
+  await h.runCapability("focus.resume", {});
+  assert.equal(h.calls.bubbles.length, 1, "assistant resume must not create a second bubble");
+  assert.equal(h.calls.speak.length, speechCount, "assistant resume must not speak");
+  assert.match(bubble.spec.text, /Focus · 10 min left/);
+  assert.equal(bubble.updates.length, 3);
+
+  await h.runCapability("focus.end", {});
+  assert.equal(h.calls.bubbles.length, 1, "assistant end must not create a replacement bubble");
+  assert.equal(h.calls.speak.length, speechCount, "assistant end must not speak");
+  assert.equal(bubble.dismissed, true, "assistant end must dismiss the existing pinned bubble");
+  assert.ok(h.calls.dismissedBubbles.includes(bubble.handle.id));
+  h.expectStored("session", null);
+  h.expectNoErrors();
+}
+
+// 1f) The harness follows the host's zero-argument stop contract.
 {
   let stopArgumentCount = -1;
   const h = createTestHarness({

--- a/plugins/official/openpets.reminders/index.js
+++ b/plugins/official/openpets.reminders/index.js
@@ -14,6 +14,21 @@ export const SNOOZE_MS = 5 * 60 * 1000;
 export const REMINDER_ID_PREFIX = "reminder-";
 
 let nextReminderSequence = 0;
+const reminderOperationQueues = new WeakMap();
+
+/**
+ * Serialize durable reminder operations per plugin context. The queue keeps
+ * moving after a failed operation while still returning that operation's
+ * original rejection to its caller.
+ */
+function withReminderOperation(ctx, operation) {
+  const previous = reminderOperationQueues.get(ctx) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(operation);
+  reminderOperationQueues.set(ctx, current);
+  return current.finally(() => {
+    if (reminderOperationQueues.get(ctx) === current) reminderOperationQueues.delete(ctx);
+  });
+}
 
 /**
  * Normalize a free-text reminder message: collapse whitespace, strip newlines,
@@ -92,7 +107,7 @@ export function reminderResult(reminder) {
 
 // --- storage -------------------------------------------------------------
 
-export async function getReminders(ctx) {
+async function readReminders(ctx) {
   const reminders = await ctx.storage.get("reminders");
   return Array.isArray(reminders)
     ? reminders
@@ -106,6 +121,10 @@ export async function getReminders(ctx) {
         )
         .slice(0, MAX_REMINDERS)
     : [];
+}
+
+export function getReminders(ctx) {
+  return withReminderOperation(ctx, () => readReminders(ctx));
 }
 
 async function saveReminders(ctx, reminders) {
@@ -125,10 +144,14 @@ async function updateStatus(ctx, count) {
 
 // --- scheduling + delivery ----------------------------------------------
 
-export async function scheduleReminder(ctx, reminder) {
+async function scheduleReminderUnsafe(ctx, reminder) {
   // schedule.once min delay is 1ms; never schedule in the past.
   const delay = Math.max(1, reminder.dueAt - Date.now());
   await ctx.schedule.once(reminder.id, delay, () => fireReminder(ctx, reminder.id));
+}
+
+export function scheduleReminder(ctx, reminder) {
+  return withReminderOperation(ctx, () => scheduleReminderUnsafe(ctx, reminder));
 }
 
 export async function addReminder(ctx, message, delayMs) {
@@ -141,11 +164,11 @@ export async function addReminder(ctx, message, delayMs) {
  * Store and schedule a reminder without producing direct-control speech.
  * Assistant capabilities use this domain operation directly.
  */
-export async function createReminder(ctx, message, dueAt) {
+async function createReminderUnsafe(ctx, message, dueAt) {
   if (!Number.isFinite(dueAt) || dueAt <= Date.now()) {
     throw new Error("Reminder dueAt must be a valid future timestamp.");
   }
-  const reminders = (await getReminders(ctx)).filter((r) => r.dueAt > Date.now());
+  const reminders = (await readReminders(ctx)).filter((r) => r.dueAt > Date.now());
   if (reminders.length >= MAX_REMINDERS) {
     throw new Error(ctx.t("error.tooMany", { max: MAX_REMINDERS }));
   }
@@ -156,12 +179,16 @@ export async function createReminder(ctx, message, dueAt) {
   };
   reminders.push(reminder);
   await saveReminders(ctx, reminders);
-  await scheduleReminder(ctx, reminder);
+  await scheduleReminderUnsafe(ctx, reminder);
   return reminder;
 }
 
-export async function removeReminder(ctx, id) {
-  const reminders = await getReminders(ctx);
+export function createReminder(ctx, message, dueAt) {
+  return withReminderOperation(ctx, () => createReminderUnsafe(ctx, message, dueAt));
+}
+
+async function removeReminderUnsafe(ctx, id) {
+  const reminders = await readReminders(ctx);
   const item = reminders.find((reminder) => reminder.id === id);
   if (!item) return null;
   await ctx.schedule.cancel(item.id);
@@ -169,30 +196,42 @@ export async function removeReminder(ctx, id) {
   return item;
 }
 
+export function removeReminder(ctx, id) {
+  return withReminderOperation(ctx, () => removeReminderUnsafe(ctx, id));
+}
+
 /**
  * Move a pending reminder five minutes into the future. `fallbackMessage` is
  * only used by the already-fired alert action, whose reminder was removed
  * before delivery; assistant callers must omit it so invalid IDs stay inert.
  */
-export async function snoozeReminder(ctx, id, fallbackMessage) {
-  const item = await removeReminder(ctx, id);
-  if (!item && fallbackMessage === undefined) return null;
-  const reminder = await createReminder(
-    ctx,
-    item?.message ?? fallbackMessage,
-    Date.now() + SNOOZE_MS,
-  );
-  return { previous: item, reminder };
+export function snoozeReminder(ctx, id, fallbackMessage) {
+  return withReminderOperation(ctx, async () => {
+    const item = await removeReminderUnsafe(ctx, id);
+    if (!item && fallbackMessage === undefined) return null;
+    const reminder = await createReminderUnsafe(
+      ctx,
+      item?.message ?? fallbackMessage,
+      Date.now() + SNOOZE_MS,
+    );
+    return { previous: item, reminder };
+  });
 }
 
-export async function clearReminders(ctx) {
+async function clearRemindersUnsafe(ctx) {
   await ctx.schedule.cancelAll();
   await saveReminders(ctx, []);
 }
 
-export async function listPendingReminders(ctx) {
-  const now = Date.now();
-  return (await getReminders(ctx)).filter((reminder) => reminder.dueAt > now);
+export function clearReminders(ctx) {
+  return withReminderOperation(ctx, () => clearRemindersUnsafe(ctx));
+}
+
+export function listPendingReminders(ctx) {
+  return withReminderOperation(ctx, async () => {
+    const now = Date.now();
+    return (await readReminders(ctx)).filter((reminder) => reminder.dueAt > now);
+  });
 }
 
 /**
@@ -259,9 +298,12 @@ async function deliver(ctx, message, { missed = false, id } = {}) {
 }
 
 export async function fireReminder(ctx, id) {
-  const reminders = await getReminders(ctx);
-  const item = reminders.find((r) => r.id === id);
-  await saveReminders(ctx, reminders.filter((r) => r.id !== id));
+  const item = await withReminderOperation(ctx, async () => {
+    const reminders = await readReminders(ctx);
+    const found = reminders.find((r) => r.id === id);
+    await saveReminders(ctx, reminders.filter((r) => r.id !== id));
+    return found;
+  });
   if (!item) return false;
   await deliver(ctx, item.message, { id: item.id });
   return true;
@@ -273,13 +315,16 @@ export async function fireReminder(ctx, id) {
  * ones (fired while OpenPets was closed) are delivered as "missed".
  */
 export async function reconcile(ctx) {
-  await ctx.schedule.cancelAll();
-  const now = Date.now();
-  const reminders = await getReminders(ctx);
-  const future = reminders.filter((r) => r.dueAt > now);
-  const overdue = reminders.filter((r) => r.dueAt <= now);
-  await saveReminders(ctx, future);
-  for (const item of future) await scheduleReminder(ctx, item);
+  const overdue = await withReminderOperation(ctx, async () => {
+    await ctx.schedule.cancelAll();
+    const now = Date.now();
+    const reminders = await readReminders(ctx);
+    const future = reminders.filter((r) => r.dueAt > now);
+    const overdueItems = reminders.filter((r) => r.dueAt <= now);
+    await saveReminders(ctx, future);
+    for (const item of future) await scheduleReminderUnsafe(ctx, item);
+    return overdueItems;
+  });
   for (const item of overdue) await deliver(ctx, item.message, { missed: true, id: item.id });
 }
 

--- a/plugins/official/openpets.reminders/index.js
+++ b/plugins/official/openpets.reminders/index.js
@@ -11,6 +11,9 @@ export const MAX_REMINDERS = 10;
 export const MAX_MESSAGE_LENGTH = 140;
 export const MAX_DELAY_MS = 24 * 60 * 60 * 1000;
 export const SNOOZE_MS = 5 * 60 * 1000;
+export const REMINDER_ID_PREFIX = "reminder-";
+
+let nextReminderSequence = 0;
 
 /**
  * Normalize a free-text reminder message: collapse whitespace, strip newlines,
@@ -54,6 +57,39 @@ export function summary(reminders, now = Date.now()) {
     .join("; ");
 }
 
+const EXPLICIT_TIMEZONE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Parse the assistant's absolute due-time contract. A timezone designator or
+ * numeric UTC offset is mandatory; local-time and natural-language values are
+ * intentionally rejected.
+ */
+export function parseDueAt(value, now = Date.now()) {
+  if (typeof value !== "string" || !EXPLICIT_TIMEZONE_PATTERN.test(value)) {
+    throw new Error("Reminder dueAt must be an ISO timestamp with Z or a numeric UTC offset.");
+  }
+  const dueAt = Date.parse(value);
+  if (!Number.isFinite(dueAt) || dueAt <= now) {
+    throw new Error("Reminder dueAt must be a valid future timestamp.");
+  }
+  return dueAt;
+}
+
+function reminderId(existing, dueAt) {
+  const timestamp = dueAt.toString(36);
+  let id;
+  do {
+    nextReminderSequence += 1;
+    id = `${REMINDER_ID_PREFIX}${timestamp}-${nextReminderSequence.toString(36)}`;
+  } while (existing.some((reminder) => reminder.id === id));
+  return id.slice(0, 64);
+}
+
+export function reminderResult(reminder) {
+  return { id: reminder.id, message: reminder.message, dueAt: reminder.dueAt };
+}
+
 // --- storage -------------------------------------------------------------
 
 export async function getReminders(ctx) {
@@ -65,6 +101,7 @@ export async function getReminders(ctx) {
             r &&
             typeof r.id === "string" &&
             typeof r.dueAt === "number" &&
+            Number.isFinite(r.dueAt) &&
             typeof r.message === "string",
         )
         .slice(0, MAX_REMINDERS)
@@ -95,21 +132,67 @@ export async function scheduleReminder(ctx, reminder) {
 }
 
 export async function addReminder(ctx, message, delayMs) {
+  const reminder = await createReminder(ctx, message, Date.now() + delayMs);
+  await ctx.pet.speak(ctx.t("speech.set", { minutes: Math.max(1, Math.round(delayMs / 60_000)) }));
+  return reminder;
+}
+
+/**
+ * Store and schedule a reminder without producing direct-control speech.
+ * Assistant capabilities use this domain operation directly.
+ */
+export async function createReminder(ctx, message, dueAt) {
+  if (!Number.isFinite(dueAt) || dueAt <= Date.now()) {
+    throw new Error("Reminder dueAt must be a valid future timestamp.");
+  }
   const reminders = (await getReminders(ctx)).filter((r) => r.dueAt > Date.now());
   if (reminders.length >= MAX_REMINDERS) {
     throw new Error(ctx.t("error.tooMany", { max: MAX_REMINDERS }));
   }
   const reminder = {
-    // id matches [A-Za-z0-9._:-]{1,64}
-    id: `reminder-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`.slice(0, 64),
+    id: reminderId(reminders, dueAt),
     message: cleanMessage(message, ctx.t("reminder.defaultMessage")),
-    dueAt: Date.now() + delayMs,
+    dueAt,
   };
   reminders.push(reminder);
   await saveReminders(ctx, reminders);
   await scheduleReminder(ctx, reminder);
-  await ctx.pet.speak(ctx.t("speech.set", { minutes: Math.max(1, Math.round(delayMs / 60_000)) }));
   return reminder;
+}
+
+export async function removeReminder(ctx, id) {
+  const reminders = await getReminders(ctx);
+  const item = reminders.find((reminder) => reminder.id === id);
+  if (!item) return null;
+  await ctx.schedule.cancel(item.id);
+  await saveReminders(ctx, reminders.filter((reminder) => reminder.id !== id));
+  return item;
+}
+
+/**
+ * Move a pending reminder five minutes into the future. `fallbackMessage` is
+ * only used by the already-fired alert action, whose reminder was removed
+ * before delivery; assistant callers must omit it so invalid IDs stay inert.
+ */
+export async function snoozeReminder(ctx, id, fallbackMessage) {
+  const item = await removeReminder(ctx, id);
+  if (!item && fallbackMessage === undefined) return null;
+  const reminder = await createReminder(
+    ctx,
+    item?.message ?? fallbackMessage,
+    Date.now() + SNOOZE_MS,
+  );
+  return { previous: item, reminder };
+}
+
+export async function clearReminders(ctx) {
+  await ctx.schedule.cancelAll();
+  await saveReminders(ctx, []);
+}
+
+export async function listPendingReminders(ctx) {
+  const now = Date.now();
+  return (await getReminders(ctx)).filter((reminder) => reminder.dueAt > now);
 }
 
 /**
@@ -117,7 +200,7 @@ export async function addReminder(ctx, message, delayMs) {
  * gracefully: a disabled toggle or an unavailable permission must never throw
  * the message away — the sticky bubble is the guaranteed channel.
  */
-async function deliver(ctx, message, { missed = false } = {}) {
+async function deliver(ctx, message, { missed = false, id } = {}) {
   const config = (await ctx.config.get()) ?? {};
   const soundEnabled = config.soundEnabled !== false;
   const osNotification = config.osNotification !== false;
@@ -165,7 +248,10 @@ async function deliver(ctx, message, { missed = false } = {}) {
   if (alert) {
     alert.onAction(async (actionId) => {
       if (actionId === "snooze") {
-        await addReminder(ctx, message, SNOOZE_MS);
+        const snoozed = await snoozeReminder(ctx, id, message);
+        if (snoozed) {
+          await ctx.pet.speak(ctx.t("speech.set", { minutes: 5 }));
+        }
       }
       // "done" needs no extra work; dismissing the bubble is the acknowledgement.
     });
@@ -177,7 +263,7 @@ export async function fireReminder(ctx, id) {
   const item = reminders.find((r) => r.id === id);
   await saveReminders(ctx, reminders.filter((r) => r.id !== id));
   if (!item) return false;
-  await deliver(ctx, item.message);
+  await deliver(ctx, item.message, { id: item.id });
   return true;
 }
 
@@ -194,15 +280,14 @@ export async function reconcile(ctx) {
   const overdue = reminders.filter((r) => r.dueAt <= now);
   await saveReminders(ctx, future);
   for (const item of future) await scheduleReminder(ctx, item);
-  for (const item of overdue) await deliver(ctx, item.message, { missed: true });
+  for (const item of overdue) await deliver(ctx, item.message, { missed: true, id: item.id });
 }
 
 // --- commands ------------------------------------------------------------
 
 async function showReminderList(ctx) {
-  const reminders = await getReminders(ctx);
+  const pending = await listPendingReminders(ctx);
   const now = Date.now();
-  const pending = reminders.filter((r) => r.dueAt > now);
   if (!pending.length) {
     await ctx.pet.speak(ctx.t("speech.none"));
     await ctx.ui.menu.setItems([]);
@@ -217,13 +302,108 @@ async function showReminderList(ctx) {
       }),
       icon: "bell",
       onSelect: async () => {
-        await ctx.schedule.cancel(reminder.id);
-        const remaining = (await getReminders(ctx)).filter((r) => r.id !== reminder.id);
-        await saveReminders(ctx, remaining);
-        await ctx.pet.speak(ctx.t("speech.cancelled", { message: reminder.message }));
+        const removed = await removeReminder(ctx, reminder.id);
+        if (removed) await ctx.pet.speak(ctx.t("speech.cancelled", { message: removed.message }));
         await showReminderList(ctx);
       },
     })),
+  );
+}
+
+const assistantSchemas = {
+  create: {
+    type: "object",
+    description: "Create a reminder for an absolute ISO timestamp with an explicit timezone or UTC offset.",
+    properties: {
+      message: { type: "string", minLength: 1, maxLength: MAX_MESSAGE_LENGTH },
+      dueAt: {
+        type: "string",
+        minLength: 1,
+        maxLength: 40,
+        description: "ISO timestamp ending in Z or containing a numeric UTC offset, for example 2026-08-22T15:30:00-04:00.",
+      },
+    },
+    required: ["message", "dueAt"],
+    additionalProperties: false,
+  },
+  list: { type: "object", additionalProperties: false },
+  byId: {
+    type: "object",
+    properties: { id: { type: "string", minLength: 1, maxLength: 64 } },
+    required: ["id"],
+    additionalProperties: false,
+  },
+};
+
+function assistantNotFound(id) {
+  return { ok: false, error: "not_found", id };
+}
+
+async function registerAssistantCapabilities(ctx) {
+  await ctx.assistant.registerCapability(
+    {
+      id: "reminders.create",
+      description: "Create a reminder at an absolute timestamp with an explicit timezone or UTC offset.",
+      inputSchema: assistantSchemas.create,
+    },
+    async (input) => {
+      const reminder = await createReminder(
+        ctx,
+        input.message,
+        parseDueAt(input.dueAt),
+      );
+      return { ok: true, reminder: reminderResult(reminder) };
+    },
+  );
+
+  await ctx.assistant.registerCapability(
+    {
+      id: "reminders.list",
+      description: "List active reminders and their stable identifiers and due times.",
+      inputSchema: assistantSchemas.list,
+    },
+    async () => ({
+      ok: true,
+      reminders: (await listPendingReminders(ctx)).map(reminderResult),
+    }),
+  );
+
+  await ctx.assistant.registerCapability(
+    {
+      id: "reminders.complete",
+      description: "Complete an active reminder by its stable identifier.",
+      inputSchema: assistantSchemas.byId,
+    },
+    async ({ id }) => {
+      const reminder = await removeReminder(ctx, id);
+      return reminder ? { ok: true, reminder: reminderResult(reminder) } : assistantNotFound(id);
+    },
+  );
+
+  await ctx.assistant.registerCapability(
+    {
+      id: "reminders.snooze",
+      description: "Snooze an active reminder by five minutes using its stable identifier.",
+      inputSchema: assistantSchemas.byId,
+    },
+    async ({ id }) => {
+      const result = await snoozeReminder(ctx, id);
+      return result
+        ? { ok: true, reminder: reminderResult(result.reminder) }
+        : assistantNotFound(id);
+    },
+  );
+
+  await ctx.assistant.registerCapability(
+    {
+      id: "reminders.remove",
+      description: "Remove an active reminder by its stable identifier.",
+      inputSchema: assistantSchemas.byId,
+    },
+    async ({ id }) => {
+      const reminder = await removeReminder(ctx, id);
+      return reminder ? { ok: true, reminder: reminderResult(reminder) } : assistantNotFound(id);
+    },
   );
 }
 
@@ -231,6 +411,7 @@ export function register(OpenPetsPlugin) {
   OpenPetsPlugin.register({
     async start(ctx) {
       await reconcile(ctx);
+      await registerAssistantCapabilities(ctx);
 
       await ctx.commands.register(
         {
@@ -326,8 +507,7 @@ export function register(OpenPetsPlugin) {
           icon: "check",
         },
         async () => {
-          await ctx.schedule.cancelAll();
-          await saveReminders(ctx, []);
+          await clearReminders(ctx);
           await ctx.ui.menu.setItems([]);
           await ctx.pet.speak(ctx.t("speech.cleared"));
         },

--- a/plugins/official/openpets.reminders/openpets.plugin.json
+++ b/plugins/official/openpets.reminders/openpets.plugin.json
@@ -3,7 +3,7 @@
   "id": "openpets.reminders",
   "name": "$t:plugin.name",
   "description": "$t:plugin.description",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "runtime": "javascript",
   "icon": "bell",
   "sdkVersion": "3.0.0",

--- a/plugins/official/openpets.reminders/test.js
+++ b/plugins/official/openpets.reminders/test.js
@@ -311,4 +311,59 @@ assert.equal(MAX_REMINDERS, 10);
   h.expectNoErrors();
 }
 
+// 10) A scheduled fire and an overlapping assistant removal serialize their
+// read/replace transactions instead of resurrecting or losing a reminder.
+{
+  const now = Date.now();
+  const h = createTestHarness(register, {
+    permissions: PERMISSIONS,
+    config: { soundEnabled: false, osNotification: false },
+    locales: LOCALES,
+    nowMs: now,
+  });
+  await h.start();
+  const first = await h.runCapability("reminders.create", {
+    message: "Fire me",
+    dueAt: new Date(now + 60_000).toISOString(),
+  });
+  const second = await h.runCapability("reminders.create", {
+    message: "Remove me",
+    dueAt: new Date(now + 3 * 60_000).toISOString(),
+  });
+
+  const originalGet = h.ctx.storage.get;
+  let signalFirstRead;
+  const firstReadEntered = new Promise((resolve) => { signalFirstRead = resolve; });
+  let releaseRead;
+  const blockedRead = new Promise((resolve) => { releaseRead = resolve; });
+  h.ctx.storage.get = async (key) => {
+    if (key === "reminders" && signalFirstRead) {
+      const signal = signalFirstRead;
+      signalFirstRead = undefined;
+      signal();
+      await blockedRead;
+    }
+    return originalGet(key);
+  };
+
+  try {
+    const fire = h.clock.advance("1m");
+    await firstReadEntered;
+    const remove = h.runCapability("reminders.remove", { id: second.reminder.id });
+    releaseRead();
+    await Promise.all([fire, remove]);
+  } finally {
+    h.ctx.storage.get = originalGet;
+  }
+
+  h.expectStored("reminders", (value) => Array.isArray(value) && value.length === 0);
+  assert.equal(h.calls.schedules.size, 0, "serialized fire/remove must leave no stale schedules");
+  assert.equal(
+    h.calls.bubbles.filter((bubble) => bubble.spec.text?.includes(first.reminder.message)).length,
+    1,
+    "the fired reminder should be delivered exactly once",
+  );
+  h.expectNoErrors();
+}
+
 console.log("openpets.reminders: all checks passed.");

--- a/plugins/official/openpets.reminders/test.js
+++ b/plugins/official/openpets.reminders/test.js
@@ -11,6 +11,7 @@ import {
   cleanMessage,
   durationMs,
   summary,
+  parseDueAt,
   register,
   MAX_REMINDERS,
 } from "./index.js";
@@ -39,6 +40,8 @@ assert.equal(
   summary([{ id: "a", message: "tea", dueAt: 1_000 + 5 * 60_000 }], 1_000),
   "5 min: tea",
 );
+assert.equal(parseDueAt("2099-01-01T12:00:00Z", 0), Date.parse("2099-01-01T12:00:00Z"));
+assert.throws(() => parseDueAt("2099-01-01T12:00:00"), /timezone|offset/i);
 
 // --- golden harness test -------------------------------------------------
 
@@ -222,5 +225,90 @@ const LOCALES = {
 
 // 7) MAX_REMINDERS guard.
 assert.equal(MAX_REMINDERS, 10);
+
+// 8) Assistant capabilities expose the same reminder domain without direct-control speech.
+{
+  const now = Date.now();
+  const h = createTestHarness(register, {
+    permissions: PERMISSIONS,
+    locales: LOCALES,
+    nowMs: now,
+  });
+  await h.start();
+  assert.deepEqual(
+    [...h.calls.assistantCapabilities.keys()],
+    ["reminders.create", "reminders.list", "reminders.complete", "reminders.snooze", "reminders.remove"],
+  );
+  assert.equal(h.calls.assistantCapabilities.get("reminders.create").capability.inputSchema.properties.dueAt.type, "string");
+
+  const dueAt = new Date(now + 30 * 60_000).toISOString();
+  const created = await h.runCapability("reminders.create", { message: "Assistant water", dueAt });
+  assert.equal(created.ok, true);
+  assert.deepEqual(created.reminder, {
+    id: created.reminder.id,
+    message: "Assistant water",
+    dueAt: Date.parse(dueAt),
+  });
+  assert.match(created.reminder.id, /^reminder-[A-Za-z0-9]+-[A-Za-z0-9]+$/);
+  assert.equal(h.calls.speak.length, 0, "assistant creation must not use command speech");
+
+  const listed = await h.runCapability("reminders.list", {});
+  assert.deepEqual(listed.reminders, [created.reminder]);
+
+  const snoozed = await h.runCapability("reminders.snooze", { id: created.reminder.id });
+  assert.equal(snoozed.ok, true);
+  assert.notEqual(snoozed.reminder.id, created.reminder.id);
+  assert.equal(snoozed.reminder.message, created.reminder.message);
+  assert.ok(snoozed.reminder.dueAt > now);
+  assert.equal(h.calls.speak.length, 0, "assistant snooze must not use command speech");
+
+  const completed = await h.runCapability("reminders.complete", { id: snoozed.reminder.id });
+  assert.equal(completed.ok, true);
+  assert.equal(completed.reminder.id, snoozed.reminder.id);
+  assert.deepEqual((await h.runCapability("reminders.list", {})).reminders, []);
+
+  const removable = await h.runCapability("reminders.create", {
+    message: "Assistant remove",
+    dueAt: new Date(now + 45 * 60_000).toISOString(),
+  });
+  const removed = await h.runCapability("reminders.remove", { id: removable.reminder.id });
+  assert.equal(removed.ok, true);
+  assert.equal(removed.reminder.id, removable.reminder.id);
+  assert.deepEqual((await h.runCapability("reminders.list", {})).reminders, []);
+
+  const invalid = await h.runCapability("reminders.complete", { id: "reminder-does-not-exist" });
+  assert.deepEqual(invalid, { ok: false, error: "not_found", id: "reminder-does-not-exist" });
+  await assert.rejects(
+    () => h.runCapability("reminders.create", { message: "No guessing", dueAt: "tomorrow afternoon" }),
+    /ISO timestamp|timezone|offset/i,
+  );
+  h.expectNoErrors();
+}
+
+// 9) Restart reconciliation restores schedules and delivers persisted overdue reminders.
+{
+  const now = Date.now();
+  const h = createTestHarness(register, {
+    permissions: PERMISSIONS,
+    config: { soundEnabled: false, osNotification: false },
+    locales: LOCALES,
+    nowMs: now,
+  });
+  await h.ctx.storage.set("reminders", [
+    { id: "reminder-restart-1", message: "Restart check", dueAt: now - 60_000 },
+    { id: "reminder-restart-2", message: "Still pending", dueAt: now + 60 * 60_000 },
+  ]);
+  await h.start();
+  h.expectBubble({ textMatch: /Restart check/ });
+  assert.equal(h.calls.schedules.size, 1);
+  h.expectStored("reminders", (value) => value.length === 1 && value[0].id === "reminder-restart-2");
+  const bubblesAfterFirstStart = h.calls.bubbles.length;
+
+  await h.stop();
+  await h.start();
+  assert.equal(h.calls.bubbles.length, bubblesAfterFirstStart, "restart must not redeliver removed overdue reminders");
+  assert.equal(h.calls.schedules.size, 1, "restart must reschedule persisted future reminders");
+  h.expectNoErrors();
+}
 
 console.log("openpets.reminders: all checks passed.");


### PR DESCRIPTION
## Summary
- add typed Focus Buddy start, status, pause, resume, and end operations
- add typed Quick Reminders create, list, complete, snooze, and remove operations
- share durable domain operations with direct controls without duplicate assistant speech, and document the v4 milestone

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm plugins:test`
- Greptile review: passed after fixing its stale-pinned-bubble P1

## Release note
- `pnpm plugins:validate-release` remains blocked by pre-existing missing provenance for community plugins `openpets.drag-vocab` and `openpets.higgsfield-watch`.
- An accidental web-sync invocation re-uploaded the existing Calendar Airmail and Day Routine ZIPs before that validator stopped; no Focus Buddy or Quick Reminders artifact was uploaded or published.

Closes #143
Closes #144