### PR TITLE
feat(voice): compose STT → Pet Assistant → TTS conversations

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -12,6 +12,7 @@ files:
   - dist/**
   - control-center-preload.cjs
   - pet-preload.cjs
+  - pet-tts-helper.cjs
   - plugin-sdk-preload.cjs
   - plugin-command-form-preload.cjs
   - panel-preload.cjs

--- a/apps/desktop/pet-preload.cjs
+++ b/apps/desktop/pet-preload.cjs
@@ -1,4 +1,5 @@
 const { ipcRenderer } = require("electron");
+const { splitSystemSpeech } = require("./pet-tts-helper.cjs");
 
 const allowedMotionStates = new Set(["idle", "run-left", "run-right"]);
 const allowedReactionStates = new Set(["idle", "running-right", "running-left", "waving", "jumping", "failed", "waiting", "running", "review"]);
@@ -324,40 +325,92 @@ ipcRenderer.on("openpets:stop-audio", () => {
 
 // --- Plugin TTS ---------------------------------------------------------------
 
+let generatedTtsRequest = 0;
+let activeTts = null;
+
+const sendTtsCompletion = (request, outcome) => {
+  try { ipcRenderer.send(request.kind === "audio" ? "openpets:tts-audio-finished" : "openpets:tts-speech-finished", { requestId: request.requestId, kind: request.kind, outcome }); } catch { /* main process observes renderer loss separately */ }
+};
+
+const stopTtsMedia = (request) => {
+  if (!request) return;
+  if (request.kind === "audio") {
+    try { request.media.pause(); } catch { /* noop */ }
+    return;
+  }
+  try { window.speechSynthesis && window.speechSynthesis.cancel(); } catch { /* noop */ }
+};
+
+const settleTts = (request, outcome) => {
+  if (!request || activeTts !== request) return false;
+  activeTts = null;
+  stopTtsMedia(request);
+  sendTtsCompletion(request, outcome);
+  return true;
+};
+
+const stopMatchingTts = (requestId, kind) => {
+  const request = activeTts;
+  if (!request) return false;
+  if (requestId !== undefined && requestId !== request.requestId) return false;
+  if (kind !== undefined && request.kind !== kind) return false;
+  return settleTts(request, "stopped");
+};
+
 ipcRenderer.on("openpets:tts-speak", (_event, payload) => {
   try {
     if (!payload || typeof payload.text !== "string" || !window.speechSynthesis) return;
-    const utterance = new SpeechSynthesisUtterance(payload.text.slice(0, 500));
-    if (typeof payload.rate === "number" && payload.rate >= 0.5 && payload.rate <= 2) utterance.rate = payload.rate;
-    if (typeof payload.voice === "string" && payload.voice) {
-      const match = window.speechSynthesis.getVoices().find((voice) => voice.name === payload.voice || voice.lang === payload.voice);
-      if (match) utterance.voice = match;
-    }
-    window.speechSynthesis.speak(utterance);
-  } catch { /* tts is best-effort */ }
+    settleTts(activeTts, "stopped");
+    const request = { requestId: typeof payload.requestId === "string" ? payload.requestId : `renderer-tts-${++generatedTtsRequest}`, kind: "system", media: { chunks: splitSystemSpeech(payload.text), index: 0 } };
+    activeTts = request;
+    const speakNext = () => {
+      if (activeTts !== request) return;
+      const text = request.media.chunks[request.media.index];
+      if (typeof text !== "string") { settleTts(request, "ended"); return; }
+      const utterance = new SpeechSynthesisUtterance(text);
+      if (typeof payload.rate === "number" && payload.rate >= 0.5 && payload.rate <= 2) utterance.rate = payload.rate;
+      if (typeof payload.voice === "string" && payload.voice) {
+        const match = window.speechSynthesis.getVoices().find((voice) => voice.name === payload.voice || voice.lang === payload.voice);
+        if (match) utterance.voice = match;
+      }
+      utterance.addEventListener("end", () => {
+        if (activeTts !== request) return;
+        request.media.index += 1;
+        if (request.media.index >= request.media.chunks.length) settleTts(request, "ended");
+        else speakNext();
+      });
+      utterance.addEventListener("error", () => { settleTts(request, "error"); });
+      try { window.speechSynthesis.speak(utterance); } catch { settleTts(request, "error"); }
+    };
+    speakNext();
+  } catch { settleTts(activeTts, "error"); }
 });
 
-ipcRenderer.on("openpets:tts-stop", () => {
-  try { window.speechSynthesis && window.speechSynthesis.cancel(); } catch { /* noop */ }
+ipcRenderer.on("openpets:tts-stop", (_event, payload) => {
+  stopMatchingTts(typeof payload?.requestId === "string" ? payload.requestId : undefined, "system");
 });
-
-let activeTtsAudio = null;
 
 ipcRenderer.on("openpets:tts-audio", (_event, payload) => {
   try {
     if (!payload || typeof payload.dataUrl !== "string" || !payload.dataUrl.startsWith("data:audio/")) return;
-    if (activeTtsAudio) activeTtsAudio.pause();
+    settleTts(activeTts, "stopped");
     const element = new Audio(payload.dataUrl);
-    activeTtsAudio = element;
-    element.addEventListener("ended", () => { if (activeTtsAudio === element) activeTtsAudio = null; });
-    element.addEventListener("error", () => { if (activeTtsAudio === element) activeTtsAudio = null; });
-    void element.play().catch(() => { if (activeTtsAudio === element) activeTtsAudio = null; });
-  } catch { /* tts is best-effort */ }
+    const request = { requestId: typeof payload.requestId === "string" ? payload.requestId : `renderer-tts-${++generatedTtsRequest}`, kind: "audio", media: element };
+    activeTts = request;
+    element.addEventListener("ended", () => {
+      settleTts(request, "ended");
+    });
+    element.addEventListener("error", () => {
+      settleTts(request, "error");
+    });
+    void element.play().catch(() => {
+      settleTts(request, "error");
+    });
+  } catch { settleTts(activeTts, "error"); }
 });
 
-ipcRenderer.on("openpets:tts-audio-stop", () => {
-  try { if (activeTtsAudio) activeTtsAudio.pause(); } catch { /* noop */ }
-  activeTtsAudio = null;
+ipcRenderer.on("openpets:tts-audio-stop", (_event, payload) => {
+  stopMatchingTts(typeof payload?.requestId === "string" ? payload.requestId : undefined, "audio");
 });
 
 const installMouseInterop = () => {

--- a/apps/desktop/pet-tts-helper.cjs
+++ b/apps/desktop/pet-tts-helper.cjs
@@ -1,0 +1,27 @@
+const DEFAULT_MAX_UTTERANCE_CHARS = 500;
+
+function splitSystemSpeech(text, maxChars = DEFAULT_MAX_UTTERANCE_CHARS) {
+  if (typeof text !== "string" || text.length === 0) return [];
+  if (!Number.isInteger(maxChars) || maxChars < 1) throw new Error("Invalid system speech chunk limit.");
+  const chunks = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(text.length, start + maxChars);
+    if (end < text.length) {
+      const breakAt = findBreak(text, start, end);
+      if (breakAt > start) end = breakAt + 1;
+    }
+    chunks.push(text.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}
+
+function findBreak(text, start, end) {
+  for (let index = end - 1; index > start; index -= 1) {
+    if (/\s/.test(text[index])) return index;
+  }
+  return -1;
+}
+
+module.exports = { DEFAULT_MAX_UTTERANCE_CHARS, splitSystemSpeech };

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -11,7 +11,7 @@ import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 
-const preloadChecks = ["control-center-preload.cjs", "pet-preload.cjs", "plugin-sdk-preload.cjs", "panel-preload.cjs", "voice-realtime-preload.cjs"];
+const preloadChecks = ["control-center-preload.cjs", "pet-preload.cjs", "pet-tts-helper.cjs", "plugin-sdk-preload.cjs", "panel-preload.cjs", "voice-realtime-preload.cjs"];
 const behaviorTests = [
   ".test-dist/tests/lease-manager.test.js",
   ".test-dist/tests/lease-manager-fixes.test.js",
@@ -49,6 +49,10 @@ const behaviorTests = [
   ".test-dist/tests/voice-bridge.test.js",
   ".test-dist/tests/voice-lifecycle.test.js",
   ".test-dist/tests/voice-conversation.test.js",
+  ".test-dist/tests/voice-assistant-session.test.js",
+  ".test-dist/tests/voice-assistant-host-core.test.js",
+  ".test-dist/tests/voice-playback.test.js",
+  ".test-dist/tests/voice-activity-slot.test.js",
   ".test-dist/tests/tray-voice.test.js",
   ".test-dist/tests/plugin-bridge-fuzz.test.js",
   ".test-dist/tests/pet-fallback-notify.test.js",

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -13,11 +13,13 @@ import { publishPluginPetEvent } from "./plugin-events-source.js";
 import { reclampAgentPetWindows } from "./agent-pet-controller.js";
 import { reclampPluginPetWindows } from "./plugin-pet-registry.js";
 import { reclampLanVisitingPetWindows } from "./lan-pet-controller.js";
+import { composeVoiceActivityBadge, composeVoiceActivityDisplay } from "./voice-activity-slot.js";
 
 let defaultPetWindow: BrowserWindow | null = null;
 let paused = false;
 let transientDisplay: PetTransientDisplay | null = null;
 let statusBadge: PetStatusBadgeReaction | null = null;
+let voiceActivityReaction: OpenPetsReaction | null = null;
 let transientDisplayTimeout: NodeJS.Timeout | null = null;
 let transientAnimationTimeout: NodeJS.Timeout | null = null;
 let statusBadgeTimeout: NodeJS.Timeout | null = null;
@@ -111,13 +113,14 @@ export function isDefaultPetVisible(): boolean {
 
 export function setDefaultPetPaused(nextPaused: boolean): void {
   paused = nextPaused;
+  if (paused) voiceActivityReaction = null;
   info("pet.default", "pause changed", { paused });
 
   if (!defaultPetWindow || defaultPetWindow.isDestroyed()) {
     return;
   }
 
-  void loadDefaultPetContent(defaultPetWindow, paused, transientDisplay, statusBadge, getCurrentDismissToken(), getDefaultPetPluginBubbles());
+  void loadDefaultPetContent(defaultPetWindow, paused, getRenderedDisplay(), getRenderedBadge(), getCurrentDismissToken(), getDefaultPetPluginBubbles());
 }
 
 export function getDefaultPetPaused(): boolean {
@@ -134,8 +137,8 @@ export function refreshDefaultPetContent(): void {
     return;
   }
 
-  debug("pet.default", "refresh content", { windowId: defaultPetWindow.id, paused, hasDisplay: Boolean(transientDisplay), badge: statusBadge, petId: getAppStateSnapshot().preferences.defaultPetId });
-  void loadDefaultPetContent(defaultPetWindow, paused, transientDisplay, statusBadge, getCurrentDismissToken(), getDefaultPetPluginBubbles());
+  debug("pet.default", "refresh content", { windowId: defaultPetWindow.id, paused, hasDisplay: Boolean(getRenderedDisplay()), badge: getRenderedBadge(), petId: getAppStateSnapshot().preferences.defaultPetId });
+  void loadDefaultPetContent(defaultPetWindow, paused, getRenderedDisplay(), getRenderedBadge(), getCurrentDismissToken(), getDefaultPetPluginBubbles());
 }
 
 export function recoverDefaultPetMouseInterop(reason: string): void {
@@ -186,6 +189,14 @@ export function applyExternalPetStatusReaction(reaction: OpenPetsReaction | null
   refreshDefaultPetContent();
 }
 
+/** Set only the voice-owned activity slot; plugin display and status state remain independent. */
+export function setDefaultPetVoiceActivity(reaction: OpenPetsReaction | null): void {
+  voiceActivityReaction = paused || reaction === "idle" ? null : reaction;
+  debug("pet.default", "voice activity slot changed", { reaction: voiceActivityReaction });
+  if (voiceActivityReaction) showDefaultPetForExternalEvent();
+  refreshDefaultPetContent();
+}
+
 export function applyExternalPetMoveBy(options: PetMoveOptions): Promise<{ readonly moved: boolean; readonly reason?: string }> {
   return moveDefaultPetBy(Number(options.x), Number(options.y), options.durationMs);
 }
@@ -220,6 +231,7 @@ export function applyExternalPetMoveToHome(): Promise<{ readonly moved: boolean;
 
 export function destroyDefaultPet(): void {
   clearDefaultPetDisplayTimers();
+  voiceActivityReaction = null;
 
   if (!defaultPetWindow || defaultPetWindow.isDestroyed()) {
     debug("pet.default", "destroy skipped", { reason: "no-window" });
@@ -278,7 +290,7 @@ function handleBubbleDismissed(dismissToken: string): void {
   }
   clearDefaultPetDisplayTimers();
   if (defaultPetWindow && !defaultPetWindow.isDestroyed()) {
-    void loadDefaultPetContent(defaultPetWindow, paused, null, null, undefined, getDefaultPetPluginBubbles());
+    void loadDefaultPetContent(defaultPetWindow, paused, getRenderedDisplay(), getRenderedBadge(), getCurrentDismissToken(), getDefaultPetPluginBubbles());
   }
 }
 
@@ -296,8 +308,8 @@ function getOrCreateDefaultPetWindow(): BrowserWindow {
   defaultPetWindow = createDefaultPetWindow({
     position,
     paused,
-    display: transientDisplay,
-    badge: statusBadge,
+    display: getRenderedDisplay(),
+    badge: getRenderedBadge(),
     pluginBubbles: getDefaultPetPluginBubbles(),
     onPositionChanged: handlePositionChanged,
     onHideRequested: hideDefaultPet,
@@ -406,8 +418,8 @@ function getMovementBlockedReason(window: BrowserWindow, allowMoving = false): s
   if (!window.isVisible()) return "hidden";
   if (paused) return "paused";
   if (isPetWindowDragging(window)) return "dragging";
-  if (transientDisplay) return "transient-display";
-  if (statusBadge) return "status-active";
+  if (getRenderedDisplay()) return "transient-display";
+  if (getRenderedBadge()) return "status-active";
   return undefined;
 }
 
@@ -451,6 +463,14 @@ function clearDefaultPetDisplayTimers(): void {
   statusBadgeTimeout = null;
   transientDisplay = null;
   statusBadge = null;
+}
+
+function getRenderedDisplay(): PetTransientDisplay | null {
+  return composeVoiceActivityDisplay(transientDisplay, voiceActivityReaction) as PetTransientDisplay | null;
+}
+
+function getRenderedBadge(): PetStatusBadgeReaction | null {
+  return composeVoiceActivityBadge(statusBadge, voiceActivityReaction) as PetStatusBadgeReaction | null;
 }
 
 function getCurrentDismissToken(): string | undefined {

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -8,6 +8,7 @@ import { stopRemoteControlService } from "./remote-control-service.js";
 import { closeAllLanVisitingPets } from "./lan-pet-controller.js";
 import { stopPluginService } from "./plugin-service.js";
 import { stopPetAssistantHost } from "./pet-assistant-host.js";
+import { stopVoiceAssistantHost } from "./voice-assistant-host.js";
 import { shutdownPluginVoice } from "./plugin-voice.js";
 import { focusOpenTaskWindows } from "./windows.js";
 
@@ -44,6 +45,7 @@ export function installAppLifecycle(): void {
     info("app", "before quit cleanup begin");
     scheduleHardExitFallback("before-quit");
     void (async () => {
+      await stopVoiceAssistantHost().catch(() => undefined);
       await stopPetAssistantHost().catch(() => undefined);
       await shutdownPluginVoice().catch(() => undefined);
       await stopPluginService().catch(() => undefined);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -19,6 +19,7 @@ import { initializePluginPlatformSettings } from "./plugin-platform-settings.js"
 import { ElectronPluginJsHost } from "./plugin-js-host.js";
 import { initializePluginService } from "./plugin-service.js";
 import { startPetAssistantHost } from "./pet-assistant-host.js";
+import { startVoiceAssistantHost } from "./voice-assistant-host.js";
 import { createAppTray, refreshTrayMenu } from "./tray.js";
 import { checkForGitHubReleaseUpdate } from "./update-checker.js";
 import { installInternalUiHandlers, installInternalUiProtocol } from "./windows.js";
@@ -138,7 +139,8 @@ if (!gotSingleInstanceLock) {
     void (async () => {
       const service = pluginService;
       await service.start();
-      startPetAssistantHost(service, pluginCapabilities.secretsStore);
+      const assistant = startPetAssistantHost(service, pluginCapabilities.secretsStore, { providerOperations: pluginCapabilities.providerService });
+      startVoiceAssistantHost(pluginCapabilities.providerService, assistant);
       const persistedPaths = service.getLocalSourcePaths();
       for (const path of paths) {
         const result = await service.loadLocalPath(path, { autoApprove: true });

--- a/apps/desktop/src/pet-assistant-host.ts
+++ b/apps/desktop/src/pet-assistant-host.ts
@@ -5,6 +5,7 @@ import type { PluginService } from "./plugin-service.js";
 import type { PluginSecretsStore } from "./plugin-secrets.js";
 import { PetAssistantService } from "./pet-assistant-service.js";
 import { TextModelClient } from "./text-model-client.js";
+import type { HostProviderOperations } from "./provider-service.js";
 import type {
   AssistantJsonObject,
   PetAssistantComposition,
@@ -16,7 +17,7 @@ let assistantService: PetAssistantService | null = null;
 let stopping: Promise<void> | null = null;
 
 type HostCapabilityHandle = PetAssistantGenerationHandle & { readonly pluginHandle: PluginAssistantCapabilityHandle };
-export type PetAssistantHostOptions = { readonly compositionProvider?: () => PetAssistantComposition };
+export type PetAssistantHostOptions = { readonly compositionProvider?: () => PetAssistantComposition; readonly providerOperations?: HostProviderOperations };
 
 /** Construct the host assistant only after the plugin runtime has started. */
 export function startPetAssistantHost(pluginService: PluginService, secrets: PluginSecretsStore, options: PetAssistantHostOptions = {}): PetAssistantService {
@@ -35,7 +36,7 @@ export function startPetAssistantHost(pluginService: PluginService, secrets: Plu
     },
     execute: (handle, input, signal) => executeCapability(pluginService, handle, input, signal),
   };
-  const service = new PetAssistantService(new TextModelClient(secrets), runtime, {
+  const service = new PetAssistantService(new TextModelClient(options.providerOperations ?? secrets), runtime, {
     // App state is host-owned and synchronous; the service snapshots this
     // profile before each turn without coupling itself to Electron state.
     compositionProvider: options.compositionProvider ?? (() => ({ personality: getAppStateSnapshot().preferences.personality })),

--- a/apps/desktop/src/pet-assistant-service.ts
+++ b/apps/desktop/src/pet-assistant-service.ts
@@ -238,6 +238,10 @@ export class PetAssistantService {
           this.#emitTranscript(conversationId, turnId, toolMessage);
         }
         messages = [...messages, ...results];
+        // A completed capability batch returns control to the model. Keep the
+        // host visibly in the thinking state while it decides the terminal
+        // response or the next batch.
+        this.#emitActivity(conversationId, turnId, "thinking");
       }
     } catch (error) {
       if (active.terminal.value) return active.terminal.value;

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -102,6 +102,19 @@ const petWindowFocusPolicy = new WeakMap<BrowserWindow, boolean>();
 const petMouseInteropRecovery = new WeakMap<BrowserWindow, (reason: string) => void>();
 const petWindowDragging = new WeakMap<BrowserWindow, boolean>();
 
+export type PetWindowSpeechCompletion = {
+  readonly window: BrowserWindow;
+  readonly requestId: string;
+  readonly kind: "audio" | "system";
+  readonly outcome: "ended" | "error" | "stopped";
+};
+const petWindowSpeechCompletionListeners = new Set<(completion: PetWindowSpeechCompletion) => void>();
+
+export function subscribePetWindowSpeechCompletion(listener: (completion: PetWindowSpeechCompletion) => void): () => void {
+  petWindowSpeechCompletionListeners.add(listener);
+  return () => { petWindowSpeechCompletionListeners.delete(listener); };
+}
+
 /**
  * Returns true when Electron is effectively running on the native Wayland
  * backend (ozone-platform=wayland). Under x11/XWayland this returns false
@@ -556,6 +569,15 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     onPetEvent?.(name, data);
   };
 
+  const handleSpeechCompletion = (event: IpcMainEvent, payload: unknown): void => {
+    if (!isFromWindow(event) || !isRecord(payload) || typeof payload.requestId !== "string" || payload.requestId.length === 0) return;
+    if ((payload.kind !== "audio" && payload.kind !== "system") || (payload.outcome !== "ended" && payload.outcome !== "error" && payload.outcome !== "stopped")) return;
+    const completion: PetWindowSpeechCompletion = { window, requestId: payload.requestId, kind: payload.kind, outcome: payload.outcome };
+    for (const listener of [...petWindowSpeechCompletionListeners]) {
+      try { listener(completion); } catch { /* observers cannot affect pet-window cleanup */ }
+    }
+  };
+
   const resetForNavigation = (): void => {
     dragging = null;
     petWindowDragging.set(window, false);
@@ -597,6 +619,8 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
     ipcMain.off("openpets:bubble-action", handleBubbleAction);
     ipcMain.off("openpets:bubble-submit", handleBubbleSubmit);
     ipcMain.off("openpets:pet-event", handlePetEvent);
+    ipcMain.off("openpets:tts-speech-finished", handleSpeechCompletion);
+    ipcMain.off("openpets:tts-audio-finished", handleSpeechCompletion);
     clearRearmTimers();
     clearForwardingWatch();
     petMouseInteropRecovery.delete(window);
@@ -621,6 +645,8 @@ function installMousePassthroughAndDrag(window: BrowserWindow, hooks: PetWindowI
   ipcMain.on("openpets:bubble-action", handleBubbleAction);
   ipcMain.on("openpets:bubble-submit", handleBubbleSubmit);
   ipcMain.on("openpets:pet-event", handlePetEvent);
+  ipcMain.on("openpets:tts-speech-finished", handleSpeechCompletion);
+  ipcMain.on("openpets:tts-audio-finished", handleSpeechCompletion);
   webContents.on("did-start-navigation", resetForNavigation);
   webContents.on("did-start-loading", resetForNavigation);
   webContents.on("did-finish-load", rearmAfterLoad);
@@ -863,25 +889,25 @@ export function stopPetWindowAudio(window: BrowserWindow): void {
 }
 
 /** Speak text via the renderer speechSynthesis voice (plugin voice.speak). */
-export function speakPetWindowTts(window: BrowserWindow, text: string, opts: { readonly voice?: string; readonly rate?: number }): void {
+export function speakPetWindowTts(window: BrowserWindow, text: string, opts: { readonly voice?: string; readonly rate?: number; readonly requestId?: string }): void {
   if (window.isDestroyed()) return;
-  window.webContents.send("openpets:tts-speak", { text, voice: opts.voice, rate: opts.rate });
+  window.webContents.send("openpets:tts-speak", { text, voice: opts.voice, rate: opts.rate, requestId: opts.requestId });
 }
 
-export function stopPetWindowTts(window: BrowserWindow): void {
+export function stopPetWindowTts(window: BrowserWindow, requestId?: string): void {
   if (window.isDestroyed()) return;
-  window.webContents.send("openpets:tts-stop");
+  window.webContents.send("openpets:tts-stop", { requestId });
 }
 
 /** Play synthesized speech without sharing the plugin sound playback channel. */
-export function playPetWindowTtsAudio(window: BrowserWindow, dataUrl: string): void {
+export function playPetWindowTtsAudio(window: BrowserWindow, dataUrl: string, requestId?: string): void {
   if (window.isDestroyed()) return;
-  window.webContents.send("openpets:tts-audio", { dataUrl });
+  window.webContents.send("openpets:tts-audio", { dataUrl, requestId });
 }
 
-export function stopPetWindowTtsAudio(window: BrowserWindow): void {
+export function stopPetWindowTtsAudio(window: BrowserWindow, requestId?: string): void {
   if (window.isDestroyed()) return;
-  window.webContents.send("openpets:tts-audio-stop");
+  window.webContents.send("openpets:tts-audio-stop", { requestId });
 }
 
 function tryUpdateLoadedPetContent(window: BrowserWindow, render: PetContentRender, name: string, sequence: number): boolean {

--- a/apps/desktop/src/plugin-voice.ts
+++ b/apps/desktop/src/plugin-voice.ts
@@ -2,14 +2,14 @@ import { getDefaultPetWindowForPlugins } from "./default-pet-controller.js";
 import { playPetWindowTtsAudio, speakPetWindowTts, stopPetWindowTts, stopPetWindowTtsAudio } from "./pet-window.js";
 import type { PluginAiGateway } from "./plugin-ai-gateway.js";
 import { VoiceConversationService, type VoiceConversationSnapshot, type VoiceRealtimeSessionConfig } from "./voice-conversation.js";
-import { VoiceCaptureService } from "./voice-capture.js";
-import { createElectronVoiceCaptureFactory } from "./voice-capture-electron.js";
 import { createElectronVoiceRealtimeTransportFactory } from "./voice-realtime-electron.js";
+import { createElectronVoiceCaptureFactory } from "./voice-capture-electron.js";
 import { createElectronVoicePrivacyIndicator } from "./voice-privacy-indicator-electron.js";
-import { VoiceMicrophoneArbiter } from "./voice-microphone-arbiter.js";
-import { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
+import type { VoiceCaptureService } from "./voice-capture.js";
 import { VoiceListeningService } from "./voice-listening-service.js";
 import { VoiceOperationState, type VoiceOperationSnapshot } from "./voice-operation-state.js";
+import { VoiceResourceOwner } from "./voice-resource-owner.js";
+import type { VoiceMicrophoneArbiter } from "./voice-microphone-arbiter.js";
 
 /**
  * Plugin voice (§13.5). TTS uses configured MiniMax speech synthesis when
@@ -48,11 +48,9 @@ export function pluginVoiceStop(): void {
 
 let activeListeningService: VoiceListeningService | null = null;
 let activePluginId: string | undefined;
-let captureService: VoiceCaptureService | null = null;
 let conversationService: VoiceConversationService | null = null;
 let conversationStartReservation: symbol | null = null;
-let privacyIndicator: VoicePrivacyIndicator | null = null;
-const microphoneArbiter = new VoiceMicrophoneArbiter();
+const voiceResources = new VoiceResourceOwner({ captureFactory: createElectronVoiceCaptureFactory(), privacyIndicatorFactory: createElectronVoicePrivacyIndicator });
 const voiceOperationState = new VoiceOperationState();
 let pluginVoiceShutdownPromise: Promise<void> | null = null;
 
@@ -64,6 +62,15 @@ export function subscribePluginVoiceOperation(listener: () => void): () => void 
   return voiceOperationState.subscribe(listener);
 }
 
+/** Shared host-owned resources used by every voice lane. */
+export function getSharedVoiceMicrophoneArbiter(): VoiceMicrophoneArbiter {
+  return voiceResources.microphoneArbiter;
+}
+
+export function getSharedVoiceCaptureService(): VoiceCaptureService {
+  return voiceResources.capture();
+}
+
 export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeoutMs: number; pluginId?: string }): Promise<{ text: string }> {
   if (activeListeningService) throw new Error("A voice capture is already in progress.");
   const reservation = voiceOperationState.reserve();
@@ -71,7 +78,7 @@ export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeou
   try {
     const transcribe = await gateway.beginTranscriptionOperation();
     const service = new VoiceListeningService(
-      getCaptureService(),
+      voiceResources.capture(),
       (capture, signal) => transcribe(capture.bytes, capture.mimeType, signal),
       { onPhaseChange: (phase) => voiceOperationState.setPhase(phase) },
     );
@@ -135,31 +142,18 @@ export function shutdownPluginVoice(): Promise<void> {
     voiceOperationState.cancelReservation();
     if (conversationService) await conversationService.shutdown().catch(() => undefined);
     if (activeListeningService) await activeListeningService.shutdown().catch(() => undefined);
-    else await captureService?.shutdown().catch(() => undefined);
+    await voiceResources.shutdown();
     conversationService = null;
-    captureService = null;
-    privacyIndicator = null;
     activeListeningService = null;
     activePluginId = undefined;
   })();
   return pluginVoiceShutdownPromise;
 }
 
-function getCaptureService(): VoiceCaptureService {
-  if (!captureService) {
-    captureService = new VoiceCaptureService(createElectronVoiceCaptureFactory(), getPrivacyIndicator(), { microphoneArbiter });
-  }
-  return captureService;
-}
-
 function createConversationService(negotiator: (sdp: string, session: VoiceRealtimeSessionConfig, signal?: AbortSignal) => Promise<string>): VoiceConversationService {
   return new VoiceConversationService({
-    microphoneArbiter,
-    privacyIndicator: getPrivacyIndicator(),
+    microphoneArbiter: voiceResources.microphoneArbiter,
+    privacyIndicator: voiceResources.privacyIndicator,
     transportFactory: createElectronVoiceRealtimeTransportFactory({ negotiate: negotiator }),
   });
-}
-
-function getPrivacyIndicator(): VoicePrivacyIndicator {
-  return privacyIndicator ??= createElectronVoicePrivacyIndicator();
 }

--- a/apps/desktop/src/provider-service.ts
+++ b/apps/desktop/src/provider-service.ts
@@ -21,7 +21,7 @@ export interface HostProviderOperations {
   binary(snapshot: ProviderOperationSnapshot, path: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Uint8Array>;
   stream(snapshot: ProviderOperationSnapshot, path: string, body: Record<string, unknown>, onData: (data: string) => void, signal?: AbortSignal): Promise<void>;
   transcribe(snapshot: ProviderOperationSnapshot, audio: Uint8Array, mimeType: string, signal?: AbortSignal): Promise<string>;
-  synthesize(snapshot: ProviderOperationSnapshot, text: string, opts: { voice?: string; rate?: number }): Promise<{ readonly bytes: Uint8Array; readonly mimeType: "audio/mpeg" } | null>;
+  synthesize(snapshot: ProviderOperationSnapshot, text: string, opts: { voice?: string; rate?: number }, signal?: AbortSignal): Promise<{ readonly bytes: Uint8Array; readonly mimeType: "audio/mpeg" } | null>;
   negotiateRealtime(snapshot: ProviderOperationSnapshot, sdp: string, session: Readonly<Record<string, unknown>>, signal?: AbortSignal): Promise<string>;
 }
 
@@ -87,11 +87,11 @@ export class HostProviderService implements HostProviderOperations {
     } finally { await request.release(); }
   }
 
-  async synthesize(snapshot: ProviderOperationSnapshot, text: string, opts: { voice?: string; rate?: number }): Promise<{ readonly bytes: Uint8Array; readonly mimeType: "audio/mpeg" } | null> {
+  async synthesize(snapshot: ProviderOperationSnapshot, text: string, opts: { voice?: string; rate?: number }, signal?: AbortSignal): Promise<{ readonly bytes: Uint8Array; readonly mimeType: "audio/mpeg" } | null> {
     const profile = snapshot.profile;
     if (profile.adapter === "system-tts") return null;
     if (profile.adapter === "minimax-tts") {
-      const parsed = await this.json(snapshot, "/t2a_v2", { model: profile.model, text, stream: false, output_format: "hex", audio_setting: { format: "mp3" }, voice_setting: { voice_id: opts.voice || "English_expressive_narrator", ...(opts.rate === undefined ? {} : { speed: opts.rate }) } }, undefined, MINIMAX_MAX_RESPONSE_BYTES) as { data?: { audio?: string; status?: number }; base_resp?: { status_code?: number; status_msg?: string } };
+      const parsed = await this.json(snapshot, "/t2a_v2", { model: profile.model, text, stream: false, output_format: "hex", audio_setting: { format: "mp3" }, voice_setting: { voice_id: opts.voice || "English_expressive_narrator", ...(opts.rate === undefined ? {} : { speed: opts.rate }) } }, signal, MINIMAX_MAX_RESPONSE_BYTES) as { data?: { audio?: string; status?: number }; base_resp?: { status_code?: number; status_msg?: string } };
       if (parsed.base_resp?.status_code !== undefined && parsed.base_resp.status_code !== 0) throw providerError("MiniMax speech synthesis failed.", "provider.response.invalid");
       const hex = parsed.data?.audio;
       if (parsed.data?.status !== 2 || typeof hex !== "string" || hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(hex)) throw providerError("MiniMax returned invalid speech audio.", "provider.response.invalid");
@@ -100,10 +100,10 @@ export class HostProviderService implements HostProviderOperations {
     }
     if (profile.adapter === "elevenlabs-tts") {
       const voice = opts.voice || "21m00Tcm4TlvDq8ikWAM";
-      return { bytes: await this.binary(snapshot, `/text-to-speech/${encodeURIComponent(voice)}`, { text, model_id: profile.model, ...(opts.rate === undefined ? {} : { voice_settings: { speed: opts.rate } }) }), mimeType: "audio/mpeg" };
+      return { bytes: await this.binary(snapshot, `/text-to-speech/${encodeURIComponent(voice)}`, { text, model_id: profile.model, ...(opts.rate === undefined ? {} : { voice_settings: { speed: opts.rate } }) }, signal), mimeType: "audio/mpeg" };
     }
     if (profile.adapter === "openai-compatible-speech") {
-      return { bytes: await this.binary(snapshot, "/audio/speech", { model: profile.model, input: text, voice: opts.voice || "alloy", response_format: "mp3", ...(opts.rate === undefined ? {} : { speed: opts.rate }) }), mimeType: "audio/mpeg" };
+      return { bytes: await this.binary(snapshot, "/audio/speech", { model: profile.model, input: text, voice: opts.voice || "alloy", response_format: "mp3", ...(opts.rate === undefined ? {} : { speed: opts.rate }) }, signal), mimeType: "audio/mpeg" };
     }
     throw providerError("Selected provider is not a TTS profile.", "provider.role.unsupported");
   }

--- a/apps/desktop/src/voice-activity-slot.ts
+++ b/apps/desktop/src/voice-activity-slot.ts
@@ -1,0 +1,26 @@
+import type { OpenPetsReaction } from "./local-ipc-protocol.js";
+
+export type ComposablePetTransientDisplay = {
+  readonly reaction?: OpenPetsReaction;
+  readonly message?: string;
+  readonly reactionMessage?: string;
+  readonly suppressReactionMessage?: boolean;
+  readonly dismissToken?: string;
+  readonly mediaPath?: string;
+  readonly displayDurationMs?: number;
+  readonly clickUrl?: string;
+};
+
+/** Overlay voice animation without taking ownership of another display's content. */
+export function composeVoiceActivityDisplay(external: ComposablePetTransientDisplay | null, voiceReaction: OpenPetsReaction | null): ComposablePetTransientDisplay | null {
+  if (!voiceReaction) return external;
+  return {
+    ...(external ?? {}),
+    reaction: voiceReaction,
+    suppressReactionMessage: true,
+  };
+}
+
+export function composeVoiceActivityBadge(external: OpenPetsReaction | null, voiceReaction: OpenPetsReaction | null): OpenPetsReaction | null {
+  return voiceReaction ?? external;
+}

--- a/apps/desktop/src/voice-assistant-host-core.ts
+++ b/apps/desktop/src/voice-assistant-host-core.ts
@@ -1,0 +1,145 @@
+import type { PetAssistantService } from "./pet-assistant-service.js";
+import type { HostProviderOperations } from "./provider-service.js";
+import type { VoiceAssistantInput, VoiceAssistantInputOptions, VoiceAssistantInputResult, VoiceAssistantSpeech, VoiceAssistantSynthesizer, VoiceAssistantTurnAdapter, VoiceAssistantTurnResult } from "./voice-assistant-session.js";
+import type { VoiceCaptureService } from "./voice-capture.js";
+import { VoiceListeningService } from "./voice-listening-service.js";
+import { VoiceAssistantSession } from "./voice-assistant-session.js";
+
+const HOST_RECORDING_DURATION_MS = 10_000;
+
+export type VoiceAssistantHostInstance = {
+  readonly session: VoiceAssistantSession;
+  shutdown(): Promise<void>;
+};
+
+/** Owns activation scope; ended sessions are discarded before the next activation. */
+export class VoiceAssistantHostController {
+  readonly #create: () => VoiceAssistantHostInstance;
+  #active: VoiceAssistantHostInstance | null = null;
+  #transition: Promise<void> = Promise.resolve();
+
+  constructor(create: () => VoiceAssistantHostInstance) {
+    this.#create = create;
+  }
+
+  get session(): VoiceAssistantSession | null { return this.#active?.session ?? null; }
+
+  activate(): Promise<VoiceAssistantSession> {
+    const next = this.#transition.then(async () => {
+      if (this.#active && this.#active.session.snapshot().status === "ended") {
+        await this.#active.shutdown();
+        this.#active = null;
+      }
+      if (!this.#active) {
+        const created = this.#create();
+        this.#active = created;
+        try { await created.session.start(); }
+        catch (error) { await created.shutdown().catch(() => undefined); this.#active = null; throw error; }
+      }
+      return this.#active.session;
+    });
+    this.#transition = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  end(): Promise<void> {
+    const next = this.#transition.then(async () => {
+      const active = this.#active;
+      if (!active) return;
+      await active.session.end();
+      await active.shutdown();
+      if (this.#active === active) this.#active = null;
+    });
+    this.#transition = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  shutdown(): Promise<void> {
+    const next = this.#transition.then(async () => {
+      const active = this.#active;
+      this.#active = null;
+      await active?.shutdown();
+    });
+    this.#transition = next.then(() => undefined, () => undefined);
+    return next;
+  }
+}
+
+export class HostVoiceInput implements VoiceAssistantInput {
+  readonly #provider: HostProviderOperations;
+  readonly #capture: VoiceCaptureService;
+  #active: { readonly requestId: string; readonly service: VoiceListeningService } | null = null;
+
+  constructor(provider: HostProviderOperations, capture: VoiceCaptureService) {
+    this.#provider = provider;
+    this.#capture = capture;
+  }
+
+  async listen(options: VoiceAssistantInputOptions): Promise<VoiceAssistantInputResult> {
+    if (this.#active) throw new Error("A voice capture is already in progress.");
+    if (options.signal.aborted) return { status: "cancelled", reason: "Voice input was cancelled." };
+    const snapshot = await this.#provider.snapshot("stt");
+    if (options.signal.aborted) return { status: "cancelled", reason: "Voice input was cancelled." };
+    const service = new VoiceListeningService(this.#capture, async (capture, signal) => options.signal.aborted ? "" : await this.#provider.transcribe(snapshot, capture.bytes, capture.mimeType, signal));
+    this.#active = { requestId: options.requestId, service };
+    try {
+      const result = await service.listenOnce(HOST_RECORDING_DURATION_MS, options.reservation);
+      if (options.signal.aborted) return { status: "cancelled", reason: "Voice input was cancelled." };
+      return { status: "completed", final: result.text };
+    } catch (error) {
+      if (options.signal.aborted) return { status: "cancelled", reason: error instanceof Error ? error.message : "Voice input was cancelled." };
+      throw error;
+    } finally {
+      if (this.#active?.requestId === options.requestId) this.#active = null;
+    }
+  }
+
+  async cancel(requestId: string): Promise<void> {
+    if (this.#active?.requestId !== requestId) return;
+    await this.#active.service.cancel();
+  }
+}
+
+export class ProviderVoiceSynthesizer implements VoiceAssistantSynthesizer {
+  readonly #provider: HostProviderOperations;
+
+  constructor(provider: HostProviderOperations) {
+    this.#provider = provider;
+  }
+
+  async synthesize(text: string, options: { readonly requestId: string; readonly signal: AbortSignal }): Promise<VoiceAssistantSpeech> {
+    const snapshot = await this.#provider.snapshot("tts");
+    const speech = await this.#provider.synthesize(snapshot, text, {}, options.signal);
+    return speech ? { kind: "audio", bytes: speech.bytes, mimeType: speech.mimeType } : { kind: "system", text };
+  }
+}
+
+export class PetAssistantVoiceAdapter implements VoiceAssistantTurnAdapter {
+  readonly #assistant: PetAssistantService;
+
+  constructor(assistant: PetAssistantService) {
+    this.#assistant = assistant;
+  }
+
+  startTurn(conversationId: string, text: string, signal: AbortSignal): Promise<VoiceAssistantTurnResult> {
+    return this.#assistant.startTurn(conversationId, text, signal).then((result) => ({ status: result.status, ...(result.response === undefined ? {} : { response: result.response }), ...(result.error === undefined ? {} : { error: result.error }) }));
+  }
+
+  subscribe(listener: (event: { readonly conversationId: string; readonly turnId: string; readonly activity: "thinking" | "acting" | "responding" }) => void): () => void {
+    return this.#assistant.subscribe((event) => {
+      if (event.type !== "activity" || (event.activity !== "thinking" && event.activity !== "acting" && event.activity !== "responding")) return;
+      listener({ conversationId: event.conversationId, turnId: event.turnId, activity: event.activity });
+    });
+  }
+
+  clearConversation(conversationId: string): void {
+    this.#assistant.clearConversation(conversationId);
+  }
+}
+
+export function reactionForVoiceActivity(activity: "listening" | "thinking" | "acting" | "speaking"): "waiting" | "thinking" | "working" | "running" {
+  if (activity === "listening") return "waiting";
+  if (activity === "acting") return "working";
+  if (activity === "speaking") return "running";
+  return "thinking";
+}

--- a/apps/desktop/src/voice-assistant-host.ts
+++ b/apps/desktop/src/voice-assistant-host.ts
@@ -1,0 +1,119 @@
+import { getDefaultPetWindowForPlugins, setDefaultPetVoiceActivity } from "./default-pet-controller.js";
+import { info, warn } from "./logger.js";
+import type { PetAssistantService } from "./pet-assistant-service.js";
+import type { HostProviderOperations } from "./provider-service.js";
+import { playPetWindowTtsAudio, speakPetWindowTts, stopPetWindowTts, stopPetWindowTtsAudio, subscribePetWindowSpeechCompletion } from "./pet-window.js";
+import type { VoiceAssistantPlayer, VoiceAssistantSpeech } from "./voice-assistant-session.js";
+import { VoiceAssistantSession, type VoiceAssistantActivity } from "./voice-assistant-session.js";
+import { getVoicePlaybackTimeoutMs, VoiceAssistantPlaybackCoordinator } from "./voice-assistant-playback.js";
+import { installWindowLossHandlers } from "./voice-playback-window.js";
+import { HostVoiceInput, PetAssistantVoiceAdapter, ProviderVoiceSynthesizer, reactionForVoiceActivity, VoiceAssistantHostController } from "./voice-assistant-host-core.js";
+import type { VoiceCaptureService } from "./voice-capture.js";
+import { getSharedVoiceCaptureService, getSharedVoiceMicrophoneArbiter } from "./plugin-voice.js";
+import type { VoiceMicrophoneArbiter } from "./voice-microphone-arbiter.js";
+
+export type VoiceAssistantHostOptions = {
+  readonly provider: HostProviderOperations;
+  readonly assistant: PetAssistantService;
+  readonly microphoneArbiter?: VoiceMicrophoneArbiter;
+  readonly capture?: VoiceCaptureService;
+  readonly activityReaction?: (activity: VoiceAssistantActivity | null) => void;
+};
+
+/** Host-private composition of bounded voice I/O, Pet Assistant, and pet speech. */
+export class VoiceAssistantHost {
+  readonly #player: PetWindowVoicePlayer;
+  readonly #session: VoiceAssistantSession;
+  readonly #activityReaction: (activity: VoiceAssistantActivity | null) => void;
+  readonly #unsubscribeSession: () => void;
+
+  constructor(options: VoiceAssistantHostOptions) {
+    this.#activityReaction = options.activityReaction ?? ((activity) => setDefaultPetVoiceActivity(activity ? reactionForVoiceActivity(activity) : null));
+    const input = new HostVoiceInput(options.provider, options.capture ?? getSharedVoiceCaptureService());
+    const adapter = new PetAssistantVoiceAdapter(options.assistant);
+    const synthesizer = new ProviderVoiceSynthesizer(options.provider);
+    this.#player = new PetWindowVoicePlayer();
+    this.#session = new VoiceAssistantSession({
+      microphoneArbiter: options.microphoneArbiter ?? getSharedVoiceMicrophoneArbiter(),
+      input,
+      assistant: adapter,
+      synthesizer,
+      player: this.#player,
+    });
+    this.#unsubscribeSession = this.#session.subscribe((event) => {
+      if (event.type === "snapshot") this.#setActivity(event.snapshot.activity);
+    });
+  }
+
+  get session(): VoiceAssistantSession { return this.#session; }
+
+  async shutdown(): Promise<void> {
+    await this.#session.shutdown();
+    this.#unsubscribeSession();
+    await this.#player.shutdown();
+  }
+
+  #setActivity(activity: VoiceAssistantActivity | null): void {
+    try { this.#activityReaction(activity); } catch (error) { warn("app", "Voice assistant activity reaction failed", { activity, reason: error instanceof Error ? error.message : "unknown" }); }
+  }
+}
+
+let activeHost: VoiceAssistantHostController | null = null;
+let stopping: Promise<void> | null = null;
+
+export function startVoiceAssistantHost(provider: HostProviderOperations, assistant: PetAssistantService): VoiceAssistantHostController {
+  if (activeHost) return activeHost;
+  if (stopping) throw new Error("Voice assistant host shutdown is in progress.");
+  activeHost = new VoiceAssistantHostController(() => new VoiceAssistantHost({ provider, assistant }));
+  info("app", "Voice assistant host ready");
+  return activeHost;
+}
+
+export function stopVoiceAssistantHost(): Promise<void> {
+  if (stopping) return stopping;
+  const host = activeHost;
+  if (!host) return Promise.resolve();
+  stopping = host.shutdown().then(() => {
+    if (activeHost === host) activeHost = null;
+    info("app", "Voice assistant host stopped");
+  }).finally(() => { stopping = null; });
+  return stopping;
+}
+
+class PetWindowVoicePlayer implements VoiceAssistantPlayer {
+  readonly #coordinator = new VoiceAssistantPlaybackCoordinator();
+  readonly #unsubscribe = subscribePetWindowSpeechCompletion((completion) => {
+    this.#coordinator.complete({ owner: completion.window, requestId: completion.requestId, kind: completion.kind, outcome: completion.outcome });
+  });
+
+  play(requestId: string, speech: VoiceAssistantSpeech, signal: AbortSignal): Promise<void> {
+    const window = getDefaultPetWindowForPlugins();
+    if (!window) return Promise.reject(new Error("No pet window is available for speech."));
+    if (signal.aborted) return Promise.reject(new Error("Voice playback was cancelled."));
+    const kind = speech.kind;
+    const cleanupWindow = installWindowLossHandlers(window, () => this.#coordinator.failOwner(window));
+    const playback = this.#coordinator.play(requestId, kind, window, {
+      start: () => {
+        if (speech.kind === "audio") playPetWindowTtsAudio(window, `data:${speech.mimeType};base64,${Buffer.from(speech.bytes).toString("base64")}`, requestId);
+        else speakPetWindowTts(window, speech.text, { requestId });
+      },
+      stop: () => {
+        if (kind === "audio") stopPetWindowTtsAudio(window, requestId);
+        else stopPetWindowTts(window, requestId);
+      },
+    }, getVoicePlaybackTimeoutMs(speech));
+    const abort = () => { this.#coordinator.stop(requestId); };
+    signal.addEventListener("abort", abort, { once: true });
+    void playback.then(() => { signal.removeEventListener("abort", abort); cleanupWindow(); }, () => { signal.removeEventListener("abort", abort); cleanupWindow(); });
+    return playback;
+  }
+
+  async stop(requestId: string): Promise<void> {
+    this.#coordinator.stop(requestId);
+  }
+
+  async shutdown(): Promise<void> {
+    this.#coordinator.shutdown();
+    this.#unsubscribe();
+  }
+}

--- a/apps/desktop/src/voice-assistant-playback.ts
+++ b/apps/desktop/src/voice-assistant-playback.ts
@@ -1,0 +1,114 @@
+export type VoicePlaybackKind = "audio" | "system";
+export type VoicePlaybackCompletion = { readonly owner: unknown; readonly requestId: string; readonly kind: VoicePlaybackKind; readonly outcome: "ended" | "error" | "stopped" };
+export const VOICE_PLAYBACK_DEFAULT_TIMEOUT_MS = 60_000;
+export const VOICE_PLAYBACK_MAX_TIMEOUT_MS = 120_000;
+const systemSpeechMinimumTimeoutMs = 20_000;
+const systemSpeechOverheadMs = 5_000;
+const systemSpeechCharactersPerSecond = 12;
+
+export type VoicePlaybackSpeech =
+  | { readonly kind: "audio"; readonly bytes: Uint8Array }
+  | { readonly kind: "system"; readonly text: string };
+
+export function getVoicePlaybackTimeoutMs(speech: VoicePlaybackSpeech, rate = 1): number {
+  if (speech.kind === "audio") {
+    // Encoded byte length does not identify duration: bitrate and codec settings
+    // can make equally sized payloads play for very different lengths.
+    return VOICE_PLAYBACK_MAX_TIMEOUT_MS;
+  }
+
+  const safeRate = Number.isFinite(rate) && rate > 0 ? rate : 1;
+  const estimatedSpeechMs = Math.ceil(speech.text.length / (systemSpeechCharactersPerSecond * safeRate) * 1_000);
+  return Math.min(VOICE_PLAYBACK_MAX_TIMEOUT_MS, Math.max(systemSpeechMinimumTimeoutMs, systemSpeechOverheadMs + estimatedSpeechMs));
+}
+
+type PendingPlayback = {
+  readonly owner: unknown;
+  readonly requestId: string;
+  readonly kind: VoicePlaybackKind;
+  readonly stop: () => void;
+  readonly resolve: () => void;
+  readonly reject: (error: unknown) => void;
+  readonly timer: NodeJS.Timeout;
+};
+
+export type VoicePlaybackTransport = {
+  start(): void;
+  stop(): void;
+};
+
+/** Main-process request coordinator; every request settles exactly once. */
+export class VoiceAssistantPlaybackCoordinator {
+  readonly #timeoutMs: number;
+  readonly #pending = new Map<string, PendingPlayback>();
+
+  constructor(timeoutMs = VOICE_PLAYBACK_DEFAULT_TIMEOUT_MS) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 1) throw new Error("Invalid voice playback timeout.");
+    this.#timeoutMs = timeoutMs;
+  }
+
+  play(requestId: string, kind: VoicePlaybackKind, owner: unknown, transport: VoicePlaybackTransport, timeoutMs = this.#timeoutMs): Promise<void> {
+    if (!requestId || this.#pending.has(requestId)) return Promise.reject(new Error("Voice playback request is already active."));
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 1) return Promise.reject(new Error("Invalid voice playback timeout."));
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.#take(requestId);
+        if (!pending) return;
+        try { pending.stop(); } catch { /* renderer may already be gone */ }
+        pending.reject(new Error("Voice playback completion timed out."));
+      }, timeoutMs);
+      const pending: PendingPlayback = { owner, requestId, kind, stop: transport.stop, resolve, reject, timer };
+      this.#pending.set(requestId, pending);
+      try { transport.start(); } catch (error) { this.#settle(pending, "error", error instanceof Error ? error : new Error(String(error))); }
+    });
+  }
+
+  complete(completion: VoicePlaybackCompletion): boolean {
+    const pending = this.#pending.get(completion.requestId);
+    if (!pending || pending.owner !== completion.owner || pending.kind !== completion.kind) return false;
+    this.#settle(pending, completion.outcome, completion.outcome === "ended" ? undefined : new Error(`Voice playback ${completion.outcome}.`));
+    return true;
+  }
+
+  stop(requestId: string): boolean {
+    const pending = this.#take(requestId);
+    if (!pending) return false;
+    try { pending.stop(); } catch { /* renderer may already be gone */ }
+    pending.reject(new Error("Voice playback was stopped."));
+    return true;
+  }
+
+  failOwner(owner: unknown, reason = "Voice playback window was lost."): void {
+    for (const pending of [...this.#pending.values()]) {
+      if (pending.owner !== owner) continue;
+      const taken = this.#take(pending.requestId);
+      if (taken) taken.reject(new Error(reason));
+    }
+  }
+
+  shutdown(reason = "Voice playback was shut down."): void {
+    for (const pending of [...this.#pending.values()]) {
+      const taken = this.#take(pending.requestId);
+      if (!taken) continue;
+      try { taken.stop(); } catch { /* renderer may already be gone */ }
+      taken.reject(new Error(reason));
+    }
+  }
+
+  get pendingCount(): number { return this.#pending.size; }
+
+  #settle(pending: PendingPlayback, outcome: "ended" | "error" | "stopped", error?: Error): void {
+    const taken = this.#take(pending.requestId);
+    if (!taken) return;
+    if (outcome === "ended") taken.resolve();
+    else taken.reject(error ?? new Error(`Voice playback ${outcome}.`));
+  }
+
+  #take(requestId: string): PendingPlayback | null {
+    const pending = this.#pending.get(requestId);
+    if (!pending) return null;
+    this.#pending.delete(requestId);
+    clearTimeout(pending.timer);
+    return pending;
+  }
+}

--- a/apps/desktop/src/voice-assistant-session.ts
+++ b/apps/desktop/src/voice-assistant-session.ts
@@ -1,0 +1,485 @@
+import type { VoiceMicrophoneArbiter, VoiceMicrophoneReservation } from "./voice-microphone-arbiter.js";
+
+export type VoiceAssistantActivity = "listening" | "thinking" | "acting" | "speaking";
+export type VoiceAssistantSessionStatus = "idle" | "active" | "muted" | "paused" | "ending" | "ended";
+export type VoiceAssistantErrorScope = "input" | "assistant" | "synthesis" | "playback" | "session";
+
+export type VoiceAssistantSessionSnapshot = {
+  readonly status: VoiceAssistantSessionStatus;
+  readonly activity: VoiceAssistantActivity | null;
+  readonly muted: boolean;
+  readonly conversationId: string;
+  readonly generation: number;
+  readonly turnId: string | null;
+  readonly userTranscript: string | null;
+  readonly assistantTranscript: string | null;
+  readonly interruptionCount: number;
+  readonly error: { readonly scope: VoiceAssistantErrorScope; readonly message: string } | null;
+};
+
+export type VoiceAssistantTranscriptEvent = {
+  readonly type: "transcript";
+  readonly sequence: number;
+  readonly turnId: string;
+  readonly speaker: "user" | "assistant";
+  readonly kind: "partial" | "final";
+  readonly text: string;
+};
+
+export type VoiceAssistantSessionEvent =
+  | { readonly type: "snapshot"; readonly sequence: number; readonly snapshot: VoiceAssistantSessionSnapshot }
+  | VoiceAssistantTranscriptEvent
+  | { readonly type: "error"; readonly sequence: number; readonly scope: VoiceAssistantErrorScope; readonly message: string }
+  | { readonly type: "interrupted"; readonly sequence: number; readonly generation: number; readonly turnId: string | null }
+  | { readonly type: "ended"; readonly sequence: number; readonly reason: "ended" | "shutdown" };
+
+type VoiceAssistantSessionEventInput =
+  | { readonly type: "snapshot"; readonly snapshot: VoiceAssistantSessionSnapshot }
+  | Omit<VoiceAssistantTranscriptEvent, "sequence">
+  | { readonly type: "error"; readonly scope: VoiceAssistantErrorScope; readonly message: string }
+  | { readonly type: "interrupted"; readonly generation: number; readonly turnId: string | null }
+  | { readonly type: "ended"; readonly reason: "ended" | "shutdown" };
+
+export type VoiceAssistantSessionListener = (event: VoiceAssistantSessionEvent) => void;
+
+export type VoiceAssistantInputResult =
+  | { readonly status: "completed"; readonly final: string }
+  | { readonly status: "cancelled"; readonly reason?: string };
+
+export type VoiceAssistantInputOptions = {
+  readonly requestId: string;
+  readonly signal: AbortSignal;
+  readonly reservation: VoiceMicrophoneReservation;
+  readonly onPartial?: (text: string) => void;
+};
+
+/** One bounded capture/transcription attempt. cancel(requestId) settles that attempt. */
+export interface VoiceAssistantInput {
+  listen(options: VoiceAssistantInputOptions): Promise<VoiceAssistantInputResult>;
+  cancel(requestId: string): Promise<void>;
+}
+
+export type VoiceAssistantTurnResult = {
+  readonly status: "completed" | "cancelled" | "failed";
+  /** The terminal response after all capability outcomes have been applied. */
+  readonly response?: string;
+  readonly error?: string;
+};
+
+export type VoiceAssistantActivityEvent = {
+  readonly conversationId: string;
+  readonly turnId: string;
+  readonly activity: "thinking" | "acting" | "responding";
+};
+
+export interface VoiceAssistantTurnAdapter {
+  startTurn(conversationId: string, text: string, signal: AbortSignal): Promise<VoiceAssistantTurnResult>;
+  subscribe(listener: (event: VoiceAssistantActivityEvent) => void): () => void;
+  clearConversation(conversationId: string): void | Promise<void>;
+}
+
+export type VoiceAssistantSpeech =
+  | { readonly kind: "audio"; readonly bytes: Uint8Array; readonly mimeType: string }
+  | { readonly kind: "system"; readonly text: string };
+export type VoiceAssistantSynthesisOptions = { readonly requestId: string; readonly signal: AbortSignal };
+
+export interface VoiceAssistantSynthesizer {
+  synthesize(text: string, options: VoiceAssistantSynthesisOptions): Promise<VoiceAssistantSpeech>;
+}
+
+/** The player owns both decoded audio and eventual system speech, per request. */
+export interface VoiceAssistantPlayer {
+  play(requestId: string, speech: VoiceAssistantSpeech, signal: AbortSignal): Promise<void>;
+  stop(requestId: string): Promise<void>;
+}
+
+export type VoiceAssistantSessionOptions = {
+  readonly conversationId?: string;
+  readonly microphoneArbiter: VoiceMicrophoneArbiter;
+  readonly input: VoiceAssistantInput;
+  readonly assistant: VoiceAssistantTurnAdapter;
+  readonly synthesizer: VoiceAssistantSynthesizer;
+  readonly player: VoiceAssistantPlayer;
+};
+
+type InputStage = {
+  readonly generation: number;
+  readonly requestId: string;
+  readonly turnId: string;
+  readonly controller: AbortController;
+  promise: Promise<void>;
+  cancelPromise: Promise<void> | null;
+  lastPartial: string | null;
+};
+
+type TurnStage = {
+  readonly generation: number;
+  readonly turnId: string;
+  readonly controller: AbortController;
+  promise: Promise<VoiceAssistantTurnResult>;
+  unsubscribe: (() => void) | null;
+};
+
+type SpeechStage = {
+  readonly generation: number;
+  readonly requestId: string;
+  readonly turnId: string;
+  readonly controller: AbortController;
+  synthesis: Promise<VoiceAssistantSpeech>;
+  playback: Promise<void> | null;
+};
+
+const DEFAULT_CONVERSATION_ID = "voice-assistant";
+
+/** Host-private batch voice session. No provider wire event crosses this boundary. */
+export class VoiceAssistantSession {
+  readonly #options: VoiceAssistantSessionOptions;
+  readonly #conversationId: string;
+  readonly #listeners = new Set<VoiceAssistantSessionListener>();
+  #microphoneReservation: VoiceMicrophoneReservation | null = null;
+  #input: InputStage | null = null;
+  #turn: TurnStage | null = null;
+  #speech: SpeechStage | null = null;
+  #ending: Promise<void> | null = null;
+  #lifecycleTail: Promise<void> = Promise.resolve();
+  #snapshot: VoiceAssistantSessionSnapshot;
+  #sequence = 1;
+  #generation = 0;
+  #started = false;
+  #ended = false;
+  #muted = false;
+  #nextRequest = 1;
+  #nextTurnOrdinal = 0;
+
+  constructor(options: VoiceAssistantSessionOptions) {
+    this.#options = options;
+    this.#conversationId = normalizeConversationId(options.conversationId ?? DEFAULT_CONVERSATION_ID);
+    this.#snapshot = freeze({
+      status: "idle",
+      activity: null,
+      muted: false,
+      conversationId: this.#conversationId,
+      generation: 0,
+      turnId: null,
+      userTranscript: null,
+      assistantTranscript: null,
+      interruptionCount: 0,
+      error: null,
+    });
+  }
+
+  snapshot(): VoiceAssistantSessionSnapshot { return this.#snapshot; }
+
+  subscribe(listener: VoiceAssistantSessionListener): () => void {
+    this.#listeners.add(listener);
+    return () => { this.#listeners.delete(listener); };
+  }
+
+  start(): Promise<void> { return this.#serialize(() => this.#start()); }
+  retry(): Promise<void> { return this.#serialize(() => this.#retry()); }
+  mute(): Promise<void> { return this.#serialize(() => this.#mute()); }
+  unmute(): Promise<void> { return this.#serialize(() => this.#unmute()); }
+  interrupt(): Promise<void> { return this.#serialize(() => this.#interrupt()); }
+  end(): Promise<void> { return this.#serialize(() => this.#end("ended")); }
+  shutdown(): Promise<void> { return this.#serialize(() => this.#end("shutdown")); }
+
+  async #start(): Promise<void> {
+    if (this.#ended) throw new Error("Voice assistant session has ended.");
+    if (this.#started) return;
+    this.#microphoneReservation = this.#options.microphoneArbiter.reserve("assistant-session");
+    this.#started = true;
+    this.#setSnapshot({ status: "active", activity: "listening", muted: false, error: null });
+    this.#beginListen();
+    await Promise.resolve();
+  }
+
+  async #retry(): Promise<void> {
+    if (!this.#started) throw new Error("Voice assistant session has not started.");
+    if (this.#ended || this.#muted || this.#snapshot.status !== "paused") return;
+    this.#setSnapshot({ status: "active", activity: "listening", error: null });
+    this.#beginListen();
+    await Promise.resolve();
+  }
+
+  async #mute(): Promise<void> {
+    if (!this.#started) throw new Error("Voice assistant session has not started.");
+    if (this.#ended || this.#muted) return;
+    this.#muted = true;
+    this.#setSnapshot({ muted: true, status: "muted", activity: null });
+    const input = this.#input;
+    if (input) {
+      ++this.#generation;
+      await this.#cancelInput(input);
+      this.#input = null;
+    }
+    if (!this.#turn && !this.#speech) this.#setSnapshot({ activity: null });
+  }
+
+  async #unmute(): Promise<void> {
+    if (!this.#started) throw new Error("Voice assistant session has not started.");
+    if (this.#ended || !this.#muted) return;
+    this.#muted = false;
+    this.#setSnapshot({ muted: false, status: "active" });
+    if (!this.#input && !this.#turn && !this.#speech) this.#beginListen();
+    await Promise.resolve();
+  }
+
+  async #interrupt(): Promise<void> {
+    if (!this.#started || this.#ended) return;
+    const input = this.#input;
+    const turn = this.#turn;
+    const speech = this.#speech;
+    ++this.#generation;
+    const turnId = input?.turnId ?? turn?.turnId ?? speech?.turnId ?? null;
+    this.#setSnapshot({ status: this.#muted ? "muted" : "active", activity: null, interruptionCount: this.#snapshot.interruptionCount + 1 });
+    this.#emit({ type: "interrupted", generation: this.#generation, turnId });
+    await this.#cancelStages(input, turn, speech);
+    this.#input = null;
+    this.#turn = null;
+    this.#speech = null;
+    if (this.#muted) this.#setSnapshot({ status: "muted", activity: null });
+    else {
+      this.#setSnapshot({ status: "active", activity: "listening" });
+      this.#beginListen();
+    }
+  }
+
+  #beginListen(): void {
+    if (this.#ended || !this.#started || !this.#microphoneReservation || this.#muted || this.#input || this.#turn || this.#speech) return;
+    const generation = ++this.#generation;
+    const ordinal = ++this.#nextTurnOrdinal;
+    const turnId = `voice-turn-${ordinal}`;
+    const requestId = `voice-input-${this.#nextRequest++}`;
+    const controller = new AbortController();
+    this.#setSnapshot({ status: "active", activity: "listening", turnId, userTranscript: null, assistantTranscript: null, error: null });
+    const stage: InputStage = { generation, requestId, turnId, controller, promise: Promise.resolve(), cancelPromise: null, lastPartial: null };
+    const promise = Promise.resolve().then(() => this.#options.input.listen({
+      requestId,
+      signal: controller.signal,
+      reservation: this.#microphoneReservation!,
+      onPartial: (value) => {
+        if (!this.#isCurrentInput(stage)) return;
+        const text = normalizeTranscript(value);
+        if (!text || text === stage.lastPartial) return;
+        stage.lastPartial = text;
+        this.#setSnapshot({ activity: "listening", turnId, userTranscript: text, error: null });
+        this.#emit({ type: "transcript", turnId, speaker: "user", kind: "partial", text });
+      },
+    })).then((result) => {
+      if (!this.#isCurrentInput(stage)) return;
+      this.#finishInput(stage);
+      if (result.status === "cancelled") {
+        this.#pauseInput(result.reason ?? "Voice input was cancelled.");
+        return;
+      }
+      const text = normalizeTranscript(result.final);
+      if (!text) {
+        this.#pauseInput("Voice input returned no text.");
+        return;
+      }
+      this.#setSnapshot({ userTranscript: text, activity: "thinking", error: null });
+      this.#emit({ type: "transcript", turnId, speaker: "user", kind: "final", text });
+      this.#beginTurn(turnId, text);
+    }).catch((error: unknown) => {
+      if (!this.#isCurrentInput(stage)) return;
+      this.#finishInput(stage);
+      this.#pauseInput(errorMessage(error));
+    });
+    stage.promise = promise;
+    this.#input = stage;
+  }
+
+  #beginTurn(turnId: string, text: string): void {
+    if (this.#ended || this.#muted || this.#turn) return;
+    const generation = ++this.#generation;
+    const controller = new AbortController();
+    const stage: TurnStage = { generation, turnId, controller, promise: Promise.resolve(undefined as never), unsubscribe: null };
+    this.#turn = stage;
+    try {
+      stage.unsubscribe = this.#options.assistant.subscribe((event) => {
+        if (!this.#isCurrentTurn(stage) || event.conversationId !== this.#conversationId) return;
+        this.#setSnapshot({ activity: this.#muted ? null : event.activity === "acting" ? "acting" : "thinking", error: null });
+      });
+    } catch (error) {
+      this.#finishTurn(stage);
+      this.#emitError("assistant", errorMessage(error));
+      this.#resumeAfterTurn();
+      return;
+    }
+    stage.promise = Promise.resolve().then(() => this.#options.assistant.startTurn(this.#conversationId, text, controller.signal));
+    void stage.promise.then((result) => {
+      if (!this.#isCurrentTurn(stage)) return;
+      this.#finishTurn(stage);
+      if (result.status === "cancelled") {
+        this.#resumeAfterTurn();
+        return;
+      }
+      if (result.status === "failed") {
+        this.#emitError("assistant", result.error ?? "Pet Assistant turn failed.");
+        this.#resumeAfterTurn();
+        return;
+      }
+      const response = normalizeTranscript(result.response ?? "");
+      if (!response) {
+        this.#emitError("assistant", "Pet Assistant returned no response.");
+        this.#resumeAfterTurn();
+        return;
+      }
+      this.#setSnapshot({ assistantTranscript: response, activity: this.#muted ? null : "thinking", error: null });
+      this.#emit({ type: "transcript", turnId, speaker: "assistant", kind: "final", text: response });
+      this.#beginSpeech(turnId, response);
+    }, (error: unknown) => {
+      if (!this.#isCurrentTurn(stage)) return;
+      this.#finishTurn(stage);
+      this.#emitError("assistant", errorMessage(error));
+      this.#resumeAfterTurn();
+    });
+  }
+
+  #beginSpeech(turnId: string, text: string): void {
+    if (this.#ended) return;
+    const generation = ++this.#generation;
+    const requestId = `voice-output-${this.#nextRequest++}`;
+    const controller = new AbortController();
+    const stage: SpeechStage = { generation, requestId, turnId, controller, synthesis: Promise.resolve(undefined as never), playback: null };
+    stage.synthesis = Promise.resolve().then(() => this.#options.synthesizer.synthesize(text, { requestId, signal: controller.signal }));
+    this.#speech = stage;
+    void stage.synthesis.then((speech) => {
+      if (!this.#isCurrentSpeech(stage)) return;
+      this.#setSnapshot({ activity: this.#muted ? null : "speaking", error: null });
+      stage.playback = Promise.resolve().then(() => this.#options.player.play(requestId, speech, controller.signal));
+      void stage.playback.then(() => {
+        if (!this.#isCurrentSpeech(stage)) return;
+        this.#finishSpeech(stage);
+        this.#resumeAfterTurn();
+      }, (error: unknown) => {
+        if (!this.#isCurrentSpeech(stage)) return;
+        this.#finishSpeech(stage);
+        this.#emitError("playback", errorMessage(error));
+        this.#resumeAfterTurn();
+      });
+    }, (error: unknown) => {
+      if (!this.#isCurrentSpeech(stage)) return;
+      this.#finishSpeech(stage);
+      this.#emitError("synthesis", errorMessage(error));
+      this.#resumeAfterTurn();
+    });
+  }
+
+  #resumeAfterTurn(): void {
+    if (this.#ended || this.#muted) {
+      if (!this.#ended) this.#setSnapshot({ status: "muted", activity: null });
+      return;
+    }
+    this.#setSnapshot({ status: "active", activity: "listening" });
+    this.#beginListen();
+  }
+
+  #pauseInput(message: string): void {
+    const normalized = message.trim() || "Voice input failed.";
+    this.#setSnapshot({ status: "paused", activity: null, error: { scope: "input", message: normalized } });
+    this.#emit({ type: "error", scope: "input", message: normalized });
+  }
+
+  async #end(reason: "ended" | "shutdown"): Promise<void> {
+    if (this.#ended) return;
+    if (this.#ending) return this.#ending;
+    this.#ending = this.#finishEnd(reason);
+    await this.#ending;
+  }
+
+  async #finishEnd(reason: "ended" | "shutdown"): Promise<void> {
+    this.#ended = true;
+    ++this.#generation;
+    this.#setSnapshot({ status: "ending", activity: null });
+    const turn = this.#turn;
+    await this.#cancelStages(this.#input, turn, this.#speech);
+    if (turn) {
+      turn.unsubscribe?.();
+      turn.unsubscribe = null;
+    }
+    try {
+      await this.#options.assistant.clearConversation(this.#conversationId);
+    } catch (error) {
+      this.#emitError("session", errorMessage(error));
+    }
+    if (this.#microphoneReservation) {
+      this.#options.microphoneArbiter.releaseReservation(this.#microphoneReservation);
+      this.#microphoneReservation = null;
+    }
+    this.#input = null;
+    this.#turn = null;
+    this.#speech = null;
+    this.#setSnapshot({ status: "ended", activity: null });
+    this.#emit({ type: "ended", reason });
+  }
+
+  async #cancelStages(input: InputStage | null, turn: TurnStage | null, speech: SpeechStage | null): Promise<void> {
+    const pending: Promise<unknown>[] = [];
+    if (input) pending.push(this.#cancelInput(input));
+    if (turn) {
+      turn.controller.abort();
+      pending.push(turn.promise.catch(() => undefined));
+    }
+    if (speech) {
+      speech.controller.abort();
+      pending.push(Promise.resolve().then(() => this.#options.player.stop(speech.requestId)).catch(() => undefined));
+      pending.push(speech.synthesis.catch(() => undefined));
+      if (speech.playback) pending.push(speech.playback.catch(() => undefined));
+    }
+    await Promise.all(pending);
+  }
+
+  async #cancelInput(stage: InputStage): Promise<void> {
+    stage.controller.abort();
+    if (!stage.cancelPromise) stage.cancelPromise = Promise.resolve().then(() => this.#options.input.cancel(stage.requestId)).catch(() => undefined);
+    await Promise.all([stage.cancelPromise, stage.promise.catch(() => undefined)]);
+  }
+
+  #finishInput(stage: InputStage): void { if (this.#input === stage) this.#input = null; }
+  #finishTurn(stage: TurnStage): void { stage.unsubscribe?.(); stage.unsubscribe = null; if (this.#turn === stage) this.#turn = null; }
+  #finishSpeech(stage: SpeechStage): void { if (this.#speech === stage) this.#speech = null; }
+
+  #isCurrentInput(stage: InputStage): boolean { return this.#input === stage && !this.#ended && this.#generation === stage.generation; }
+  #isCurrentTurn(stage: TurnStage): boolean { return this.#turn === stage && !this.#ended && this.#generation === stage.generation; }
+  #isCurrentSpeech(stage: SpeechStage): boolean { return this.#speech === stage && !this.#ended && this.#generation === stage.generation; }
+
+  #serialize<T>(operation: () => Promise<T> | T): Promise<T> {
+    const next = this.#lifecycleTail.then(operation, operation);
+    this.#lifecycleTail = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  #setSnapshot(patch: Partial<VoiceAssistantSessionSnapshot>): void {
+    this.#snapshot = freeze({ ...this.#snapshot, ...patch, generation: this.#generation });
+    this.#emit({ type: "snapshot", snapshot: this.#snapshot });
+  }
+
+  #emitError(scope: VoiceAssistantErrorScope, message: string): void {
+    const normalized = message.trim() || "Voice assistant operation failed.";
+    this.#setSnapshot({ error: { scope, message: normalized } });
+    this.#emit({ type: "error", scope, message: normalized });
+  }
+
+  #emit(event: VoiceAssistantSessionEventInput): void {
+    const immutable = freeze({ ...event, sequence: this.#sequence++ }) as unknown as VoiceAssistantSessionEvent;
+    for (const listener of [...this.#listeners]) {
+      try { listener(immutable); } catch { /* observers cannot affect cleanup */ }
+    }
+  }
+}
+
+function normalizeConversationId(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error("Voice assistant conversation id must not be empty.");
+  return normalized;
+}
+
+function normalizeTranscript(value: string): string { return value.trim(); }
+function errorMessage(error: unknown): string { return error instanceof Error && error.message ? error.message : String(error); }
+
+function freeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value as Record<string, unknown>)) freeze(child);
+  return Object.freeze(value);
+}

--- a/apps/desktop/src/voice-capture.ts
+++ b/apps/desktop/src/voice-capture.ts
@@ -106,6 +106,9 @@ export class VoiceCaptureService {
 
     try {
       if (microphoneReservation && !this.#microphoneArbiter) throw new Error("A microphone reservation requires its arbiter.");
+      if (microphoneReservation && this.#microphoneArbiter && !this.#microphoneArbiter.ownsReservation(microphoneReservation)) {
+        throw new Error("A microphone reservation belongs to a different arbiter.");
+      }
       active.microphoneLease = microphoneReservation
         ? microphoneReservation.acquireTrack()
         : toTrackLease(this.#microphoneArbiter?.acquire("listen"));

--- a/apps/desktop/src/voice-capture.ts
+++ b/apps/desktop/src/voice-capture.ts
@@ -1,5 +1,5 @@
 import type { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
-import type { VoiceMicrophoneArbiter, VoiceMicrophoneLease } from "./voice-microphone-arbiter.js";
+import type { VoiceMicrophoneArbiter, VoiceMicrophoneReservation, VoiceMicrophoneTrackLease } from "./voice-microphone-arbiter.js";
 
 export const VOICE_ACQUISITION_TIMEOUT_MS = 15_000;
 export const VOICE_MIN_RECORDING_DURATION_MS = 1_000;
@@ -54,7 +54,7 @@ type ActiveCapture = {
   recordingTimer: NodeJS.Timeout | null;
   finishing: Promise<VoiceCaptureResult> | null;
   cleaned: boolean;
-  microphoneLease: VoiceMicrophoneLease | null;
+  microphoneLease: VoiceMicrophoneTrackLease | null;
 };
 
 export type VoiceCaptureServiceOptions = {
@@ -76,7 +76,7 @@ export class VoiceCaptureService {
     this.#microphoneArbiter = options.microphoneArbiter;
   }
 
-  async start(timeoutMs: number): Promise<{
+  async start(timeoutMs: number, microphoneReservation?: VoiceMicrophoneReservation): Promise<{
     readonly result: Promise<VoiceCaptureResult>;
     stop(): Promise<VoiceCaptureResult>;
     cancel(reason?: string): Promise<void>;
@@ -105,7 +105,10 @@ export class VoiceCaptureService {
     };
 
     try {
-      active.microphoneLease = this.#microphoneArbiter?.acquire("listen") ?? null;
+      if (microphoneReservation && !this.#microphoneArbiter) throw new Error("A microphone reservation requires its arbiter.");
+      active.microphoneLease = microphoneReservation
+        ? microphoneReservation.acquireTrack()
+        : toTrackLease(this.#microphoneArbiter?.acquire("listen"));
       active.attempt = this.#factory(durationMs, () => {
         if (active.cancelled || this.#active !== active) return false;
         active.indicatorLive = true;
@@ -163,8 +166,8 @@ export class VoiceCaptureService {
     }
   }
 
-  async captureOneShot(timeoutMs: number): Promise<VoiceCaptureResult> {
-    const handle = await this.start(timeoutMs);
+  async captureOneShot(timeoutMs: number, microphoneReservation?: VoiceMicrophoneReservation): Promise<VoiceCaptureResult> {
+    const handle = await this.start(timeoutMs, microphoneReservation);
     return handle.result;
   }
 
@@ -178,7 +181,6 @@ export class VoiceCaptureService {
 
   async shutdown(): Promise<void> {
     await this.cancelActive("OpenPets is shutting down.");
-    this.#indicator.shutdown();
   }
 
   #requestCancel(active: ActiveCapture, error: Error): void {
@@ -267,4 +269,8 @@ function deferred<T>(): Deferred<T> {
 
 function normalizeError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function toTrackLease(lease: { readonly generation: number; release(): void } | undefined): VoiceMicrophoneTrackLease | null {
+  return lease ? { owner: "listen", generation: lease.generation, release: lease.release } : null;
 }

--- a/apps/desktop/src/voice-conversation.ts
+++ b/apps/desktop/src/voice-conversation.ts
@@ -209,7 +209,6 @@ export class VoiceConversationService {
     this.#shutdownRequested = true;
     this.#shutdownPromise = (async () => {
       await this.close("OpenPets is shutting down.");
-      this.#privacyIndicator.shutdown();
     })();
     return this.#shutdownPromise;
   }

--- a/apps/desktop/src/voice-listening-service.ts
+++ b/apps/desktop/src/voice-listening-service.ts
@@ -1,4 +1,5 @@
 import type { VoiceCaptureResult, VoiceCaptureService } from "./voice-capture.js";
+import type { VoiceMicrophoneReservation } from "./voice-microphone-arbiter.js";
 
 export const VOICE_TRANSCRIPTION_TIMEOUT_MS = 30_000;
 export const VOICE_EMPTY_TRANSCRIPT_ERROR = "Voice transcription returned no text.";
@@ -45,7 +46,7 @@ export class VoiceListeningService {
     this.#onPhaseChange = options.onPhaseChange;
   }
 
-  listenOnce(recordingDurationMs: number): Promise<{ text: string }> {
+  listenOnce(recordingDurationMs: number, microphoneReservation?: VoiceMicrophoneReservation): Promise<{ text: string }> {
     if (this.#active) throw new Error("A voice capture is already in progress.");
     const done = deferred<void>();
     let rejectCancel!: (error: unknown) => void;
@@ -62,7 +63,7 @@ export class VoiceListeningService {
     };
     this.#active = active;
     this.#onPhaseChange?.("acquiring");
-    const run = this.#run(active, recordingDurationMs).finally(async () => {
+    const run = this.#run(active, recordingDurationMs, microphoneReservation).finally(async () => {
       await this.#capture.cancelActive(active.cancelError?.message ?? "Voice listening finished.").catch(() => undefined);
       if (this.#active === active) this.#active = null;
       active.done.resolve(undefined);
@@ -85,12 +86,11 @@ export class VoiceListeningService {
 
   async shutdown(): Promise<void> {
     await this.cancel("OpenPets is shutting down.");
-    await this.#capture.shutdown();
   }
 
-  async #run(active: ActiveListen, recordingDurationMs: number): Promise<{ text: string }> {
+  async #run(active: ActiveListen, recordingDurationMs: number, microphoneReservation?: VoiceMicrophoneReservation): Promise<{ text: string }> {
     try {
-      const startPromise = this.#capture.start(recordingDurationMs);
+      const startPromise = this.#capture.start(recordingDurationMs, microphoneReservation);
       void startPromise.catch(() => undefined);
       const handle = await Promise.race([startPromise, active.cancelPromise]);
       active.capturePhase = "recording";

--- a/apps/desktop/src/voice-microphone-arbiter.ts
+++ b/apps/desktop/src/voice-microphone-arbiter.ts
@@ -1,4 +1,4 @@
-export type VoiceMicrophoneOwner = "listen" | "conversation";
+export type VoiceMicrophoneOwner = "listen" | "conversation" | "assistant-session";
 
 export type VoiceMicrophoneLease = {
   readonly owner: VoiceMicrophoneOwner;
@@ -6,35 +6,103 @@ export type VoiceMicrophoneLease = {
   release(): void;
 };
 
+/** The only microphone capability an input adapter receives for a session. */
+export type VoiceMicrophoneTrackLease = {
+  readonly owner: "listen";
+  readonly generation: number;
+  release(): void;
+};
+
+/** Opaque reservation: adapters can acquire one track, but cannot release the parent. */
+export type VoiceMicrophoneReservation = {
+  readonly generation: number;
+  acquireTrack(): VoiceMicrophoneTrackLease;
+};
+
+type ActiveEntry = {
+  readonly owner: VoiceMicrophoneOwner;
+  readonly generation: number;
+  childActive: boolean;
+  released: boolean;
+};
+
 /** The host-level boundary that prevents independent voice paths owning audio together. */
 export class VoiceMicrophoneArbiter {
-  #active: { readonly owner: VoiceMicrophoneOwner; readonly generation: number } | null = null;
+  #active: ActiveEntry | null = null;
+  readonly #leases = new WeakMap<object, { readonly entry: ActiveEntry; released: boolean }>();
+  readonly #reservations = new WeakMap<object, { readonly entry: ActiveEntry; released: boolean }>();
   #nextGeneration = 0;
 
-  get activeOwner(): VoiceMicrophoneOwner | null {
-    return this.#active?.owner ?? null;
-  }
+  get activeOwner(): VoiceMicrophoneOwner | null { return this.#active?.owner ?? null; }
 
   acquire(owner: VoiceMicrophoneOwner): VoiceMicrophoneLease {
-    if (this.#active) {
-      throw new Error(`The microphone is already in use by ${this.#ownerDescription(this.#active.owner)}.`);
-    }
-
-    const entry = { owner, generation: ++this.#nextGeneration };
-    this.#active = entry;
-    let released = false;
-    return {
+    const entry = this.#acquireEntry(owner);
+    const lease = {
       owner,
       generation: entry.generation,
       release: () => {
-        if (released) return;
-        released = true;
-        if (this.#active === entry) this.#active = null;
+        const metadata = this.#leases.get(lease);
+        if (!metadata || metadata.released) return;
+        metadata.released = true;
+        entry.released = true;
+        this.#releaseEntry(entry);
       },
-    };
+    } satisfies VoiceMicrophoneLease;
+    this.#leases.set(lease, { entry, released: false });
+    return lease;
+  }
+
+  reserve(owner: VoiceMicrophoneOwner): VoiceMicrophoneReservation {
+    const entry = this.#acquireEntry(owner);
+    const reservation = {
+      generation: entry.generation,
+      acquireTrack: () => {
+        const metadata = this.#reservations.get(reservation);
+        if (!metadata || metadata.released || metadata.entry.released || this.#active !== metadata.entry) {
+          throw new Error("The microphone reservation is no longer active.");
+        }
+        if (metadata.entry.childActive) throw new Error("The microphone reservation already has an active track.");
+        metadata.entry.childActive = true;
+        let released = false;
+        return {
+          owner: "listen" as const,
+          generation: metadata.entry.generation,
+          release: () => {
+            if (released) return;
+            released = true;
+            metadata.entry.childActive = false;
+            this.#releaseEntry(metadata.entry);
+          },
+        };
+      },
+    } satisfies VoiceMicrophoneReservation;
+    this.#reservations.set(reservation, { entry, released: false });
+    return reservation;
+  }
+
+  releaseReservation(reservation: VoiceMicrophoneReservation): void {
+    const metadata = this.#reservations.get(reservation);
+    if (!metadata || metadata.released) return;
+    if (metadata.entry.childActive) throw new Error("Cannot release a microphone reservation with an active track.");
+    metadata.released = true;
+    metadata.entry.released = true;
+    this.#releaseEntry(metadata.entry);
+  }
+
+  #acquireEntry(owner: VoiceMicrophoneOwner): ActiveEntry {
+    if (this.#active) throw new Error(`The microphone is already in use by ${this.#ownerDescription(this.#active.owner)}.`);
+    const entry = { owner, generation: ++this.#nextGeneration, childActive: false, released: false };
+    this.#active = entry;
+    return entry;
+  }
+
+  #releaseEntry(entry: ActiveEntry): void {
+    if (entry.released && !entry.childActive && this.#active === entry) this.#active = null;
   }
 
   #ownerDescription(owner: VoiceMicrophoneOwner): string {
-    return owner === "listen" ? "one-shot voice listening" : "a realtime voice conversation";
+    if (owner === "listen") return "one-shot voice listening";
+    if (owner === "conversation") return "a realtime voice conversation";
+    return "an assistant voice session";
   }
 }

--- a/apps/desktop/src/voice-microphone-arbiter.ts
+++ b/apps/desktop/src/voice-microphone-arbiter.ts
@@ -80,6 +80,10 @@ export class VoiceMicrophoneArbiter {
     return reservation;
   }
 
+  ownsReservation(reservation: VoiceMicrophoneReservation): boolean {
+    return this.#reservations.has(reservation);
+  }
+
   releaseReservation(reservation: VoiceMicrophoneReservation): void {
     const metadata = this.#reservations.get(reservation);
     if (!metadata || metadata.released) return;

--- a/apps/desktop/src/voice-playback-window.ts
+++ b/apps/desktop/src/voice-playback-window.ts
@@ -1,0 +1,26 @@
+import type { BrowserWindow } from "electron";
+
+/** Fail request-scoped playback as soon as its renderer can no longer complete it. */
+export function installWindowLossHandlers(window: BrowserWindow, onLost: () => void): () => void {
+  const cleanup = () => {
+    window.off("closed", onClosed);
+    window.webContents.off("destroyed", onDestroyed);
+    window.webContents.off("render-process-gone", onRenderProcessGone);
+    window.webContents.off("did-navigate", onNavigate);
+    window.webContents.off("did-navigate-in-page", onNavigateInPage);
+    window.webContents.off("did-fail-load", onFailLoad);
+  };
+  const onClosed = () => { cleanup(); onLost(); };
+  const onDestroyed = () => { cleanup(); onLost(); };
+  const onRenderProcessGone = () => { cleanup(); onLost(); };
+  const onNavigate = () => { cleanup(); onLost(); };
+  const onNavigateInPage = () => { cleanup(); onLost(); };
+  const onFailLoad = () => { cleanup(); onLost(); };
+  window.on("closed", onClosed);
+  window.webContents.on("destroyed", onDestroyed);
+  window.webContents.on("render-process-gone", onRenderProcessGone);
+  window.webContents.on("did-navigate", onNavigate);
+  window.webContents.on("did-navigate-in-page", onNavigateInPage);
+  window.webContents.on("did-fail-load", onFailLoad);
+  return cleanup;
+}

--- a/apps/desktop/src/voice-resource-owner.ts
+++ b/apps/desktop/src/voice-resource-owner.ts
@@ -1,0 +1,42 @@
+import { VoiceCaptureService, type VoiceCaptureFactory } from "./voice-capture.js";
+import { VoiceMicrophoneArbiter } from "./voice-microphone-arbiter.js";
+import { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
+
+export type VoiceResourceOwnerOptions = {
+  readonly microphoneArbiter?: VoiceMicrophoneArbiter;
+  readonly privacyIndicator?: VoicePrivacyIndicator;
+  readonly privacyIndicatorFactory?: () => VoicePrivacyIndicator;
+  readonly captureFactory?: VoiceCaptureFactory;
+};
+
+/** Sole owner of shared microphone capture and privacy resources. */
+export class VoiceResourceOwner {
+  readonly microphoneArbiter: VoiceMicrophoneArbiter;
+  readonly privacyIndicator: VoicePrivacyIndicator;
+  readonly #captureFactory: VoiceCaptureFactory;
+  #capture: VoiceCaptureService | null = null;
+  #shutdownPromise: Promise<void> | null = null;
+
+  constructor(options: VoiceResourceOwnerOptions = {}) {
+    this.microphoneArbiter = options.microphoneArbiter ?? new VoiceMicrophoneArbiter();
+    if (!options.privacyIndicator && !options.privacyIndicatorFactory) throw new Error("A shared voice privacy indicator is required.");
+    if (!options.captureFactory) throw new Error("A shared voice capture factory is required.");
+    this.privacyIndicator = options.privacyIndicator ?? options.privacyIndicatorFactory!();
+    this.#captureFactory = options.captureFactory;
+  }
+
+  capture(): VoiceCaptureService {
+    if (this.#shutdownPromise) throw new Error("Shared voice resources are shut down.");
+    return this.#capture ??= new VoiceCaptureService(this.#captureFactory, this.privacyIndicator, { microphoneArbiter: this.microphoneArbiter });
+  }
+
+  shutdown(): Promise<void> {
+    if (this.#shutdownPromise) return this.#shutdownPromise;
+    this.#shutdownPromise = (async () => {
+      await this.#capture?.shutdown().catch(() => undefined);
+      this.privacyIndicator.shutdown();
+      this.#capture = null;
+    })();
+    return this.#shutdownPromise;
+  }
+}

--- a/apps/desktop/tests/pet-assistant-service.test.ts
+++ b/apps/desktop/tests/pet-assistant-service.test.ts
@@ -30,6 +30,7 @@ function model(responses: readonly PetAssistantTextModelResponse[], requests: Pe
 {
   const resultObject = { started: true, minutes: 25 };
   const requests: PetAssistantTextModelRequest[] = [];
+  const activities: string[] = [];
   const service = new PetAssistantService(model([
     { type: "tool-calls", toolCalls: [{ id: "call-1", name: petAssistantToolName("focus.buddy", "start"), arguments: { minutes: 25 } }] },
     { type: "text", text: "Focus started for 25 minutes." },
@@ -38,9 +39,11 @@ function model(responses: readonly PetAssistantTextModelResponse[], requests: Pe
     assert.deepEqual(input, { minutes: 25 });
     return { ok: true, result: resultObject };
   }));
+  service.subscribe((event) => { if (event.type === "activity") activities.push(event.activity); });
   const result = await service.startTurn("conversation", "Start focus for 25 minutes.");
   assert.equal(result.status, "completed");
   assert.equal(result.response, "Focus started for 25 minutes.");
+  assert.deepEqual(activities, ["thinking", "acting", "thinking", "responding"], "the assistant returns to thinking after each capability batch");
   assert.deepEqual((requests[1]?.messages.at(-1) as { result: { result: unknown } }).result.result, resultObject);
 }
 

--- a/apps/desktop/tests/provider-service.test.ts
+++ b/apps/desktop/tests/provider-service.test.ts
@@ -47,6 +47,15 @@ try {
   const sttSnapshot = await service.snapshot("stt");
   const textSnapshot = await service.snapshot("text");
   await assert.rejects(() => service.binary(ttsSnapshot, "/audio/speech", {}), /HTTP 500/);
+  const synthesisAbort = new AbortController();
+  const pendingSynthesis = new HostProviderService(secrets, {
+    fetchImpl: async (_input, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("fetch aborted")), { once: true });
+    }),
+  });
+  const synthesis = pendingSynthesis.synthesize(ttsSnapshot, "cancel me", {}, synthesisAbort.signal);
+  synthesisAbort.abort();
+  await assert.rejects(() => synthesis, /cancelled/);
   await assert.rejects(() => service.transcribe(sttSnapshot, new Uint8Array([1]), "audio/webm"), /HTTP 500/);
   await assert.rejects(() => service.stream(textSnapshot, "/chat/completions", {}, () => undefined), /HTTP 500/);
   assert.equal(cancelled, 3, "HTTP error bodies must be cancelled before the operation returns");

--- a/apps/desktop/tests/voice-activity-slot.test.ts
+++ b/apps/desktop/tests/voice-activity-slot.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+
+import { composeVoiceActivityBadge, composeVoiceActivityDisplay } from "../src/voice-activity-slot.js";
+
+const externalDisplay = {
+  message: "Plugin-owned message",
+  mediaPath: "/tmp/plugin-media.png",
+  clickUrl: "https://example.test/plugin",
+  dismissToken: "plugin-display-1",
+  reaction: "success" as const,
+};
+
+assert.deepEqual(composeVoiceActivityDisplay(externalDisplay, "thinking"), {
+  ...externalDisplay,
+  reaction: "thinking",
+  suppressReactionMessage: true,
+}, "voice activity overlays animation while preserving unrelated plugin content");
+assert.deepEqual(composeVoiceActivityDisplay(externalDisplay, null), externalDisplay, "clearing voice activity restores the unrelated display unchanged");
+assert.deepEqual(composeVoiceActivityBadge("success", "running"), "running");
+assert.deepEqual(composeVoiceActivityBadge("success", null), "success", "clearing voice activity restores the unrelated badge");
+
+console.log("Voice activity slot composition verified.");

--- a/apps/desktop/tests/voice-assistant-host-core.test.ts
+++ b/apps/desktop/tests/voice-assistant-host-core.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+
+import { PetAssistantService } from "../src/pet-assistant-service.js";
+import { petAssistantToolName } from "../src/pet-assistant-tools.js";
+import { TextModelClient } from "../src/text-model-client.js";
+import type { HostProviderOperations, ProviderOperationSnapshot } from "../src/provider-service.js";
+import { HostVoiceInput, PetAssistantVoiceAdapter, ProviderVoiceSynthesizer, reactionForVoiceActivity } from "../src/voice-assistant-host-core.js";
+import { VoiceAssistantHostController } from "../src/voice-assistant-host-core.js";
+import { VoiceAssistantSession } from "../src/voice-assistant-session.js";
+import { VoiceConversationService } from "../src/voice-conversation.js";
+import { VoiceResourceOwner } from "../src/voice-resource-owner.js";
+import { VoiceMicrophoneArbiter } from "../src/voice-microphone-arbiter.js";
+import { VoiceCaptureService } from "../src/voice-capture.js";
+import type { VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
+import { VoicePrivacyIndicator } from "../src/voice-privacy-indicator.js";
+
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) { if (predicate()) return; await flush(); }
+  throw new Error("Timed out waiting for composed voice behavior.");
+}
+
+function snapshot(role: "text" | "stt" | "tts"): ProviderOperationSnapshot {
+  return { role, profile: { id: role, label: role, adapter: role === "stt" ? "openai-compatible-transcription" : role === "tts" ? "openai-compatible-speech" : "openai-compatible-text", model: role, baseUrl: "https://provider.example" } } as ProviderOperationSnapshot;
+}
+
+function captureService(arbiter: VoiceMicrophoneArbiter): VoiceCaptureService {
+  const surface: VoicePrivacyIndicatorSurface = { show() {}, hide() {}, destroy() {} };
+  return new VoiceCaptureService((_duration, onAcquired) => ({
+    acquire: async () => {
+      onAcquired();
+      return {
+        result: Promise.resolve({ bytes: new Uint8Array([1, 2, 3]), mimeType: "audio/webm" }),
+        stop: async () => ({ bytes: new Uint8Array([1, 2, 3]), mimeType: "audio/webm" }),
+        cancel: async () => undefined,
+        close: async () => undefined,
+      };
+    },
+    cancel: async () => undefined,
+    dispose: async () => undefined,
+  }), new VoicePrivacyIndicator(() => surface), { microphoneArbiter: arbiter });
+}
+
+async function main(): Promise<void> {
+  const roles: string[] = [];
+  const provider: HostProviderOperations = {
+    snapshot: async (role) => { roles.push(role); return snapshot(role === "realtime" ? "text" : role); },
+    json: async () => ({}),
+    binary: async () => new Uint8Array(),
+    stream: async () => undefined,
+    transcribe: async () => "hello from microphone",
+    synthesize: async () => ({ bytes: new Uint8Array([7, 8]), mimeType: "audio/mpeg" }),
+    negotiateRealtime: async () => "",
+  };
+
+  const arbiter = new VoiceMicrophoneArbiter();
+  const reservation = arbiter.reserve("assistant-session");
+  const input = new HostVoiceInput(provider, captureService(arbiter));
+  const inputResult = await input.listen({ requestId: "input-1", signal: new AbortController().signal, reservation });
+  assert.deepEqual(inputResult, { status: "completed", final: "hello from microphone" });
+  const speech = await new ProviderVoiceSynthesizer(provider).synthesize("hello", { requestId: "output-1", signal: new AbortController().signal });
+  assert.deepEqual(speech, { kind: "audio", bytes: new Uint8Array([7, 8]), mimeType: "audio/mpeg" });
+  assert.deepEqual(roles, ["stt", "tts"], "input and synthesis snapshot their own provider roles independently");
+  arbiter.releaseReservation(reservation);
+
+  let selectedProfile = "stt-old";
+  let resolveAcquisition!: (recording: { readonly result: Promise<{ readonly bytes: Uint8Array; readonly mimeType: string }>; stop(): Promise<{ readonly bytes: Uint8Array; readonly mimeType: string }>; cancel(): Promise<void>; close(): Promise<void> }) => void;
+  let resolveCapture!: (capture: { readonly bytes: Uint8Array; readonly mimeType: string }) => void;
+  const pendingCapture = new VoiceCaptureService((_duration, onAcquired) => ({
+    acquire: () => new Promise((resolve) => {
+      resolveAcquisition = (recording) => { onAcquired(); resolve(recording); };
+    }),
+    cancel: async () => undefined,
+    dispose: async () => undefined,
+  }), new VoicePrivacyIndicator(() => ({ show() {}, hide() {}, destroy() {} })), { microphoneArbiter: arbiter });
+  let usedProfile = "";
+  const pinnedProvider: HostProviderOperations = {
+    ...provider,
+    snapshot: async () => { const current = snapshot("stt"); return { ...current, profile: { ...current.profile, id: selectedProfile } }; },
+    transcribe: async (receivedSnapshot) => { usedProfile = receivedSnapshot.profile.id; return "pinned transcript"; },
+  };
+  const pinnedInput = new HostVoiceInput(pinnedProvider, pendingCapture);
+  const pinnedReservation = arbiter.reserve("assistant-session");
+  const pinnedListen = pinnedInput.listen({ requestId: "pinned-input", signal: new AbortController().signal, reservation: pinnedReservation });
+  await flush();
+  selectedProfile = "stt-new";
+  resolveAcquisition({ result: new Promise((resolve) => { resolveCapture = resolve; }), stop: async () => ({ bytes: new Uint8Array([1, 2, 3]), mimeType: "audio/webm" }), cancel: async () => undefined, close: async () => undefined });
+  await flush();
+  resolveCapture({ bytes: new Uint8Array([1, 2, 3]), mimeType: "audio/webm" });
+  assert.deepEqual(await pinnedListen, { status: "completed", final: "pinned transcript" });
+  assert.equal(usedProfile, "stt-old", "the STT snapshot is pinned before capture starts");
+  arbiter.releaseReservation(pinnedReservation);
+
+  assert.equal(reactionForVoiceActivity("listening"), "waiting");
+  assert.equal(reactionForVoiceActivity("thinking"), "thinking");
+  assert.equal(reactionForVoiceActivity("acting"), "working");
+  assert.equal(reactionForVoiceActivity("speaking"), "running");
+
+  const assistant = new PetAssistantService({ generate: async () => ({ type: "text", text: "done" }) }, { snapshot: () => ({ capabilities: [] }), execute: async () => ({ ok: true, result: {} }) });
+  const adapter = new PetAssistantVoiceAdapter(assistant);
+  const activity: string[] = [];
+  const unsubscribe = adapter.subscribe((event) => activity.push(event.activity));
+  const result = await adapter.startTurn("voice", "hello", new AbortController().signal);
+  unsubscribe();
+  assert.equal(result.status, "completed");
+  assert.deepEqual(activity, ["thinking", "responding"], "the adapter forwards canonical assistant activity events");
+  await assistant.stop();
+
+  const sessionArbiter = new VoiceMicrophoneArbiter();
+  let created = 0;
+  const controller = new VoiceAssistantHostController(() => {
+    created += 1;
+    let cancelInput!: () => void;
+    const input = {
+      listen: async () => new Promise<{ status: "cancelled"; reason: string }>((resolve) => { cancelInput = () => resolve({ status: "cancelled", reason: "ended" }); }),
+      cancel: async () => { cancelInput?.(); },
+    };
+    const session = new VoiceAssistantSession({
+      microphoneArbiter: sessionArbiter,
+      input,
+      assistant: { startTurn: async () => ({ status: "cancelled" as const }), subscribe: () => () => {}, clearConversation: () => undefined },
+      synthesizer: { synthesize: async () => ({ kind: "system" as const, text: "" }) },
+      player: { play: async () => undefined, stop: async () => undefined },
+    });
+    return { session, shutdown: () => session.shutdown() };
+  });
+  const firstSession = await controller.activate();
+  assert.equal(sessionArbiter.activeOwner, "assistant-session");
+  await controller.end();
+  assert.equal(firstSession.snapshot().activity, null, "ended sessions clear host activity");
+  assert.equal(sessionArbiter.activeOwner, null, "ending releases the session microphone reservation");
+  const secondSession = await controller.activate();
+  assert.notEqual(secondSession, firstSession, "a later activation creates a fresh generic session");
+  assert.equal(created, 2);
+  await controller.shutdown();
+  assert.equal(sessionArbiter.activeOwner, null);
+
+  let indicatorDestroyed = 0;
+  let indicatorTracks = 0;
+  const ownerSurface: VoicePrivacyIndicatorSurface = { show() {}, hide() {}, destroy() { indicatorDestroyed += 1; } };
+  const ownerIndicator = new VoicePrivacyIndicator(() => ownerSurface);
+  const owner = new VoiceResourceOwner({
+    microphoneArbiter: new VoiceMicrophoneArbiter(),
+    privacyIndicator: ownerIndicator,
+    captureFactory: () => ({ acquire: async () => ({ result: Promise.resolve({ bytes: new Uint8Array([1]), mimeType: "audio/webm" }), stop: async () => ({ bytes: new Uint8Array([1]), mimeType: "audio/webm" }), cancel: async () => undefined, close: async () => undefined }), cancel: async () => undefined, dispose: async () => undefined }),
+  });
+  ownerIndicator.trackStarted();
+  ownerIndicator.trackStarted();
+  indicatorTracks = ownerIndicator.liveTracks;
+  const lane = new VoiceConversationService({ microphoneArbiter: owner.microphoneArbiter, privacyIndicator: owner.privacyIndicator, transportFactory: () => ({ start: async () => undefined, setMuted: () => undefined, close: async () => undefined }) });
+  await lane.shutdown();
+  assert.equal(indicatorDestroyed, 0, "individual lane shutdown cannot destroy shared privacy state");
+  assert.equal(ownerIndicator.liveTracks, indicatorTracks);
+  await owner.shutdown();
+  assert.equal(indicatorDestroyed, 1, "the shared owner destroys privacy state once all lanes stop");
+
+  const composedRoles: string[] = [];
+  let utterance = 0;
+  let textCall = 0;
+  const capabilityHandle = { generation: 1 } as object;
+  const capabilityInvocations: unknown[] = [];
+  const composedProvider: HostProviderOperations = {
+    snapshot: async (role) => { composedRoles.push(role); return { ...snapshot(role === "realtime" ? "text" : role), profile: { ...snapshot(role === "realtime" ? "text" : role).profile, id: `${role}-selected` } }; },
+    json: async (_snapshot, path) => {
+      assert.equal(path, "/chat/completions");
+      textCall += 1;
+      if (textCall === 1) return { choices: [{ message: { tool_calls: [{ id: "call-1", function: { name: petAssistantToolName("focus.buddy", "start"), arguments: JSON.stringify({ minutes: 25 }) } }] } }] };
+      return { choices: [{ message: { content: textCall === 2 ? "Focus capability completed." : "Second authoritative answer." } }] };
+    },
+    binary: async () => new Uint8Array(),
+    stream: async () => undefined,
+    transcribe: async () => `selected request ${++utterance}`,
+    synthesize: async () => ({ bytes: new Uint8Array([9]), mimeType: "audio/mpeg" }),
+    negotiateRealtime: async () => "",
+  };
+  const composedAssistant = new PetAssistantService(new TextModelClient(composedProvider), {
+    snapshot: () => ({ capabilities: [{ pluginId: "focus.buddy", capability: { id: "start", description: "Start focus", inputSchema: { type: "object" } }, handle: capabilityHandle }] }),
+    execute: async (_handle, input) => { capabilityInvocations.push(input); return { ok: true, result: { started: true } }; },
+  });
+  const composedArbiter = new VoiceMicrophoneArbiter();
+  const composedInput = new HostVoiceInput(composedProvider, captureService(composedArbiter));
+  const composedOutput = new ProviderVoiceSynthesizer(composedProvider);
+  const assistantTranscripts: string[] = [];
+  const transcriptEvents: string[] = [];
+  const composedActivities: string[] = [];
+  const composedSession = new VoiceAssistantSession({
+    microphoneArbiter: composedArbiter,
+    input: composedInput,
+    assistant: new PetAssistantVoiceAdapter(composedAssistant),
+    synthesizer: composedOutput,
+    player: { play: async () => { await flush(); }, stop: async () => undefined },
+  });
+  composedSession.subscribe((event) => {
+    if (event.type === "snapshot" && event.snapshot.activity && composedActivities.at(-1) !== event.snapshot.activity) composedActivities.push(event.snapshot.activity);
+    if (event.type !== "transcript") return;
+    transcriptEvents.push(`${event.speaker}:${event.kind}`);
+    if (event.speaker === "assistant" && event.kind === "final") assistantTranscripts.push(event.text);
+  });
+  await composedSession.start();
+  await waitFor(() => assistantTranscripts.length === 2);
+  await composedSession.end();
+  await composedAssistant.stop();
+  assert.deepEqual(capabilityInvocations, [{ minutes: 25 }]);
+  assert.deepEqual(assistantTranscripts, ["Focus capability completed.", "Second authoritative answer."]);
+  assert.deepEqual(transcriptEvents, ["user:final", "assistant:final", "user:final", "assistant:final"], "the composed host emits final-only transcripts");
+  assert.equal(composedActivities.includes("listening"), true);
+  assert.equal(composedActivities.includes("thinking"), true);
+  assert.equal(composedActivities.includes("acting"), true);
+  assert.equal(composedActivities.includes("speaking"), true);
+  assert.equal(composedRoles.includes("text"), true);
+  assert.equal(composedRoles.includes("stt"), true);
+  assert.equal(composedRoles.includes("tts"), true);
+  assert.equal(composedArbiter.activeOwner, null, "composed session cleanup releases the microphone");
+}
+
+main().then(() => console.log("Voice assistant host core behavior verified."), (error) => { console.error(error); process.exitCode = 1; });

--- a/apps/desktop/tests/voice-assistant-session.test.ts
+++ b/apps/desktop/tests/voice-assistant-session.test.ts
@@ -1,0 +1,440 @@
+import assert from "node:assert/strict";
+
+import {
+  VoiceAssistantSession,
+  type VoiceAssistantActivityEvent,
+  type VoiceAssistantInput,
+  type VoiceAssistantInputOptions,
+  type VoiceAssistantPlayer,
+  type VoiceAssistantSessionEvent,
+  type VoiceAssistantSessionSnapshot,
+  type VoiceAssistantSpeech,
+  type VoiceAssistantSynthesizer,
+  type VoiceAssistantTurnAdapter,
+  type VoiceAssistantTurnResult,
+} from "../src/voice-assistant-session.js";
+import {
+  VoiceCaptureService,
+  type VoiceCaptureAttempt,
+  type VoiceCaptureRecording,
+  type VoiceCaptureResult,
+} from "../src/voice-capture.js";
+import { VoiceMicrophoneArbiter, type VoiceMicrophoneReservation } from "../src/voice-microphone-arbiter.js";
+import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
+
+type Deferred<T> = { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void };
+
+function deferred<T>(): Deferred<T> {
+  let resolveValue!: (value: T) => void;
+  let rejectValue!: (error: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => { resolveValue = resolve; rejectValue = reject; });
+  void promise.catch(() => undefined);
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
+async function flush(): Promise<void> {
+  for (let index = 0; index < 16; index += 1) await Promise.resolve();
+}
+
+class FakeInput implements VoiceAssistantInput {
+  readonly calls: Array<{ readonly options: VoiceAssistantInputOptions; readonly result: Deferred<{ status: "completed"; final: string } | { status: "cancelled"; reason?: string }> }> = [];
+  readonly cancelIds: string[] = [];
+  cancelGate: Deferred<void> | null = null;
+  activeCount = 0;
+  maxActiveCount = 0;
+
+  listen(options: VoiceAssistantInputOptions): Promise<{ status: "completed"; final: string } | { status: "cancelled"; reason?: string }> {
+    const result = deferred<{ status: "completed"; final: string } | { status: "cancelled"; reason?: string }>();
+    this.calls.push({ options, result });
+    this.activeCount += 1;
+    this.maxActiveCount = Math.max(this.maxActiveCount, this.activeCount);
+    result.promise.finally(() => { this.activeCount -= 1; }).catch(() => undefined);
+    return result.promise;
+  }
+
+  async cancel(requestId: string): Promise<void> {
+    this.cancelIds.push(requestId);
+    if (this.cancelGate) await this.cancelGate.promise;
+    const call = this.calls.find((candidate) => candidate.options.requestId === requestId);
+    call?.result.resolve({ status: "cancelled", reason: "cancelled by test" });
+  }
+
+  partial(text: string, index = this.calls.length - 1): void { this.calls[index]?.options.onPartial?.(text); }
+  finish(text: string, index = this.calls.length - 1): void { this.calls[index]?.result.resolve({ status: "completed", final: text }); }
+  cancelResult(index = this.calls.length - 1): void { this.calls[index]?.result.resolve({ status: "cancelled", reason: "adapter cancelled" }); }
+  reject(error: unknown, index = this.calls.length - 1): void { this.calls[index]?.result.reject(error); }
+}
+
+class FakeAssistant implements VoiceAssistantTurnAdapter {
+  readonly calls: Array<{ conversationId: string; text: string; signal: AbortSignal; result: Deferred<VoiceAssistantTurnResult> }> = [];
+  #listener: ((event: VoiceAssistantActivityEvent) => void) | null = null;
+  clearCount = 0;
+
+  startTurn(conversationId: string, text: string, signal: AbortSignal): Promise<VoiceAssistantTurnResult> {
+    const result = deferred<VoiceAssistantTurnResult>();
+    this.calls.push({ conversationId, text, signal, result });
+    signal.addEventListener("abort", () => result.resolve({ status: "cancelled" }), { once: true });
+    return result.promise;
+  }
+
+  subscribe(listener: (event: VoiceAssistantActivityEvent) => void): () => void {
+    this.#listener = listener;
+    return () => { if (this.#listener === listener) this.#listener = null; };
+  }
+
+  activity(activity: VoiceAssistantActivityEvent["activity"]): void {
+    const call = this.calls.at(-1);
+    if (!call) return;
+    this.#listener?.({ conversationId: call.conversationId, turnId: `adapter-${this.calls.length}`, activity });
+  }
+
+  clearConversation(_conversationId: string): void { this.clearCount += 1; }
+}
+
+class FakeSynthesizer implements VoiceAssistantSynthesizer {
+  readonly calls: Array<{ requestId: string; text: string; signal: AbortSignal; result: Deferred<VoiceAssistantSpeech> }> = [];
+
+  synthesize(text: string, options: { requestId: string; signal: AbortSignal }): Promise<VoiceAssistantSpeech> {
+    const result = deferred<VoiceAssistantSpeech>();
+    this.calls.push({ requestId: options.requestId, text, signal: options.signal, result });
+    options.signal.addEventListener("abort", () => result.resolve({ kind: "system", text: "cancelled" }), { once: true });
+    return result.promise;
+  }
+}
+
+class FakePlayer implements VoiceAssistantPlayer {
+  readonly calls: Array<{ requestId: string; speech: VoiceAssistantSpeech; signal: AbortSignal; result: Deferred<void> }> = [];
+  readonly stopIds: string[] = [];
+
+  play(requestId: string, speech: VoiceAssistantSpeech, signal: AbortSignal): Promise<void> {
+    const result = deferred<void>();
+    this.calls.push({ requestId, speech, signal, result });
+    signal.addEventListener("abort", () => result.resolve(undefined), { once: true });
+    return result.promise;
+  }
+
+  async stop(requestId: string): Promise<void> { this.stopIds.push(requestId); }
+}
+
+function fixture() {
+  const input = new FakeInput();
+  const assistant = new FakeAssistant();
+  const synthesizer = new FakeSynthesizer();
+  const player = new FakePlayer();
+  const microphoneArbiter = new VoiceMicrophoneArbiter();
+  const session = new VoiceAssistantSession({ microphoneArbiter, input, assistant, synthesizer, player, conversationId: "same-conversation" });
+  const sessionEvents: VoiceAssistantSessionEvent[] = [];
+  session.subscribe((event) => sessionEvents.push(event));
+  return { input, assistant, synthesizer, player, microphoneArbiter, session, sessionEvents };
+}
+
+function snapshots(events: readonly VoiceAssistantSessionEvent[]): VoiceAssistantSessionSnapshot[] {
+  return events.filter((event): event is Extract<VoiceAssistantSessionEvent, { type: "snapshot" }> => event.type === "snapshot").map((event) => event.snapshot);
+}
+
+function distinctActivities(events: readonly VoiceAssistantSessionEvent[]): Array<string | null> {
+  const values = snapshots(events).map((snapshot) => snapshot.activity);
+  return values.filter((value, index) => index === 0 || value !== values[index - 1]);
+}
+
+// Multi-turn canonical behavior: partials are turn-local replacements and the
+// assistant transcript is the terminal capability-aware Pet Assistant result.
+{
+  const current = fixture();
+  await current.session.start();
+  current.input.partial(" same ");
+  current.input.partial("same");
+  current.input.finish("same");
+  await flush();
+  current.assistant.activity("thinking");
+  current.assistant.activity("acting");
+  current.assistant.calls[0]!.result.resolve({ status: "completed", response: "Capability outcomes: completed=1, rejected=0, unavailable=0, indeterminate=0." });
+  await flush();
+  current.synthesizer.calls[0]!.result.resolve({ kind: "audio", bytes: new Uint8Array([1]), mimeType: "audio/test" });
+  await flush();
+  current.player.calls[0]!.result.resolve(undefined);
+  await flush();
+  assert.equal(current.session.snapshot().turnId, "voice-turn-2");
+  assert.equal(current.session.snapshot().userTranscript, null);
+  assert.equal(current.session.snapshot().assistantTranscript, null);
+
+  current.input.partial("same");
+  current.input.finish("second turn");
+  await flush();
+  current.assistant.calls[1]!.result.resolve({ status: "completed", response: "second answer" });
+  await flush();
+  current.synthesizer.calls[1]!.result.resolve({ kind: "system", text: "second answer" });
+  await flush();
+  current.player.calls[1]!.result.resolve(undefined);
+  await flush();
+
+  const transcripts = current.sessionEvents.filter((event): event is Extract<VoiceAssistantSessionEvent, { type: "transcript" }> => event.type === "transcript");
+  assert.deepEqual(transcripts.map(({ turnId, speaker, kind, text }) => [turnId, speaker, kind, text]), [
+    ["voice-turn-1", "user", "partial", "same"],
+    ["voice-turn-1", "user", "final", "same"],
+    ["voice-turn-1", "assistant", "final", "Capability outcomes: completed=1, rejected=0, unavailable=0, indeterminate=0."],
+    ["voice-turn-2", "user", "partial", "same"],
+    ["voice-turn-2", "user", "final", "second turn"],
+    ["voice-turn-2", "assistant", "final", "second answer"],
+  ]);
+  assert.deepEqual(current.assistant.calls.map((call) => call.conversationId), ["same-conversation", "same-conversation"]);
+  assert.equal(current.player.calls[1]!.speech.kind, "system");
+  assert.deepEqual(distinctActivities(current.sessionEvents), ["listening", "thinking", "acting", "thinking", "speaking", "listening", "thinking", "speaking", "listening"]);
+  assert.ok(current.sessionEvents.every((event) => Object.isFrozen(event)));
+  await current.session.end();
+  assert.equal(current.assistant.clearCount, 1);
+}
+
+// Final-only STT emits only its one nonblank final.
+{
+  const current = fixture();
+  await current.session.start();
+  assert.equal(current.session.snapshot().turnId, "voice-turn-1");
+  assert.equal(current.session.snapshot().userTranscript, null);
+  assert.equal(current.session.snapshot().assistantTranscript, null);
+  current.input.finish("final only");
+  await flush();
+  assert.equal(current.session.snapshot().turnId, "voice-turn-1");
+  assert.equal(current.session.snapshot().userTranscript, "final only");
+  const users = current.sessionEvents.filter((event): event is Extract<VoiceAssistantSessionEvent, { type: "transcript" }> => event.type === "transcript" && event.speaker === "user");
+  assert.deepEqual(users.map((event) => [event.kind, event.text]), [["final", "final only"]]);
+  await current.session.end();
+}
+
+// Input, assistant, synthesis, and playback interruption all settle their
+// current generation, preserve the reservation/conversation, and continue.
+for (const stage of ["input", "assistant", "synthesis", "playback"] as const) {
+  const current = fixture();
+  await current.session.start();
+  if (stage === "input") {
+    await current.session.interrupt();
+  } else {
+    current.input.finish("interrupt me");
+    await flush();
+    if (stage !== "assistant") {
+      current.assistant.calls[0]!.result.resolve({ status: "completed", response: "spoken response" });
+      await flush();
+      if (stage === "playback") {
+        current.synthesizer.calls[0]!.result.resolve({ kind: "audio", bytes: new Uint8Array([1]), mimeType: "audio/test" });
+        await flush();
+      }
+    }
+    await current.session.interrupt();
+  }
+  assert.equal(current.session.snapshot().status, "active");
+  assert.equal(current.microphoneArbiter.activeOwner, "assistant-session");
+  assert.equal(current.sessionEvents.filter((event) => event.type === "interrupted").length, 1);
+  assert.equal(current.sessionEvents.some((event) => event.type === "ended"), false);
+  assert.equal(current.assistant.clearCount, 0);
+  assert.equal(current.input.calls.length, 2);
+  if (stage === "assistant") assert.equal(current.assistant.calls[0]!.signal.aborted, true);
+  if (stage === "synthesis") assert.equal(current.synthesizer.calls[0]!.signal.aborted, true);
+  if (stage === "playback") assert.deepEqual(current.player.stopIds, [current.player.calls[0]!.requestId]);
+  if (stage === "synthesis" || stage === "playback") {
+    assert.equal(current.sessionEvents.filter((event) => event.type === "interrupted").at(-1)?.turnId, "voice-turn-1");
+  }
+  current.input.calls[0]!.options.onPartial?.("stale completion");
+  assert.equal(current.sessionEvents.some((event) => event.type === "transcript" && event.text === "stale completion"), false);
+  await current.session.end();
+}
+
+// Mute is microphone-only: output continues, but host activity is cleared and
+// the session becomes muted without opening a new input until unmute.
+{
+  const current = fixture();
+  await current.session.start();
+  current.input.finish("keep speaking");
+  await flush();
+  await current.session.mute();
+  assert.equal(current.session.snapshot().activity, null);
+  current.assistant.calls[0]!.result.resolve({ status: "completed", response: "still speaking" });
+  await flush();
+  assert.equal(current.session.snapshot().activity, null);
+  current.synthesizer.calls[0]!.result.resolve({ kind: "audio", bytes: new Uint8Array([1]), mimeType: "audio/test" });
+  await flush();
+  assert.equal(current.session.snapshot().activity, null);
+  await current.session.mute();
+  assert.equal(current.session.snapshot().activity, null);
+  current.player.calls[0]!.result.resolve(undefined);
+  await flush();
+  assert.equal(current.session.snapshot().status, "muted");
+  assert.equal(current.session.snapshot().activity, null);
+  assert.equal(current.input.calls.length, 1);
+  await current.session.unmute();
+  assert.equal(current.input.calls.length, 2);
+  await current.session.end();
+}
+
+// Synthesis and request-scoped playback failures also recover to listening.
+{
+  const synthesisFailure = fixture();
+  await synthesisFailure.session.start();
+  synthesisFailure.input.finish("synthesis fails");
+  await flush();
+  synthesisFailure.assistant.calls[0]!.result.resolve({ status: "completed", response: "failure" });
+  await flush();
+  synthesisFailure.synthesizer.calls[0]!.result.reject(new Error("synthesis failed"));
+  await flush();
+  assert.equal(synthesisFailure.input.calls.length, 2);
+  assert.ok(synthesisFailure.sessionEvents.some((event) => event.type === "error" && event.scope === "synthesis"));
+  await synthesisFailure.session.end();
+
+  const playbackFailure = fixture();
+  await playbackFailure.session.start();
+  playbackFailure.input.finish("playback fails");
+  await flush();
+  playbackFailure.assistant.calls[0]!.result.resolve({ status: "completed", response: "failure" });
+  await flush();
+  playbackFailure.synthesizer.calls[0]!.result.resolve({ kind: "audio", bytes: new Uint8Array([1]), mimeType: "audio/test" });
+  await flush();
+  playbackFailure.player.calls[0]!.result.reject(new Error("playback failed"));
+  await flush();
+  assert.equal(playbackFailure.input.calls.length, 2);
+  assert.ok(playbackFailure.sessionEvents.some((event) => event.type === "error" && event.scope === "playback"));
+  await playbackFailure.session.end();
+}
+
+// Input failure pauses once instead of hot-retrying; retry() is deliberate,
+// and terminal cleanup still releases the session reservation.
+{
+  const current = fixture();
+  await current.session.start();
+  current.input.reject(new Error("input failed immediately"));
+  await flush();
+  assert.equal(current.input.calls.length, 1);
+  assert.equal(current.session.snapshot().status, "paused");
+  assert.equal(current.session.snapshot().activity, null);
+  assert.match(current.session.snapshot().error?.message ?? "", /input failed immediately/);
+  await current.session.retry();
+  assert.equal(current.input.calls.length, 2);
+  await current.session.end();
+  assert.equal(current.microphoneArbiter.activeOwner, null);
+
+  const blank = fixture();
+  await blank.session.start();
+  blank.input.finish("   ");
+  await flush();
+  assert.equal(blank.input.calls.length, 1);
+  assert.equal(blank.session.snapshot().status, "paused");
+  await blank.session.end();
+}
+
+// Lifecycle operations serialize behind stage cleanup. Concurrent mute,
+// unmute, and end cannot overlap capture or return before cancellation.
+{
+  const current = fixture();
+  await current.session.start();
+  const gate = deferred<void>();
+  current.input.cancelGate = gate;
+  let endSettled = false;
+  const mute = current.session.mute();
+  const unmute = current.session.unmute();
+  const end = current.session.end().then(() => { endSettled = true; });
+  await flush();
+  assert.equal(endSettled, false);
+  gate.resolve(undefined);
+  await Promise.all([mute, unmute, end]);
+  assert.equal(current.input.maxActiveCount, 1);
+  assert.equal(current.microphoneArbiter.activeOwner, null);
+  assert.equal(current.sessionEvents.filter((event) => event.type === "ended").length, 1);
+  await Promise.all([current.session.end(), current.session.shutdown()]);
+  assert.equal(current.sessionEvents.filter((event) => event.type === "ended").length, 1);
+}
+
+// End, repeated end, and shutdown all wait for the one in-flight cleanup.
+{
+  const current = fixture();
+  await current.session.start();
+  const gate = deferred<void>();
+  current.input.cancelGate = gate;
+  let firstSettled = false;
+  let secondSettled = false;
+  let shutdownSettled = false;
+  const first = current.session.end().then(() => { firstSettled = true; });
+  const second = current.session.end().then(() => { secondSettled = true; });
+  const shutdown = current.session.shutdown().then(() => { shutdownSettled = true; });
+  await flush();
+  assert.deepEqual([firstSettled, secondSettled, shutdownSettled], [false, false, false]);
+  gate.resolve(undefined);
+  await Promise.all([first, second, shutdown]);
+  assert.equal(current.microphoneArbiter.activeOwner, null);
+  assert.equal(current.sessionEvents.filter((event) => event.type === "ended").length, 1);
+}
+
+// Adapter cancellation and failed turns recover to a fresh listening stage.
+{
+  const current = fixture();
+  await current.session.start();
+  current.input.cancelResult();
+  await flush();
+  assert.equal(current.input.calls.length, 1);
+  assert.equal(current.session.snapshot().status, "paused");
+  await current.session.retry();
+  assert.equal(current.input.calls.length, 2);
+  current.input.finish("cancelled turn");
+  await flush();
+  current.assistant.calls[0]!.result.resolve({ status: "cancelled" });
+  await flush();
+  assert.equal(current.input.calls.length, 3);
+  current.input.finish("failed turn");
+  await flush();
+  current.assistant.calls[1]!.result.resolve({ status: "failed", error: "failed deterministically" });
+  await flush();
+  assert.equal(current.input.calls.length, 4);
+  assert.ok(current.sessionEvents.some((event) => event.type === "error" && event.scope === "assistant"));
+  await current.session.end();
+}
+
+class FakeSurface implements VoicePrivacyIndicatorSurface {
+  showCount = 0;
+  hideCount = 0;
+  destroyCount = 0;
+  show(): void { this.showCount += 1; }
+  hide(): void { this.hideCount += 1; }
+  destroy(): void { this.destroyCount += 1; }
+}
+
+class ImmediateRecording implements VoiceCaptureRecording {
+  readonly result: Promise<VoiceCaptureResult>;
+  #reject!: (error: unknown) => void;
+  constructor() {
+    this.result = new Promise<VoiceCaptureResult>((_resolve, reject) => { this.#reject = reject; });
+    void this.result.catch(() => undefined);
+  }
+  async stop(): Promise<VoiceCaptureResult> { return { bytes: new Uint8Array(128), mimeType: "audio/webm" }; }
+  async cancel(): Promise<void> { this.#reject(new Error("capture cancelled")); }
+  async close(): Promise<void> {}
+}
+
+class ImmediateAttempt implements VoiceCaptureAttempt {
+  readonly recording = new ImmediateRecording();
+  readonly #onAcquired: () => boolean;
+  constructor(onAcquired: () => boolean) { this.#onAcquired = onAcquired; }
+  async acquire(): Promise<VoiceCaptureRecording> { if (!this.#onAcquired()) throw new Error("capture cancelled"); return this.recording; }
+  async cancel(): Promise<void> { await this.recording.cancel(); }
+  async dispose(): Promise<void> {}
+}
+
+// The real capture seam acquires one child track, drives privacy from that
+// actual track, rejects a second child, and leaves shared indicator teardown to
+// the host rather than VoiceCaptureService.shutdown().
+{
+  const surface = new FakeSurface();
+  const indicator = new VoicePrivacyIndicator(() => surface);
+  const arbiter = new VoiceMicrophoneArbiter();
+  const reservation: VoiceMicrophoneReservation = arbiter.reserve("assistant-session");
+  const capture = new VoiceCaptureService((_duration, onAcquired) => new ImmediateAttempt(onAcquired), indicator, { microphoneArbiter: arbiter });
+  const second = new VoiceCaptureService((_duration, onAcquired) => new ImmediateAttempt(onAcquired), indicator, { microphoneArbiter: arbiter });
+  const handle = await capture.start(1_000, reservation);
+  assert.equal(surface.showCount, 1);
+  assert.equal(Object.prototype.hasOwnProperty.call(reservation, "release"), false);
+  await assert.rejects(() => second.start(1_000, reservation), /already has an active track/);
+  await handle.cancel("test cleanup");
+  assert.equal(surface.hideCount, 1);
+  await capture.shutdown();
+  assert.equal(surface.destroyCount, 0);
+  arbiter.releaseReservation(reservation);
+  assert.equal(arbiter.activeOwner, null);
+}
+
+console.log("Composable voice assistant session behavior verified.");

--- a/apps/desktop/tests/voice-conversation.test.ts
+++ b/apps/desktop/tests/voice-conversation.test.ts
@@ -307,7 +307,9 @@ for (const failure of [
   assert.equal(transport.resources.audioAttached, false);
   assert.equal(transport.resources.windowAlive, false);
   assert.equal(current.indicator.liveTracks, 0);
-  assert.equal(current.surface.destroyCount, 1);
+  assert.equal(current.surface.destroyCount, 0, "lane shutdown must not destroy shared privacy state");
+  current.indicator.shutdown();
+  assert.equal(current.surface.destroyCount, 1, "the shared owner performs final indicator destruction");
   assert.equal(current.microphoneArbiter.activeOwner, null);
   await assert.rejects(() => current.service.start(), /shut down/);
 }

--- a/apps/desktop/tests/voice-lifecycle.test.ts
+++ b/apps/desktop/tests/voice-lifecycle.test.ts
@@ -334,7 +334,7 @@ assert.equal(VOICE_MAX_RECORDING_DURATION_MS, 30_000);
   await flush();
   await current.listening.shutdown();
   await assert.rejects(pending, /OpenPets is shutting down\./);
-  assert.equal(current.surface.destroyCount, 1);
+  assert.equal(current.surface.destroyCount, 0, "shared privacy indicator teardown belongs to the host");
   assert.equal(current.getAttempt().disposeCount, 1);
 }
 

--- a/apps/desktop/tests/voice-lifecycle.test.ts
+++ b/apps/desktop/tests/voice-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/voice-listening-service.js";
 import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
 import { VoiceOperationState } from "../src/voice-operation-state.js";
+import { VoiceMicrophoneArbiter } from "../src/voice-microphone-arbiter.js";
 
 class FakeSurface implements VoicePrivacyIndicatorSurface {
   showCount = 0;
@@ -123,7 +124,7 @@ type Fixture = {
 
 function fixture(
   transcriber: (capture: VoiceCaptureResult, signal: AbortSignal) => Promise<string> = async () => "  hello  ",
-  options: { acquisitionTimeoutMs?: number; transcriptionTimeoutMs?: number; onPhaseChange?: (phase: "acquiring" | "recording" | "transcribing") => void } = {},
+  options: { acquisitionTimeoutMs?: number; transcriptionTimeoutMs?: number; onPhaseChange?: (phase: "acquiring" | "recording" | "transcribing") => void; microphoneArbiter?: VoiceMicrophoneArbiter } = {},
 ): Fixture {
   const surface = new FakeSurface();
   const indicator = new VoicePrivacyIndicator(() => surface);
@@ -131,7 +132,7 @@ function fixture(
   const capture = new VoiceCaptureService((_, onAcquired) => {
     attempt = new ControlledAttempt(onAcquired);
     return attempt;
-  }, indicator, { acquisitionTimeoutMs: options.acquisitionTimeoutMs });
+  }, indicator, { acquisitionTimeoutMs: options.acquisitionTimeoutMs, microphoneArbiter: options.microphoneArbiter });
   const listening = new VoiceListeningService(capture, transcriber, { transcriptionTimeoutMs: options.transcriptionTimeoutMs, onPhaseChange: options.onPhaseChange });
   return { surface, indicator, capture, listening, getAttempt: () => attempt! };
 }
@@ -144,6 +145,31 @@ assert.equal(VOICE_ACQUISITION_TIMEOUT_MS, 15_000);
 assert.equal(VOICE_TRANSCRIPTION_TIMEOUT_MS, 30_000);
 assert.equal(VOICE_MIN_RECORDING_DURATION_MS, 1_000);
 assert.equal(VOICE_MAX_RECORDING_DURATION_MS, 30_000);
+
+{
+  const captureArbiter = new VoiceMicrophoneArbiter();
+  const foreignArbiter = new VoiceMicrophoneArbiter();
+  const foreignReservation = foreignArbiter.reserve("listen");
+  const current = fixture(async () => "hello", { microphoneArbiter: captureArbiter });
+
+  await assert.rejects(() => current.capture.start(5_000, foreignReservation), /different arbiter/);
+  assert.equal(captureArbiter.activeOwner, null, "foreign reservations do not acquire the capture arbiter");
+  foreignArbiter.releaseReservation(foreignReservation);
+}
+
+{
+  const microphoneArbiter = new VoiceMicrophoneArbiter();
+  const reservation = microphoneArbiter.reserve("listen");
+  const current = fixture(async () => "hello", { microphoneArbiter });
+  const handlePromise = current.capture.start(5_000, reservation);
+  await flush();
+  current.getAttempt().resolveAcquisition();
+  const handle = await handlePromise;
+  current.getAttempt().recording.resolveCapture();
+  await handle.result;
+  microphoneArbiter.releaseReservation(reservation);
+  assert.equal(microphoneArbiter.activeOwner, null, "same-arbiter reservations still complete normal capture");
+}
 
 {
   const state = new VoiceOperationState();

--- a/apps/desktop/tests/voice-playback.test.ts
+++ b/apps/desktop/tests/voice-playback.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { EventEmitter } from "node:events";
+
+import { getVoicePlaybackTimeoutMs, VOICE_PLAYBACK_MAX_TIMEOUT_MS, VoiceAssistantPlaybackCoordinator } from "../src/voice-assistant-playback.js";
+import { installWindowLossHandlers } from "../src/voice-playback-window.js";
+
+const require = createRequire(import.meta.url);
+const { splitSystemSpeech } = require("../../pet-tts-helper.cjs") as { splitSystemSpeech(text: string, maxChars?: number): string[] };
+
+async function main(): Promise<void> {
+  const owner = { id: "pet-window" };
+  const otherOwner = { id: "other-window" };
+  let started = 0;
+  let stopped = 0;
+  const coordinator = new VoiceAssistantPlaybackCoordinator(20);
+  const transport = { start: () => { started += 1; }, stop: () => { stopped += 1; } };
+
+  const first = coordinator.play("request-1", "audio", owner, transport);
+  assert.equal(coordinator.complete({ owner: otherOwner, requestId: "request-1", kind: "audio", outcome: "ended" }), false, "completion from another window cannot settle playback");
+  assert.equal(coordinator.complete({ owner, requestId: "request-1", kind: "audio", outcome: "ended" }), true);
+  await first;
+
+  const replacement = coordinator.play("request-2", "audio", owner, transport);
+  assert.equal(coordinator.complete({ owner, requestId: "wrong-request", kind: "audio", outcome: "stopped" }), false, "a mismatched scoped stop cannot settle the active request");
+  assert.equal(coordinator.complete({ owner, requestId: "request-2", kind: "audio", outcome: "stopped" }), true, "renderer replacement settles the old request");
+  await assert.rejects(replacement, /stopped/);
+
+  const perRequestCoordinator = new VoiceAssistantPlaybackCoordinator(5);
+  const perRequest = perRequestCoordinator.play("request-custom-timeout", "audio", owner, { start: () => undefined, stop: () => undefined }, 500);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(perRequestCoordinator.complete({ owner, requestId: "request-custom-timeout", kind: "audio", outcome: "ended" }), true, "the supplied request timeout remains active after the coordinator default expires");
+  await perRequest;
+
+  const unscopedStop = coordinator.play("request-3", "system", owner, transport);
+  assert.equal(coordinator.complete({ owner, requestId: "request-3", kind: "system", outcome: "stopped" }), true, "unscoped renderer stop is reported against the active request");
+  await assert.rejects(unscopedStop, /stopped/);
+
+  const lostWindow = coordinator.play("request-4", "audio", owner, transport);
+  coordinator.failOwner(owner);
+  await assert.rejects(lostWindow, /window was lost/);
+
+  const sendFailure = coordinator.play("request-5", "audio", owner, { start: () => { throw new Error("renderer send failed"); }, stop: () => undefined });
+  await assert.rejects(sendFailure, /renderer send failed/);
+
+  const timeout = coordinator.play("request-6", "audio", owner, transport);
+  await assert.rejects(timeout, /timed out/);
+  assert.equal(started, 5);
+  assert.equal(stopped, 1, "timeout requests are stopped before rejection");
+  assert.equal(coordinator.pendingCount, 0);
+
+  const longSystemText = "This is a deliberately long system speech response. ".repeat(60);
+  const longSystemTimeout = getVoicePlaybackTimeoutMs({ kind: "system", text: longSystemText });
+  assert.equal(longSystemTimeout > 15_000, true, "long system speech receives more than the old fixed deadline");
+  assert.equal(getVoicePlaybackTimeoutMs({ kind: "system", text: longSystemText }, 0.5) >= longSystemTimeout, true, "slower speech receives a longer deadline");
+  assert.equal(getVoicePlaybackTimeoutMs({ kind: "system", text: "x".repeat(10_000) }) <= VOICE_PLAYBACK_MAX_TIMEOUT_MS, true, "system speech deadline is capped");
+  const lowBitrateAudio = new Uint8Array(64_000);
+  assert.equal(getVoicePlaybackTimeoutMs({ kind: "audio", bytes: lowBitrateAudio }), VOICE_PLAYBACK_MAX_TIMEOUT_MS, "valid low-bitrate provider audio is not cut off by a byte-derived allowance");
+
+  for (const event of ["render-process-gone", "did-fail-load"] as const) {
+    const lossOwner = { id: event };
+    const lossCoordinator = new VoiceAssistantPlaybackCoordinator(10_000);
+    const windowEvents = new EventEmitter();
+    const window = { on: windowEvents.on.bind(windowEvents), off: windowEvents.off.bind(windowEvents), webContents: new EventEmitter() } as unknown as Electron.BrowserWindow;
+    const lost = lossCoordinator.play(event, "audio", lossOwner, transport);
+    const cleanup = installWindowLossHandlers(window, () => lossCoordinator.failOwner(lossOwner));
+    window.webContents.emit(event);
+    await assert.rejects(lost, /window was lost/);
+    cleanup();
+  }
+
+  const longText = "one two three four five six seven eight nine ten ".repeat(80);
+  const chunks = splitSystemSpeech(longText, 32);
+  assert.equal(chunks.join(""), longText, "system chunks preserve the authoritative text");
+  assert.equal(chunks.every((chunk) => chunk.length <= 32), true);
+  assert.equal(chunks.length > 1, true);
+}
+
+main().then(() => console.log("Voice playback and TTS chunk behavior verified."), (error) => { console.error(error); process.exitCode = 1; });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,28 @@ turns whose outcomes all complete retain the model response. Chat/voice UI and
 transcript/history persistence remain separate v4 work; provider-profile
 management is implemented through the host-owned Control Center bridge.
 
+### Generic host voice session (#147)
+
+The desktop owns a host controller/factory for one bounded generic session at a
+time. Activation creates a fresh `VoiceAssistantSession`; ending it releases its
+microphone reservation, and a later activation creates a new session rather than
+reusing the terminal object. The session composes final-only bounded STT input,
+the canonical Pet Assistant capability loop, and authoritative response TTS.
+The text, STT, and TTS profiles are snapshotted independently; the STT snapshot is
+captured before microphone acquisition and remains fixed through transcription.
+There is no Talk control, shortcut, chat surface, retained transcript/history, or
+Realtime protocol integration in #147; those remain deferred to #150, #148, #149,
+and #139 respectively.
+
+Pet-window TTS is request-scoped. Audio and system speech retain a request id and
+kind in the renderer, settle replacement/stop/error/close/renderer-loss/navigation
+paths exactly once, and the main process rejects a lost or non-completing playback
+request at a bounded, duration-aware deadline. System speech is split into bounded
+utterance chunks while preserving the authoritative assistant text and emits one
+completion after the final chunk. Voice activity is rendered through a dedicated
+composable slot, leaving unrelated plugin display and status slots intact when
+voice activity clears.
+
 Provider profile management for issue #145 is a host-owned Control Center flow:
 the renderer consumes redacted snapshots and explicit actions over preload while
 the main process owns validation, persistence, and credentials. These are the
@@ -174,6 +196,9 @@ These hold everywhere; the rest of the docs assume them.
 - **Voice is bounded and visible.** Listening is one-shot, one-at-a-time,
   explicitly cancellable, visibly indicated while a media track is live, and
   bounded by separate microphone-acquisition and transcription timeouts.
+- **Voice resource ownership is centralized.** Assistant, plugin one-shot, and
+  private Realtime lanes release their own leases/tracks; only the shared voice
+  resource owner destroys the privacy indicator after every lane has stopped.
 - **Pet Assistant lifecycle is bounded.** The host loop is stopped and active
   turns are cancelled before plugin teardown; capability handles remain pinned
   to the plugin generation that registered them.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -250,17 +250,37 @@ wake-word listening is implemented. While active, the existing tray menu exposes
 transcription** while provider transcription is pending; the control disappears
 when the operation settles.
 
-Phase 1 also adds a host-private `VoiceConversationService` and a separate
-hidden, sandboxed realtime renderer. The service owns one persistent conversation,
-shares the microphone lease with one-shot listening, tracks interruptions and
-mute state internally, rejects stale session events, and releases privacy state
-on every close path. The renderer owns `getUserMedia`, WebRTC, the data channel,
-and remote audio; the host keeps the OpenAI credential and performs bounded SDP
-negotiation. The session uses automatic server VAD turns with interruption and no
-tools. This phase intentionally has no visible conversation status, UI, tray
-control, pet indicator, settings, public SDK method, plugin permission, plugin
-tool, transcript, memory, or generic TTS behavior. Those are deferred until the
-host lifecycle and protocol are reviewed for Phase 2.
+The private `VoiceConversationService` and hidden, sandboxed realtime renderer
+remain infrastructure only. The service owns one realtime lane, shares the
+microphone lease with one-shot listening, tracks interruptions and mute state,
+rejects stale events, and releases only its own track/lease on close. It never
+destroys the shared privacy indicator; `voice-resource-owner.ts` performs that
+final teardown after the assistant, plugin one-shot, and realtime lanes stop.
+The renderer owns `getUserMedia`, WebRTC, the data channel, and remote audio; the
+host keeps the OpenAI credential and performs bounded SDP negotiation. Realtime
+protocol work remains deferred to #139.
+
+#### Generic host voice session (#147)
+
+`voice-assistant-host.ts` exposes a host controller/factory, not an app-lifetime
+terminal session. Each activation creates one `VoiceAssistantSession`; ending it
+releases the microphone reservation and the next activation creates a fresh
+session. The composition is bounded final-only capture/transcription → canonical
+Pet Assistant → authoritative TTS. Text, STT, and TTS provider profiles are
+independent, with the STT profile snapshotted before capture begins. No Talk
+control, shortcut, chat UI, retained history, or Realtime protocol is added here.
+
+Pet-window playback is request-scoped by `{ requestId, kind }`. Renderer audio and
+system speech settle replacement, matching/unscoped stop, error, close, renderer
+loss, navigation, and timeout paths exactly once. Deadlines are bounded but
+duration-aware: system speech accounts for the complete chunked text and speech
+rate, while provider audio receives a generous allowance under the hard maximum.
+System speech reports one completion only after the last chunk, preserving the
+authoritative assistant text. Voice activity uses its own composable pet slot, so
+voice animation/status cleanup cannot erase an unrelated plugin message, media
+bubble, or status badge. It maps listening/thinking/acting/speaking to
+waiting/thinking/working/running and clears the voice slot on mute, pause, end,
+and shutdown.
 
 #### Pet Assistant host integration (#138, #146)
 

--- a/docs/openpets_v4.md
+++ b/docs/openpets_v4.md
@@ -1,5 +1,5 @@
 ---
-description: Product direction and delivery goal for OpenPets v4: a conversational pet that can use enabled companion capabilities.
+description: "Product direction and delivery goal for OpenPets v4: a conversational pet that can use enabled companion capabilities."
 ---
 
 # OpenPets v4 — Pet Assistant
@@ -25,26 +25,23 @@ consume those integrations.
 
 ## The product experience
 
-Voice is the first conversation surface:
-
-1. The person clicks the pet's Talk control or uses its keyboard shortcut.
-2. The pet visibly enters a listening state and OpenPets shows its microphone
-   indicator.
-3. The person speaks naturally: “Set a focus timer for 25 minutes,” “Remind me
-   tomorrow at 9,” or “What focus session is running?”
-4. The pet understands the request, invokes an available capability, reflects
-   its state while working, and answers plainly: “Focus started for 25 minutes.”
-5. The person can continue the conversation, interrupt the pet, mute it, or end
-   the session explicitly.
+The intended voice product experience is described here for v4 planning, but
+the current #147 delivery deliberately adds no Talk control or keyboard
+shortcut. Those activation surfaces are deferred to #150. The host contract
+already supports the eventual flow: one activation owns one bounded session,
+the pet enters listening, the person speaks, the canonical assistant may invoke
+an enabled capability, and authoritative output is spoken before the session
+can accept another turn.
 
 Chat is another v4 conversation surface, not a separate assistant product. It
 uses the same conversation, capabilities, execution results, and pet behavior;
 it only changes the input and output modality.
 
-Voice conversations include live transcription, so spoken requests and the
-pet's responses are available in the conversation UI as text. The persistence
-policy is bounded, recent local history that the owner can inspect and delete;
-v4 does not infer or retain long-term semantic memory.
+The generic #147 session emits final user and assistant transcript events only;
+it does not expose a conversation UI or retain transcript/history. Chat UI and
+bounded recent-history management remain deferred to #148 and #149. The
+provider-neutral host contract does not infer or retain long-term semantic
+memory.
 
 OpenPets connects the experience to configured AI, speech-to-text, and
 text-to-speech providers through host-owned integrations. The product contract
@@ -93,6 +90,25 @@ accepts, and the result it returns.
   succeeded when the responsible plugin reports failure or needs more input.
 - Realtime voice transport is infrastructure, not the product by itself. The
   product is a pet that can converse and act.
+
+### #147 generic voice contract
+
+The desktop host composes final-only bounded STT capture, the canonical
+generation-pinned Pet Assistant capability runtime, and provider-backed TTS.
+Text, STT, and TTS profiles are selected independently; the STT selection is
+snapshotted before capture and remains fixed through transcription. Assistant
+capability results remain authoritative, and the terminal assistant response is
+the exact text handed to TTS. TTS playback is request-scoped with duration-aware
+bounded deadlines and settles replacement, stop, renderer loss, navigation, and
+timeout paths exactly once. Voice activity renders through a dedicated composable
+pet slot so cleanup does not erase unrelated plugin display state.
+
+An activation owns one session and its microphone reservation. Ending releases
+that reservation; a later activation creates a fresh session. Assistant,
+plugin one-shot, and private Realtime lanes release only their own work. A
+shared host resource owner destroys the privacy indicator only after all lanes
+have stopped. #147 adds no Talk controls/shortcut, chat UI, retained history, or
+Realtime protocol behavior; #150, #148, #149, and #139 remain deferred.
 
 The current #138/#146/#145 implementation has no chat surface,
 transcript/history persistence, or editable sensitive-action confirmation

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -212,6 +212,24 @@ cleared with an explicit empty array. Because snapshots expose header names but
 not values, header replacement is an intentional whole-list operation rather
 than a per-header edit.
 
+The host voice lanes consume these profiles independently: text reasoning,
+final-only STT, and TTS each take their own operation snapshot. The generic voice
+session pins STT before capture starts and passes the same snapshot through
+transcription; changing provider settings affects a later activation, not an
+in-flight capture. TTS playback is host-owned and request-scoped, including
+bounded system-utterance chunking, duration-aware deadlines, renderer-loss and
+navigation handling, and completion/error/stop handling. Voice activity uses a
+separate host-owned pet slot and does not clear plugin-owned display or status
+state. Plugins do not own the microphone, privacy surface, renderer playback
+lifecycle, or generic assistant session.
+
+`voice-resource-owner.ts` is the sole owner of the shared microphone arbiter,
+capture service, and privacy indicator. Plugin one-shot listening, the private
+Realtime lane, and the generic assistant lane release only their own tracks and
+leases. The shared owner destroys the privacy surface once, after every lane has
+stopped during app teardown. This does not add a public voice conversation API or
+make Realtime part of the plugin contract; #139 remains deferred.
+
 Generic `openai-compatible-text` is the codec for OpenAI, Ollama, LM Studio,
 vLLM, MiniMax chat, and cloud gateways. Anthropic remains native because its
 messages/tool wire format differs. STT is an explicit


### PR DESCRIPTION
Closes #147

## Scope
- Host-private, provider-neutral multi-turn STT → Pet Assistant → TTS sessions with interruption, mute, explicit end, cancellation, cleanup, normalized transcripts, and canonical pet activity mapping.
- Independent #145 text/STT/TTS profile snapshots, shared microphone/privacy ownership, request-scoped system/audio playback, and deterministic fake-adapter coverage.

## Non-goals
- No Talk controls or shortcut (#150), chat UI (#148), retained history (#149), or OpenAI Realtime protocol work (#139).

## Validation
- `pnpm --filter @open-pets/desktop test:build` and focused voice/provider/assistant behavior tests
- `pnpm --filter @open-pets/desktop typecheck`
- `pnpm --filter @open-pets/desktop build`
- `pnpm docs:build`
- `git diff --check`

## Greptile
- Core local review: 5/5, no unresolved comments after remediation.

## Caveat
- The full desktop test runner currently stops at the pre-existing Node/Electron named-export failure in `provider-credential-deletion.test.js` after the preceding suites pass; this PR does not change that unrelated test/runtime boundary.