### PR TITLE
fix(desktop): keep gravity inside Windows work area (#155)

### DIFF
--- a/apps/desktop/src/pet-motion-engine.ts
+++ b/apps/desktop/src/pet-motion-engine.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import type { BrowserWindow } from "electron";
 
 import { clampToTerminalBounds, getEffectiveConfinementBounds } from "./confinement-manager.js";
-import { clampToNearestDisplayIfOffscreen, clampToVisibleWorkArea, defaultPetWindowSize, isCrossDisplayRoamingEnabled, type Point } from "./display.js";
+import { clampToNearestDisplayIfOffscreen, clampToVisibleWorkArea, defaultPetWindowSize, isCrossDisplayRoamingEnabled, type Point, type WindowSize } from "./display.js";
 // isPetWindowDragging is lazily loaded via _setIsPetWindowDraggingForTesting seam
 
 // ---------------------------------------------------------------------------
@@ -173,7 +173,7 @@ export async function motionMoveTo(petHandleId: string, accessor: WindowAccessor
   // competing-writer race that causes jitter.
   if (state.follow !== null || state.physics !== null) {
     const [startX, startY] = window.getPosition();
-    const clamped = clampPosition(petHandleId, target);
+    const clamped = clampPosition(petHandleId, target, getWindowSize(window));
     state.moveTarget = { x: clamped.x, y: clamped.y, startX, startY, elapsed: 0, durationMs, easing };
     // Return a promise that resolves when the generation changes (move completes or is superseded).
     return new Promise<void>((resolve) => {
@@ -187,7 +187,7 @@ export async function motionMoveTo(petHandleId: string, accessor: WindowAccessor
 
   // No continuous loop — drive it ourselves (legacy step loop).
   const [startX, startY] = window.getPosition();
-  const clamped = clampPosition(petHandleId, target);
+  const clamped = clampPosition(petHandleId, target, getWindowSize(window));
   const steps = Math.max(4, Math.round(durationMs / 33));
   for (let step = 1; step <= steps; step += 1) {
     const live = accessor();
@@ -275,6 +275,7 @@ function tickPet(petHandleId: string, accessor: WindowAccessor, state: MotionSta
   }
   let rawX = x + state.fracX;
   let rawY = y + state.fracY;
+  const windowSize = getWindowSize(window);
 
   if (state.follow) {
     const cursor = getScreen().getCursorScreenPoint();
@@ -310,11 +311,11 @@ function tickPet(petHandleId: string, accessor: WindowAccessor, state: MotionSta
     // tie-break at monitor seams and caused rapid floor oscillation between
     // mismatched-height displays. Using the geometric center also aligns with
     // clampToVisibleWorkArea, which already uses the center for display selection.
-    const centerX = x + Math.round(defaultPetWindowSize.width / 2);
-    const centerY = y + Math.round(defaultPetWindowSize.height / 2);
+    const centerX = x + Math.round(windowSize.width / 2);
+    const centerY = y + Math.round(windowSize.height / 2);
     const display = getScreen().getDisplayNearestPoint({ x: centerX, y: centerY });
     const confinementBounds = getEffectiveConfinementBounds(petHandleId);
-    const floor = computeGravityFloor(confinementBounds, display.workArea.y, display.workArea.height, defaultPetWindowSize.height);
+    const floor = computeGravityFloor(confinementBounds, display.workArea.y, display.workArea.height, windowSize.height);
     state.physics.vy = Math.min(state.physics.vy + 2.2, 48);
     rawY = y + state.physics.vy;
     if (rawY >= floor) {
@@ -333,7 +334,7 @@ function tickPet(petHandleId: string, accessor: WindowAccessor, state: MotionSta
   state.fracY = nextYFull - nextY;
 
   if (nextX !== x || nextY !== y) {
-    const clamped = clampPosition(petHandleId, { x: nextX, y: nextY });
+    const clamped = clampPosition(petHandleId, { x: nextX, y: nextY }, windowSize);
     if (!Number.isFinite(clamped.x) || !Number.isFinite(clamped.y)) return;  // skip write when clamp produces NaN (e.g. from NaN workArea on monitor disconnect)
     window.setPosition(clamped.x, clamped.y, false);
   }
@@ -348,11 +349,19 @@ function delay(ms: number): Promise<void> {
  * - If the pet has active terminal confinement, clamp to terminal bounds.
  * - Otherwise clamp to visible work area (free-roam).
  */
-function clampPosition(petHandleId: string, pos: Point): Point {
+function clampPosition(petHandleId: string, pos: Point, windowSize: WindowSize = defaultPetWindowSize): Point {
   const terminalBounds = getEffectiveConfinementBounds(petHandleId);
-  if (terminalBounds) return clampToTerminalBounds(pos, defaultPetWindowSize, terminalBounds);
-  if (isCrossDisplayRoamingEnabled()) return clampToNearestDisplayIfOffscreen(pos, defaultPetWindowSize);
-  return clampToVisibleWorkArea(pos, defaultPetWindowSize);
+  if (terminalBounds) return clampToTerminalBounds(pos, windowSize, terminalBounds);
+  if (isCrossDisplayRoamingEnabled()) return clampToNearestDisplayIfOffscreen(pos, windowSize);
+  return clampToVisibleWorkArea(pos, windowSize);
+}
+
+function getWindowSize(window: BrowserWindow): WindowSize {
+  const candidate = window as BrowserWindow & { getBounds?: () => { width: number; height: number } };
+  if (typeof candidate.getBounds !== "function") return defaultPetWindowSize;
+  const bounds = candidate.getBounds();
+  if (!Number.isFinite(bounds.width) || bounds.width <= 0 || !Number.isFinite(bounds.height) || bounds.height <= 0) return defaultPetWindowSize;
+  return { width: bounds.width, height: bounds.height };
 }
 
 /** Exported for unit testing only — do not call from production code. */

--- a/apps/desktop/tests/pet-motion-engine-gravity-seam.test.ts
+++ b/apps/desktop/tests/pet-motion-engine-gravity-seam.test.ts
@@ -23,6 +23,7 @@ import { describe, it, after, afterEach } from "node:test";
 
 import { computeGravityFloor, _setScreenForTesting, _setIsPetWindowDraggingForTesting, _resetMotionStatesForTesting, registerPet, motionSetPhysics } from "../src/pet-motion-engine.js";
 import { _setScreenForTesting as setDisplayScreen, invalidateDisplayCache, setCrossDisplayRoamingEnabled, defaultPetWindowSize } from "../src/display.js";
+import { setConfinementEnabled } from "../src/confinement-manager.js";
 
 const petH = defaultPetWindowSize.height; // 420
 
@@ -177,6 +178,43 @@ describe("gravity seam oscillation regression", () => {
         `indicates the display-selection flip-flop is still occurring (floor_A=${floorA})`,
       );
     }
+  });
+
+  it("keeps the native window bottom inside the work area on Windows-sized bounds", async () => {
+    const display = { bounds: { x: 0, y: 0, width: 1536, height: 864 }, workArea: { x: 0, y: 0, width: 1536, height: 816 } };
+    const screen = {
+      getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+      getAllDisplays: () => [display],
+      getPrimaryDisplay: () => display,
+      getDisplayNearestPoint: () => display,
+    };
+
+    _setScreenForTesting(screen as any);
+    setDisplayScreen(screen as any);
+    invalidateDisplayCache();
+    setCrossDisplayRoamingEnabled(false);
+    setConfinementEnabled(false);
+    _setIsPetWindowDraggingForTesting(() => false);
+
+    let petX = 500;
+    let petY = 300;
+    const nativeWindow = {
+      getPosition: (): [number, number] => [petX, petY],
+      getBounds: () => ({ x: petX, y: petY, width: 344, height: 424 }),
+      isDestroyed: () => false,
+      isVisible: () => true,
+      setPosition: (x: number, y: number) => {
+        petX = x;
+        petY = y;
+      },
+    };
+    const accessor = () => nativeWindow as any;
+
+    registerPet("native-bounds-test", accessor);
+    motionSetPhysics("native-bounds-test", accessor, { gravity: true, bounce: 0 });
+    await new Promise<void>((resolve) => setTimeout(resolve, loopIntervalMs * 30));
+
+    assert.ok(petY + nativeWindow.getBounds().height <= display.workArea.y + display.workArea.height, "gravity must keep the native window bottom inside the Windows work area");
   });
 });
 

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -125,6 +125,9 @@ target vectors and physics overrides through the engine's public API
 **sole continuous position writer**; all per-pet step loops were eliminated to
 prevent jitter from competing writers. Sub-pixel fractional accumulators
 (`fracX` / `fracY` in `MotionState`) ensure smooth movement at any tick rate.
+Gravity and per-tick containment use the live native pet-window bounds, not only
+the nominal canvas dimensions, so platform-specific window chrome cannot place
+the window below a display work area.
 See [Plugin platform](/plugins) and [Plugin SDK v3](/sdk) for the plugin side.
 
 ### Display containment and cross-display roaming


### PR DESCRIPTION
Closes #155

## Summary

- Use live BrowserWindow bounds for motion gravity and containment.
- Add a regression test that keeps the native window bottom inside the selected display workArea.
- Document the platform-specific bounds invariant in docs/pets.md.

## Root cause

Windows can report live BrowserWindow bounds larger than OpenPets' nominal 340x420 size. Gravity and clamping previously used the nominal size, allowing the real native window bottom below the Windows workArea. Reset Pet Position wrote a safe nominal position, but active gravity immediately wrote the invalid nominal floor again, so recovery was only temporary while gravity remained active.

Motion containment now uses the live BrowserWindow bounds. Gravity, confinement, cross-display roaming, monitor-seam behavior, and the single-writer motion model are preserved.

## Validation

- Reproduced on Windows with a 1536x816 work area.
- Reproduced at pet scales 0.5 and 1.5.
- Regression test verifies the native window bottom remains inside workArea.
- Focused motion, display, confinement, seam, cross-display, ticker, hidden-move, NaN-guard, single-writer, and roaming tests passed.
- Desktop typecheck passed.
- Desktop build passed.
- Desktop test-build passed.
- git diff --check passed.
- Full suite remains blocked by the unrelated claude-memory.test.ts Windows symlink EPERM failure.
- Physical multi-monitor validation was unavailable; existing seam and cross-display tests pass.