### PR TITLE
feat(voice): add optional OpenAI Realtime Pet Assistant adapter

### DIFF
--- a/apps/desktop/assets/voice-realtime.html
+++ b/apps/desktop/assets/voice-realtime.html
@@ -8,6 +8,7 @@
 
   const MAX_SIGNAL_BYTES = 256 * 1024;
   let sessionId = "";
+  let generation = 0;
   let stream = null;
   let peer = null;
   let channel = null;
@@ -16,6 +17,8 @@
   let closing = false;
   let assistantSpeaking = false;
   let responseInProgress = false;
+  const transcriptBuffers = new Map();
+  const emittedToolCalls = new Set();
 
   const emit = (event) => {
     try { bridge.emit({ sessionId, ...event }); } catch { /* host teardown may race renderer cleanup */ }
@@ -68,7 +71,7 @@
     } else if (type === "response.created") {
       responseInProgress = true;
       emit({ type: "response-started" });
-    } else if (type === "response.output_audio.delta" || type === "response.output_audio_transcript.delta") {
+    } else if (type === "response.output_audio.delta") {
       if (!assistantSpeaking) emit({ type: "response-audio-started" });
       assistantSpeaking = true;
       responseInProgress = true;
@@ -80,10 +83,51 @@
       assistantSpeaking = false;
       responseInProgress = false;
       emit({ type: "response-completed" });
+    } else if (type === "conversation.item.input_audio_transcription.delta") {
+      appendTranscript(message.item_id, "user", "partial", message.delta);
+    } else if (type === "conversation.item.input_audio_transcription.completed") {
+      appendTranscript(message.item_id, "user", "final", message.transcript);
+    } else if (type === "response.output_audio_transcript.delta") {
+      if (!assistantSpeaking) emit({ type: "response-audio-started" });
+      assistantSpeaking = true;
+      responseInProgress = true;
+      appendTranscript(message.item_id, "assistant", "partial", message.delta);
+    } else if (type === "response.output_audio_transcript.done") {
+      appendTranscript(message.item_id, "assistant", "final", message.transcript);
+    } else if (type === "response.function_call_arguments.done") {
+      emitToolCall(message.call_id, message.name, message.arguments);
+    } else if (type === "response.output_item.done") {
+      const item = message.item;
+      if (item && typeof item === "object" && !Array.isArray(item) && item.type === "function_call") {
+        emitToolCall(item.call_id, item.name, item.arguments);
+      }
     } else if (type === "error") {
       const error = message.error && typeof message.error === "object" && !Array.isArray(message.error) ? message.error : {};
       fail(typeof error.message === "string" ? error.message : "Realtime voice provider reported an error.");
     }
+  };
+
+  const appendTranscript = (entryId, speaker, status, text) => {
+    if (typeof entryId !== "string" || !entryId || typeof text !== "string" || !text) return;
+    const previous = transcriptBuffers.get(entryId) || "";
+    const value = status === "partial" ? previous + text : text;
+    if (new TextEncoder().encode(value).byteLength > MAX_SIGNAL_BYTES) return;
+    transcriptBuffers.set(entryId, value);
+    emit({ type: "transcript", entryId, speaker, status, text: value });
+    if (status === "final") transcriptBuffers.delete(entryId);
+  };
+
+  const emitToolCall = (callId, name, args) => {
+    if (typeof callId !== "string" || !callId || typeof name !== "string" || !name || typeof args !== "string" || !args || emittedToolCalls.has(callId)) return;
+    if (new TextEncoder().encode(args).byteLength > MAX_SIGNAL_BYTES) return;
+    try {
+      const parsed = JSON.parse(args);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
+    } catch {
+      // Keep the malformed representation visible to the host validator; never execute it as {}.
+    }
+    emittedToolCalls.add(callId);
+    emit({ type: "tool-call", callId, name, arguments: args });
   };
 
   const start = async () => {
@@ -127,14 +171,22 @@
 
   bridge.onCommand((command) => {
     if (!command || typeof command !== "object") return;
-    if (command.type !== "start" && command.sessionId !== sessionId) return;
+    if (command.type !== "start" && (command.sessionId !== sessionId || command.generation !== generation)) return;
     if (command.type === "start") {
       sessionId = typeof command.sessionId === "string" ? command.sessionId : "";
+      generation = Number.isSafeInteger(command.generation) ? command.generation : 0;
       void start();
     } else if (command.type === "answer" && typeof command.sdp === "string" && command.sdp.length <= MAX_SIGNAL_BYTES && peer) {
       void peer.setRemoteDescription({ type: "answer", sdp: command.sdp }).catch(fail);
     } else if (command.type === "mute") {
       for (const track of stream?.getAudioTracks?.() ?? []) track.enabled = command.muted !== true;
+    } else if (command.type === "provider-event" && typeof command.message === "string" && channel) {
+      if (new TextEncoder().encode(command.message).byteLength > MAX_SIGNAL_BYTES) return;
+      try {
+        const providerEvent = JSON.parse(command.message);
+        if (!providerEvent || typeof providerEvent !== "object" || Array.isArray(providerEvent)) return;
+        channel.send(command.message);
+      } catch { /* malformed host output is ignored by the sandbox */ }
     } else if (command.type === "close") {
       closeResources(true);
     }

--- a/apps/desktop/assets/voice-realtime.html
+++ b/apps/desktop/assets/voice-realtime.html
@@ -17,6 +17,10 @@
   let closing = false;
   let assistantSpeaking = false;
   let responseInProgress = false;
+  let activeResponseId = null;
+  let activeInputItemId = null;
+  const closedResponseIds = new Set();
+  const closedInputItemIds = new Set();
   const transcriptBuffers = new Map();
   const emittedToolCalls = new Set();
 
@@ -62,44 +66,71 @@
     if (!message || typeof message !== "object" || Array.isArray(message)) return;
     const type = typeof message.type === "string" ? message.type : "";
     if (type === "input_audio_buffer.speech_started") {
-      if (responseInProgress) emit({ type: "interrupted" });
+      const itemId = providerId(message.item_id);
+      if (!itemId || closedInputItemIds.has(itemId) || activeInputItemId === itemId) return;
+      if (activeInputItemId) closedInputItemIds.add(activeInputItemId);
+      const interruptedResponseId = activeResponseId;
+      if (responseInProgress && interruptedResponseId) {
+        closedResponseIds.add(interruptedResponseId);
+        emit({ type: "interrupted", responseId: interruptedResponseId, itemId });
+      }
+      activeInputItemId = itemId;
+      activeResponseId = null;
       responseInProgress = false;
       assistantSpeaking = false;
-      emit({ type: "speech-started" });
+      emit({ type: "speech-started", itemId });
     } else if (type === "input_audio_buffer.speech_stopped") {
-      emit({ type: "speech-stopped" });
+      const itemId = providerId(message.item_id);
+      if (!itemId || itemId !== activeInputItemId || closedInputItemIds.has(itemId)) return;
+      emit({ type: "speech-stopped", itemId });
     } else if (type === "response.created") {
+      const responseId = responseIdFromCreated(message);
+      if (!responseId || closedResponseIds.has(responseId) || activeResponseId) return;
+      activeResponseId = responseId;
       responseInProgress = true;
-      emit({ type: "response-started" });
+      emit({ type: "response-started", responseId });
     } else if (type === "response.output_audio.delta") {
-      if (!assistantSpeaking) emit({ type: "response-audio-started" });
+      const responseId = providerId(message.response_id);
+      if (!responseId || responseId !== activeResponseId) return;
+      if (!assistantSpeaking) emit({ type: "response-audio-started", responseId });
       assistantSpeaking = true;
       responseInProgress = true;
     } else if (type === "response.output_audio.done") {
-      if (assistantSpeaking) emit({ type: "response-audio-stopped" });
+      const responseId = providerId(message.response_id);
+      if (!responseId || responseId !== activeResponseId) return;
+      if (assistantSpeaking) emit({ type: "response-audio-stopped", responseId });
       assistantSpeaking = false;
     } else if (type === "response.done") {
-      if (assistantSpeaking) emit({ type: "response-audio-stopped" });
+      const responseId = responseIdFromDone(message);
+      if (!responseId || responseId !== activeResponseId) return;
+      if (assistantSpeaking) emit({ type: "response-audio-stopped", responseId });
       assistantSpeaking = false;
       responseInProgress = false;
-      emit({ type: "response-completed" });
+      activeResponseId = null;
+      closedResponseIds.add(responseId);
+      emit({ type: "response-completed", responseId });
     } else if (type === "conversation.item.input_audio_transcription.delta") {
       appendTranscript(message.item_id, "user", "partial", message.delta);
     } else if (type === "conversation.item.input_audio_transcription.completed") {
       appendTranscript(message.item_id, "user", "final", message.transcript);
     } else if (type === "response.output_audio_transcript.delta") {
-      if (!assistantSpeaking) emit({ type: "response-audio-started" });
+      const responseId = providerId(message.response_id);
+      if (!responseId || responseId !== activeResponseId) return;
+      if (!assistantSpeaking) emit({ type: "response-audio-started", responseId });
       assistantSpeaking = true;
       responseInProgress = true;
-      appendTranscript(message.item_id, "assistant", "partial", message.delta);
+      appendTranscript(message.item_id, "assistant", "partial", message.delta, responseId);
     } else if (type === "response.output_audio_transcript.done") {
-      appendTranscript(message.item_id, "assistant", "final", message.transcript);
+      const responseId = providerId(message.response_id);
+      if (!responseId || responseId !== activeResponseId) return;
+      appendTranscript(message.item_id, "assistant", "final", message.transcript, responseId);
     } else if (type === "response.function_call_arguments.done") {
-      emitToolCall(message.call_id, message.name, message.arguments);
+      emitToolCall(message.response_id, message.item_id, message.call_id, message.name, message.arguments);
     } else if (type === "response.output_item.done") {
       const item = message.item;
-      if (item && typeof item === "object" && !Array.isArray(item) && item.type === "function_call") {
-        emitToolCall(item.call_id, item.name, item.arguments);
+      const responseId = providerId(message.response_id);
+      if (responseId && responseId === activeResponseId && item && typeof item === "object" && !Array.isArray(item) && item.type === "function_call") {
+        emitToolCall(responseId, item.id, item.call_id, item.name, item.arguments);
       }
     } else if (type === "error") {
       const error = message.error && typeof message.error === "object" && !Array.isArray(message.error) ? message.error : {};
@@ -107,18 +138,22 @@
     }
   };
 
-  const appendTranscript = (entryId, speaker, status, text) => {
-    if (typeof entryId !== "string" || !entryId || typeof text !== "string" || !text) return;
-    const previous = transcriptBuffers.get(entryId) || "";
+  const appendTranscript = (itemId, speaker, status, text, responseId) => {
+    if (typeof itemId !== "string" || !itemId || typeof text !== "string" || !text) return;
+    if (speaker === "user" && itemId !== activeInputItemId) return;
+    if (speaker === "assistant" && responseId !== activeResponseId) return;
+    if (closedInputItemIds.has(itemId) || (responseId && closedResponseIds.has(responseId))) return;
+    const previous = transcriptBuffers.get(itemId) || "";
     const value = status === "partial" ? previous + text : text;
     if (new TextEncoder().encode(value).byteLength > MAX_SIGNAL_BYTES) return;
-    transcriptBuffers.set(entryId, value);
-    emit({ type: "transcript", entryId, speaker, status, text: value });
-    if (status === "final") transcriptBuffers.delete(entryId);
+    transcriptBuffers.set(itemId, value);
+    emit({ type: "transcript", entryId: itemId, itemId, ...(responseId ? { responseId } : {}), speaker, status, text: value });
+    if (status === "final") transcriptBuffers.delete(itemId);
   };
 
-  const emitToolCall = (callId, name, args) => {
-    if (typeof callId !== "string" || !callId || typeof name !== "string" || !name || typeof args !== "string" || !args || emittedToolCalls.has(callId)) return;
+  const emitToolCall = (responseId, itemId, callId, name, args) => {
+    if (typeof responseId !== "string" || !responseId || responseId !== activeResponseId || closedResponseIds.has(responseId)) return;
+    if (typeof itemId !== "string" || !itemId || typeof callId !== "string" || !callId || typeof name !== "string" || !name || typeof args !== "string" || !args || emittedToolCalls.has(callId)) return;
     if (new TextEncoder().encode(args).byteLength > MAX_SIGNAL_BYTES) return;
     try {
       const parsed = JSON.parse(args);
@@ -127,8 +162,12 @@
       // Keep the malformed representation visible to the host validator; never execute it as {}.
     }
     emittedToolCalls.add(callId);
-    emit({ type: "tool-call", callId, name, arguments: args });
+    emit({ type: "tool-call", responseId, itemId, callId, name, arguments: args });
   };
+
+  const providerId = (value) => typeof value === "string" && /^[A-Za-z0-9_-]+$/.test(value) ? value : null;
+  const responseIdFromCreated = (message) => message.response && typeof message.response === "object" && !Array.isArray(message.response) ? providerId(message.response.id) : null;
+  const responseIdFromDone = (message) => message.response && typeof message.response === "object" && !Array.isArray(message.response) ? providerId(message.response.id) : null;
 
   const start = async () => {
     if (started || closing) return;

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -54,6 +54,7 @@ const behaviorTests = [
   ".test-dist/tests/voice-bridge.test.js",
   ".test-dist/tests/voice-lifecycle.test.js",
   ".test-dist/tests/voice-conversation.test.js",
+  ".test-dist/tests/voice-realtime-assistant.test.js",
   ".test-dist/tests/voice-assistant-session.test.js",
   ".test-dist/tests/renderer-conversation-voice-state.test.js",
   ".test-dist/tests/renderer-conversation-history-state.test.js",

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -199,7 +199,7 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `pet-assistant-host.ts` / `pet-assistant-service.ts`: Host-owned provider-neutral assistant lifecycle, per-turn prompt composition, bounded active/archive context, archive query/erase seam, and generation-pinned capability routing
 - `pet-assistant-archive.ts`: Host-owned local terminal-text archive with atomic writes, retention/quarantine, and bounded prompt-window support
 - `pet-assistant-history-ipc.ts`: Pure narrow history list/delete/clear handler helpers, including startup and identifier validation
-- `pet-assistant-conversation.ts`: Host-owned current-session presentation projection, stable typed-chat controller, cancellation seam, and future normalized voice-transcript seam
+- `pet-assistant-conversation.ts`: Host-owned current-session presentation projection, stable typed-chat controller, cancellation seam, and normalized voice-transcript seam
 - `pet-assistant-personality.ts`: Pure personality defaults, bounds, patch validation, and safe deterministic serialization
 - `logger.ts`: Structured logging with scopes (app, ipc, lease, pet.default, pet.agent, pet.window, state, tray, ui), log rotation, redaction
 

--- a/apps/desktop/src/pet-assistant-service.ts
+++ b/apps/desktop/src/pet-assistant-service.ts
@@ -17,6 +17,8 @@ import {
   type PetAssistantToolResult,
   type PetAssistantTurnOptions,
   type PetAssistantTurnResult,
+  type PetAssistantRealtimeSession,
+  type PetAssistantRealtimeTurn,
 } from "./pet-assistant-types.js";
 import { randomUUID } from "node:crypto";
 import { buildPetAssistantTools, type PetAssistantToolSet } from "./pet-assistant-tools.js";
@@ -52,6 +54,27 @@ type ActiveTurn = {
   model: PetAssistantTextModel;
 };
 
+type RealtimeTurnState = {
+  readonly turnId: string;
+  readonly archiveTurnId: string;
+  readonly controller: AbortController;
+  readonly terminal: { value?: PetAssistantTurnResult };
+  readonly toolSet: PetAssistantToolSet;
+  readonly messages: PetAssistantMessage[];
+  readonly seenToolCallIds: Set<string>;
+  invocationStarted: boolean;
+  activeToolName?: string;
+  activeCall?: PetAssistantToolCall;
+  closePromise: Promise<PetAssistantTurnResult> | null;
+};
+
+type CapabilityExecutionState = {
+  readonly terminal: { value?: PetAssistantTurnResult };
+  invocationStarted: boolean;
+  activeToolName?: string;
+  activeCall?: PetAssistantToolCall;
+};
+
 const cancelledError = new Error("Pet Assistant turn cancelled.");
 
 export class PetAssistantService {
@@ -67,6 +90,8 @@ export class PetAssistantService {
   #nextTurn = 1;
   #nextSequence = 1;
   #stopped = false;
+  readonly #realtimeTurns = new Map<string, RealtimeTurnState>();
+  readonly #realtimePromises = new Set<Promise<unknown>>();
 
   constructor(model: PetAssistantTextModel, runtime: PetAssistantCapabilityRuntime, options: PetAssistantServiceOptions = {}) {
     this.#model = model;
@@ -116,8 +141,114 @@ export class PetAssistantService {
       this.#stopped = true;
       this.#emit({ type: "lifecycle", sequence: 0, lifecycle: "closing" });
       for (const active of this.#active.values()) active.controller.abort();
+      for (const turn of this.#realtimeTurns.values()) turn.controller.abort();
     }
-    await Promise.allSettled([...this.#active.values()].map((active) => active.promise).filter((promise): promise is Promise<PetAssistantTurnResult> => promise !== undefined));
+    await Promise.allSettled([
+      ...[...this.#active.values()].map((active) => active.promise).filter((promise): promise is Promise<PetAssistantTurnResult> => promise !== undefined),
+      ...this.#realtimePromises,
+    ]);
+  }
+
+  /** Snapshot provider-safe capabilities and expose only host-owned execution. */
+  async openRealtimeSession(signal: AbortSignal = new AbortController().signal): Promise<PetAssistantRealtimeSession> {
+    if (this.#stopped) throw new Error("Pet Assistant service is stopped.");
+    const snapshot = await waitFor(this.#runtime.snapshot(signal), signal);
+    const toolSet = buildPetAssistantTools(snapshot);
+    const instructions = composeHostSystemPrompt(this.#compositionProvider());
+    let closed = false;
+    const turns = new Set<RealtimeTurnState>();
+    const session: PetAssistantRealtimeSession = {
+      tools: toolSet.tools,
+      instructions,
+      beginTurn: (turnId, turnSignal) => {
+        if (closed) throw new Error("Pet Assistant realtime session is closed.");
+        const normalizedTurnId = validateTurnId(turnId);
+        if (this.#realtimeTurns.has(normalizedTurnId) || this.#active.has(PET_ASSISTANT_CONVERSATION_ID)) {
+          throw new Error(`Conversation ${PET_ASSISTANT_CONVERSATION_ID} already has an active turn.`);
+        }
+        const controller = new AbortController();
+        const abort = () => controller.abort();
+        if (turnSignal.aborted) controller.abort();
+        else turnSignal.addEventListener("abort", abort, { once: true });
+        const state: RealtimeTurnState = {
+          turnId: normalizedTurnId,
+          archiveTurnId: randomUUID(),
+          controller,
+          terminal: {},
+          toolSet,
+          messages: [],
+          seenToolCallIds: new Set(),
+          invocationStarted: false,
+          closePromise: null,
+        };
+        turns.add(state);
+        this.#realtimeTurns.set(PET_ASSISTANT_CONVERSATION_ID, state);
+        this.#emit({ type: "lifecycle", sequence: 0, lifecycle: "opening", conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: normalizedTurnId });
+        const finish = (result: PetAssistantTurnResult): PetAssistantTurnResult => this.#finishRealtimeTurn(state, result, () => {
+          turnSignal.removeEventListener("abort", abort);
+          turns.delete(state);
+          if (this.#realtimeTurns.get(PET_ASSISTANT_CONVERSATION_ID) === state) this.#realtimeTurns.delete(PET_ASSISTANT_CONVERSATION_ID);
+        });
+        const turn: PetAssistantRealtimeTurn = {
+          turnId: normalizedTurnId,
+          recordTranscript: (role, text) => {
+            if (state.terminal.value || !this.#isCurrentRealtimeTurn(state) || text.trim() === "") return;
+            if (byteLength(text) > this.#limits.maxMessageBytes) throw new Error("Realtime transcript is too large.");
+            const message: PetAssistantMessage = deepFreeze({ role, content: text });
+            state.messages.push(message);
+            this.#emitTranscript(PET_ASSISTANT_CONVERSATION_ID, normalizedTurnId, message);
+          },
+          recordToolCall: (call) => {
+            if (state.terminal.value || !this.#isCurrentRealtimeTurn(state)) return;
+            if (!validateRealtimeToolCall(call, this.#limits, state.seenToolCallIds)) throw new Error("Realtime tool call is invalid.");
+            const message: PetAssistantMessage = deepFreeze({ role: "assistant", toolCalls: [cloneToolCall(call)] });
+            state.messages.push(message);
+            this.#emitTranscript(PET_ASSISTANT_CONVERSATION_ID, normalizedTurnId, message);
+            this.#emitActivity(PET_ASSISTANT_CONVERSATION_ID, normalizedTurnId, "acting", call.name);
+          },
+          executeToolCall: (call, callSignal) => {
+            if (state.terminal.value || !this.#isCurrentRealtimeTurn(state)) return Promise.resolve(deepFreeze({ status: "indeterminate", reason: "Capability result was not available." }));
+            if (!state.seenToolCallIds.has(call.id) && !validateRealtimeToolCall(call, this.#limits, state.seenToolCallIds)) {
+              return Promise.resolve(deepFreeze({ status: "rejected", reason: "Tool-call arguments are malformed." }));
+            }
+            const executionSignal = combineAbortSignals(state.controller.signal, callSignal);
+            const operation = this.#executeCall(toolSet, call, state, executionSignal)
+              .then((result) => {
+                if (state.terminal.value || !this.#isCurrentRealtimeTurn(state)) return deepFreeze({ status: "indeterminate", reason: "Capability result arrived after the turn ended." });
+                const message: PetAssistantMessage = deepFreeze({ role: "tool", toolCallId: call.id, name: call.name, result });
+                state.messages.push(message);
+                this.#emitTranscript(PET_ASSISTANT_CONVERSATION_ID, normalizedTurnId, message);
+                this.#emitActivity(PET_ASSISTANT_CONVERSATION_ID, normalizedTurnId, "thinking");
+                return result;
+              });
+            this.#realtimePromises.add(operation);
+            void operation.finally(() => this.#realtimePromises.delete(operation));
+            return operation;
+          },
+          complete: (response) => finish({ conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: normalizedTurnId, status: "completed", ...(response === undefined ? {} : { response }) }),
+          cancel: () => {
+            state.controller.abort();
+            if (!state.closePromise) state.closePromise = Promise.resolve(finish({ conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: normalizedTurnId, status: "cancelled", error: state.invocationStarted ? "Pet Assistant turn cancelled after capability invocation started." : cancelledError.message }));
+            return state.closePromise;
+          },
+        };
+        return turn;
+      },
+      close: async () => {
+        closed = true;
+        await Promise.all([...turns].map((turn) => {
+          turn.controller.abort();
+          if (turn.closePromise) return turn.closePromise;
+          const result = this.#finishRealtimeTurn(turn, { conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: turn.turnId, status: "cancelled", error: turn.invocationStarted ? "Pet Assistant turn cancelled after capability invocation started." : cancelledError.message }, () => {
+            turns.delete(turn);
+            if (this.#realtimeTurns.get(PET_ASSISTANT_CONVERSATION_ID) === turn) this.#realtimeTurns.delete(PET_ASSISTANT_CONVERSATION_ID);
+          });
+          turn.closePromise = Promise.resolve(result);
+          return turn.closePromise;
+        }));
+      },
+    };
+    return session;
   }
 
   clearConversation(conversationId: string): void {
@@ -287,7 +418,7 @@ export class PetAssistantService {
     }
   }
 
-  async #executeCall(toolSet: PetAssistantToolSet, call: PetAssistantToolCall, active: ActiveTurn, signal: AbortSignal): Promise<PetAssistantToolResult> {
+  async #executeCall(toolSet: PetAssistantToolSet, call: PetAssistantToolCall, active: CapabilityExecutionState, signal: AbortSignal): Promise<PetAssistantToolResult> {
     const target = toolSet.targetsByName.get(call.name);
     if (!target) return deepFreeze({ status: "unavailable", reason: "Capability is unavailable." });
     if (!isPlainObject(call.arguments)) return deepFreeze({ status: "rejected", reason: "Capability arguments must be an object." });
@@ -314,6 +445,27 @@ export class PetAssistantService {
       active.activeToolName = undefined;
       active.activeCall = undefined;
     }
+  }
+
+  #finishRealtimeTurn(state: RealtimeTurnState, result: PetAssistantTurnResult, cleanup: () => void): PetAssistantTurnResult {
+    if (state.terminal.value) return state.terminal.value;
+    const outcomes = state.messages
+      .filter((message): message is Extract<PetAssistantMessage, { readonly role: "tool" }> => message.role === "tool")
+      .map((message): PetAssistantToolOutcome => ({ id: message.toolCallId, name: message.name, result: message.result }));
+    const summary = summarizeCapabilityOutcomes(outcomes);
+    const terminalResult = outcomes.length > 0 ? { ...result, ...(summary === undefined ? {} : { response: summary }), toolOutcomes: outcomes } : result;
+    if (terminalResult.status === "completed" && state.messages.length > 0) this.#commit(PET_ASSISTANT_CONVERSATION_ID, state.archiveTurnId, state.messages);
+    this.#archiveTerminalText(PET_ASSISTANT_CONVERSATION_ID, state.archiveTurnId, terminalResult, state.messages);
+    state.terminal.value = freezeEvent(terminalResult);
+    if (result.status === "cancelled") this.#emitActivity(PET_ASSISTANT_CONVERSATION_ID, state.turnId, "cancelled", state.activeToolName);
+    this.#emit({ type: "lifecycle", sequence: 0, lifecycle: "idle", conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: state.turnId });
+    this.#emit({ type: "terminal", sequence: 0, result: state.terminal.value });
+    cleanup();
+    return state.terminal.value;
+  }
+
+  #isCurrentRealtimeTurn(state: RealtimeTurnState): boolean {
+    return !this.#stopped && this.#realtimeTurns.get(PET_ASSISTANT_CONVERSATION_ID) === state && !state.terminal.value;
   }
 
   #commit(conversationId: string, archiveTurnId: string, messages: readonly PetAssistantMessage[]): void {
@@ -523,6 +675,33 @@ function safeError(error: unknown): string {
 function validateTurnId(value: string): string {
   if (typeof value !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) throw new Error("Assistant turn id is invalid.");
   return value;
+}
+
+function validateRealtimeToolCall(call: PetAssistantToolCall, limits: PetAssistantLimits, seen: Set<string>): boolean {
+  if (!call || typeof call.id !== "string" || call.id.trim() === "" || seen.has(call.id) || byteLength(call.id) > limits.maxToolCallIdBytes) return false;
+  if (typeof call.name !== "string" || call.name.trim() === "" || byteLength(call.name) > limits.maxToolNameBytes) return false;
+  if (!isStrictJsonValue(call.arguments) || !isPlainObject(call.arguments)) return false;
+  try {
+    if (jsonByteLength(call.arguments) > limits.maxMessageBytes) return false;
+  } catch {
+    return false;
+  }
+  seen.add(call.id);
+  return true;
+}
+
+function cloneToolCall(call: PetAssistantToolCall): PetAssistantToolCall {
+  return deepFreeze({ id: call.id, name: call.name, arguments: cloneAndFreeze(call.arguments) });
+}
+
+function combineAbortSignals(...signals: readonly AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  for (const signal of signals) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", abort, { once: true });
+  }
+  return controller.signal;
 }
 
 function deepFreeze<T>(value: T): T {

--- a/apps/desktop/src/pet-assistant-types.ts
+++ b/apps/desktop/src/pet-assistant-types.ts
@@ -121,6 +121,22 @@ export type PetAssistantTurnOptions = {
   readonly turnId?: string;
 };
 
+export type PetAssistantRealtimeSession = {
+  readonly tools: readonly PetAssistantTool[];
+  readonly instructions: string;
+  beginTurn(turnId: string, signal: AbortSignal): PetAssistantRealtimeTurn;
+  close(): Promise<void>;
+};
+
+export type PetAssistantRealtimeTurn = {
+  readonly turnId: string;
+  recordTranscript(role: "user" | "assistant", text: string): void;
+  recordToolCall(call: PetAssistantToolCall): void;
+  executeToolCall(call: PetAssistantToolCall, signal: AbortSignal): Promise<PetAssistantToolResult>;
+  complete(response?: string): PetAssistantTurnResult;
+  cancel(): Promise<PetAssistantTurnResult>;
+};
+
 export type PetAssistantTranscriptMessage = {
   readonly conversationId: string;
   readonly turnId: string;

--- a/apps/desktop/src/plugin-platform-settings.ts
+++ b/apps/desktop/src/plugin-platform-settings.ts
@@ -96,7 +96,7 @@ let settingsPath: string | null = null;
 let cached: PluginPlatformSettings = defaultPluginPlatformSettings;
 
 export const providerPresets = Object.freeze([
-  { id: "openai", label: "OpenAI", adapter: "openai-realtime" as const, model: "gpt-4o-mini", baseUrl: "https://api.openai.com/v1", credentialMode: "required" as const },
+  { id: "openai", label: "OpenAI", adapter: "openai-realtime" as const, model: "gpt-realtime-2.1", baseUrl: "https://api.openai.com/v1", credentialMode: "required" as const },
   { id: "anthropic", label: "Anthropic", adapter: "anthropic-text" as const, model: "claude-haiku-4-5-20251001", baseUrl: "https://api.anthropic.com", credentialMode: "required" as const },
   { id: "ollama", label: "Ollama", adapter: "openai-compatible-text" as const, model: "llama3.2", baseUrl: "http://127.0.0.1:11434/v1", credentialMode: "none" as const },
   { id: "lm-studio", label: "LM Studio", adapter: "openai-compatible-text" as const, model: "local-model", baseUrl: "http://127.0.0.1:1234/v1", credentialMode: "none" as const },

--- a/apps/desktop/src/plugin-voice.ts
+++ b/apps/desktop/src/plugin-voice.ts
@@ -1,8 +1,6 @@
 import { getDefaultPetWindowForPlugins } from "./default-pet-controller.js";
 import { playPetWindowTtsAudio, speakPetWindowTts, stopPetWindowTts, stopPetWindowTtsAudio } from "./pet-window.js";
 import type { PluginAiGateway } from "./plugin-ai-gateway.js";
-import { VoiceConversationService, type VoiceConversationSnapshot, type VoiceRealtimeSessionConfig } from "./voice-conversation.js";
-import { createElectronVoiceRealtimeTransportFactory } from "./voice-realtime-electron.js";
 import { createElectronVoiceCaptureFactory } from "./voice-capture-electron.js";
 import { createElectronVoicePrivacyIndicator } from "./voice-privacy-indicator-electron.js";
 import type { VoiceCaptureService } from "./voice-capture.js";
@@ -48,8 +46,6 @@ export function pluginVoiceStop(): void {
 
 let activeListeningService: VoiceListeningService | null = null;
 let activePluginId: string | undefined;
-let conversationService: VoiceConversationService | null = null;
-let conversationStartReservation: symbol | null = null;
 const voiceResources = new VoiceResourceOwner({ captureFactory: createElectronVoiceCaptureFactory(), privacyIndicatorFactory: createElectronVoicePrivacyIndicator });
 const voiceOperationState = new VoiceOperationState();
 let pluginVoiceShutdownPromise: Promise<void> | null = null;
@@ -69,6 +65,10 @@ export function getSharedVoiceMicrophoneArbiter(): VoiceMicrophoneArbiter {
 
 export function getSharedVoiceCaptureService(): VoiceCaptureService {
   return voiceResources.capture();
+}
+
+export function getSharedVoicePrivacyIndicator() {
+  return voiceResources.privacyIndicator;
 }
 
 export async function pluginVoiceListen(gateway: PluginAiGateway, opts: { timeoutMs: number; pluginId?: string }): Promise<{ text: string }> {
@@ -103,57 +103,14 @@ export async function cancelPluginVoiceListen(pluginId?: string, reason = "Voice
   await activeListeningService.cancel(reason).catch(() => undefined);
 }
 
-/** Host-private realtime foundation; intentionally not wired into the plugin SDK. */
-export async function startPluginVoiceConversation(gateway: PluginAiGateway): Promise<VoiceConversationSnapshot> {
-  if (conversationStartReservation || conversationService?.snapshot().phase !== "idle") throw new Error("A realtime voice conversation is already in progress.");
-  const reservation = Symbol("plugin-voice-conversation");
-  conversationStartReservation = reservation;
-  try {
-    const negotiator = await gateway.beginRealtimeOperation();
-    if (conversationStartReservation !== reservation) throw new Error("Voice conversation startup was cancelled.");
-    const service = createConversationService(negotiator);
-    conversationService = service;
-    return await service.start();
-  } finally {
-    if (conversationStartReservation === reservation) conversationStartReservation = null;
-  }
-}
-
-export function getPluginVoiceConversationSnapshot(): VoiceConversationSnapshot | null {
-  return conversationService?.snapshot() ?? null;
-}
-
-export async function closePluginVoiceConversation(): Promise<void> {
-  await conversationService?.close();
-}
-
-export async function mutePluginVoiceConversation(): Promise<void> {
-  await conversationService?.mute();
-}
-
-export async function unmutePluginVoiceConversation(): Promise<void> {
-  await conversationService?.unmute();
-}
-
 export function shutdownPluginVoice(): Promise<void> {
   if (pluginVoiceShutdownPromise) return pluginVoiceShutdownPromise;
   pluginVoiceShutdownPromise = (async () => {
-    conversationStartReservation = null;
     voiceOperationState.cancelReservation();
-    if (conversationService) await conversationService.shutdown().catch(() => undefined);
     if (activeListeningService) await activeListeningService.shutdown().catch(() => undefined);
     await voiceResources.shutdown();
-    conversationService = null;
     activeListeningService = null;
     activePluginId = undefined;
   })();
   return pluginVoiceShutdownPromise;
-}
-
-function createConversationService(negotiator: (sdp: string, session: VoiceRealtimeSessionConfig, signal?: AbortSignal) => Promise<string>): VoiceConversationService {
-  return new VoiceConversationService({
-    microphoneArbiter: voiceResources.microphoneArbiter,
-    privacyIndicator: voiceResources.privacyIndicator,
-    transportFactory: createElectronVoiceRealtimeTransportFactory({ negotiate: negotiator }),
-  });
 }

--- a/apps/desktop/src/voice-assistant-host-core.ts
+++ b/apps/desktop/src/voice-assistant-host-core.ts
@@ -1,15 +1,14 @@
 import type { PetAssistantService } from "./pet-assistant-service.js";
 import type { HostProviderOperations } from "./provider-service.js";
-import type { VoiceAssistantInput, VoiceAssistantInputOptions, VoiceAssistantInputResult, VoiceAssistantSpeech, VoiceAssistantSynthesizer, VoiceAssistantTurnAdapter, VoiceAssistantTurnResult } from "./voice-assistant-session.js";
+import type { VoiceAssistantInput, VoiceAssistantInputOptions, VoiceAssistantInputResult, VoiceAssistantSpeech, VoiceAssistantSessionLike, VoiceAssistantSynthesizer, VoiceAssistantTurnAdapter, VoiceAssistantTurnResult } from "./voice-assistant-session.js";
 import type { VoiceCaptureService } from "./voice-capture.js";
 import { VoiceListeningService } from "./voice-listening-service.js";
-import { VoiceAssistantSession } from "./voice-assistant-session.js";
 import type { VoiceAssistantSessionEvent } from "./voice-assistant-session.js";
 
 const HOST_RECORDING_DURATION_MS = 10_000;
 
 export type VoiceAssistantHostInstance = {
-  readonly session: VoiceAssistantSession;
+  readonly session: VoiceAssistantSessionLike;
   readonly sessionId?: number;
   shutdown(): Promise<void>;
 };
@@ -29,7 +28,7 @@ export class VoiceAssistantHostController {
     this.#create = create;
   }
 
-  get session(): VoiceAssistantSession | null { return this.#active?.session ?? null; }
+  get session(): VoiceAssistantSessionLike | null { return this.#active?.session ?? null; }
 
   subscribe(listener: (event: VoiceAssistantHostEvent) => void): () => void {
     this.#listeners.add(listener);
@@ -37,7 +36,7 @@ export class VoiceAssistantHostController {
     return () => { this.#listeners.delete(listener); };
   }
 
-  activate(): Promise<VoiceAssistantSession> {
+  activate(): Promise<VoiceAssistantSessionLike> {
     if (this.#stopped) return Promise.reject(new Error("Voice assistant host has stopped."));
     const next = this.#transition.then(async () => {
       if (this.#stopped) throw new Error("Voice assistant host has stopped.");
@@ -65,7 +64,7 @@ export class VoiceAssistantHostController {
     return next;
   }
 
-  toggle(): Promise<VoiceAssistantSession | null> {
+  toggle(): Promise<VoiceAssistantSessionLike | null> {
     if (this.#stopped) return Promise.reject(new Error("Voice assistant host has stopped."));
     const next = this.#transition.then(async () => {
       if (this.#stopped) throw new Error("Voice assistant host has stopped.");

--- a/apps/desktop/src/voice-assistant-host.ts
+++ b/apps/desktop/src/voice-assistant-host.ts
@@ -18,6 +18,10 @@ import type { PetAssistantModalityCoordinator } from "./pet-assistant-modality.j
 import { getVoiceAssistantShortcutSnapshot } from "./voice-assistant-shortcut.js";
 import type { VoiceAssistantShortcutSnapshot } from "./voice-assistant-shortcut.js";
 import { shutdownVoiceAssistantResources, shutdownVoiceAssistantWithCleanup } from "./voice-assistant-host-cleanup.js";
+import { getPluginPlatformSettings } from "./plugin-platform-settings.js";
+import { createElectronVoiceRealtimeTransportFactory } from "./voice-realtime-electron.js";
+import { OpenAIRealtimeVoiceAssistantSession } from "./voice-realtime-assistant.js";
+import { getSharedVoicePrivacyIndicator } from "./plugin-voice.js";
 
 export type VoiceAssistantHostOptions = {
   readonly sessionId: number;
@@ -47,7 +51,7 @@ export type VoiceAssistantTalkEvent = (Exclude<VoiceAssistantHostEvent, { readon
 export class VoiceAssistantHost {
   readonly sessionId: number;
   readonly #player: PetWindowVoicePlayer;
-  readonly #session: VoiceAssistantSession;
+  readonly #session: import("./voice-assistant-session.js").VoiceAssistantSessionLike;
   readonly #unsubscribeSession: () => void;
   readonly #feedbackReducer?: PetAssistantFeedbackReducer;
   readonly #conversationController = getPetAssistantConversationController();
@@ -59,16 +63,30 @@ export class VoiceAssistantHost {
     const adapter = new PetAssistantVoiceAdapter(options.assistant);
     const synthesizer = new ProviderVoiceSynthesizer(options.provider);
     this.#player = new PetWindowVoicePlayer();
-    this.#session = new VoiceAssistantSession({
-      conversationId: PET_ASSISTANT_CONVERSATION_ID,
-      turnIdPrefix: `voice-session-${options.sessionId}`,
-      microphoneArbiter: options.microphoneArbiter ?? getSharedVoiceMicrophoneArbiter(),
-      input,
-      assistant: adapter,
-      synthesizer,
-      player: this.#player,
-      modalityCoordinator: options.modalityCoordinator ?? getPetAssistantModalityCoordinator(),
-    });
+    const microphoneArbiter = options.microphoneArbiter ?? getSharedVoiceMicrophoneArbiter();
+    const modalityCoordinator = options.modalityCoordinator ?? getPetAssistantModalityCoordinator();
+    this.#session = isNativeRealtimeSelected()
+      ? new OpenAIRealtimeVoiceAssistantSession({
+        provider: options.provider,
+        assistant: options.assistant,
+        microphoneArbiter,
+        privacyIndicator: getSharedVoicePrivacyIndicator(),
+        modalityCoordinator,
+        transportFactory: (provider) => createElectronVoiceRealtimeTransportFactory({
+          negotiate: (sdp, session, signal) => options.provider.negotiateRealtime(provider, sdp, session, signal),
+        }),
+        turnIdPrefix: `voice-session-${options.sessionId}`,
+      })
+      : new VoiceAssistantSession({
+        conversationId: PET_ASSISTANT_CONVERSATION_ID,
+        turnIdPrefix: `voice-session-${options.sessionId}`,
+        microphoneArbiter,
+        input,
+        assistant: adapter,
+        synthesizer,
+        player: this.#player,
+        modalityCoordinator,
+      });
     this.#unsubscribeSession = this.#session.subscribe((event) => {
       this.#feedbackReducer?.applyVoiceEvent(event);
       if (event.type === "transcript") {
@@ -86,7 +104,7 @@ export class VoiceAssistantHost {
     });
   }
 
-  get session(): VoiceAssistantSession { return this.#session; }
+  get session(): import("./voice-assistant-session.js").VoiceAssistantSessionLike { return this.#session; }
 
   async shutdown(): Promise<void> {
     await shutdownVoiceAssistantResources(
@@ -120,6 +138,12 @@ export function startVoiceAssistantHost(provider: HostProviderOperations, assist
   for (const listener of voiceEventListeners) voiceEventUnsubscribers.set(listener, activeHost.subscribe((event) => listener(addShortcutToEvent(event))));
   info("app", "Voice assistant host ready");
   return activeHost;
+}
+
+function isNativeRealtimeSelected(): boolean {
+  const settings = getPluginPlatformSettings();
+  const selected = settings.selections.text;
+  return selected !== null && settings.profiles[selected]?.adapter === "openai-realtime";
 }
 
 export function stopVoiceAssistantHost(): Promise<void> {

--- a/apps/desktop/src/voice-assistant-session.ts
+++ b/apps/desktop/src/voice-assistant-session.ts
@@ -35,7 +35,7 @@ export type VoiceAssistantSessionEvent =
   | { readonly type: "turn-settled"; readonly sequence: number; readonly turnId: string; readonly outcome: "completed" | "cancelled" | "failed" }
   | { readonly type: "ended"; readonly sequence: number; readonly reason: "ended" | "shutdown" };
 
-type VoiceAssistantSessionEventInput =
+export type VoiceAssistantSessionEventInput =
   | { readonly type: "snapshot"; readonly snapshot: VoiceAssistantSessionSnapshot }
   | Omit<VoiceAssistantTranscriptEvent, "sequence">
   | { readonly type: "error"; readonly scope: VoiceAssistantErrorScope; readonly message: string; readonly turnId?: string }
@@ -44,6 +44,18 @@ type VoiceAssistantSessionEventInput =
   | { readonly type: "ended"; readonly reason: "ended" | "shutdown" };
 
 export type VoiceAssistantSessionListener = (event: VoiceAssistantSessionEvent) => void;
+
+export interface VoiceAssistantSessionLike {
+  snapshot(): VoiceAssistantSessionSnapshot;
+  subscribe(listener: VoiceAssistantSessionListener): () => void;
+  start(): Promise<void>;
+  retry(): Promise<void>;
+  mute(): Promise<void>;
+  unmute(): Promise<void>;
+  interrupt(): Promise<void>;
+  end(): Promise<void>;
+  shutdown(): Promise<void>;
+}
 
 export type VoiceAssistantInputResult =
   | { readonly status: "completed"; readonly final: string }
@@ -137,7 +149,7 @@ type SpeechStage = {
 const DEFAULT_CONVERSATION_ID = "voice-assistant";
 
 /** Host-private batch voice session. No provider wire event crosses this boundary. */
-export class VoiceAssistantSession {
+export class VoiceAssistantSession implements VoiceAssistantSessionLike {
   readonly #options: VoiceAssistantSessionOptions;
   readonly #conversationId: string;
   readonly #turnIdPrefix: string;

--- a/apps/desktop/src/voice-conversation.ts
+++ b/apps/desktop/src/voice-conversation.ts
@@ -41,15 +41,15 @@ export type VoiceConversationEvent =
   | { readonly type: "microphone-released" }
   | { readonly type: "negotiating" }
   | { readonly type: "connected" }
-  | { readonly type: "speech-started" }
-  | { readonly type: "speech-stopped" }
-  | { readonly type: "response-started" }
-  | { readonly type: "response-audio-started" }
-  | { readonly type: "response-audio-stopped" }
-  | { readonly type: "response-completed" }
-  | { readonly type: "transcript"; readonly entryId: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string }
-  | { readonly type: "tool-call"; readonly callId: string; readonly name: string; readonly arguments: string }
-  | { readonly type: "interrupted" }
+  | { readonly type: "speech-started"; readonly itemId: string }
+  | { readonly type: "speech-stopped"; readonly itemId: string }
+  | { readonly type: "response-started"; readonly responseId: string }
+  | { readonly type: "response-audio-started"; readonly responseId: string }
+  | { readonly type: "response-audio-stopped"; readonly responseId: string }
+  | { readonly type: "response-completed"; readonly responseId: string }
+  | { readonly type: "transcript"; readonly entryId: string; readonly itemId: string; readonly responseId?: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string }
+  | { readonly type: "tool-call"; readonly callId: string; readonly itemId: string; readonly responseId: string; readonly name: string; readonly arguments: string }
+  | { readonly type: "interrupted"; readonly responseId?: string; readonly itemId?: string }
   | { readonly type: "error"; readonly error: unknown }
   | { readonly type: "closed"; readonly reason?: string };
 

--- a/apps/desktop/src/voice-conversation.ts
+++ b/apps/desktop/src/voice-conversation.ts
@@ -1,17 +1,25 @@
 import type { VoiceMicrophoneArbiter, VoiceMicrophoneLease } from "./voice-microphone-arbiter.js";
 import type { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
+import type { PetAssistantToolResult } from "./pet-assistant-types.js";
 
 export const VOICE_REALTIME_MODEL = "gpt-realtime-2.1";
 
 export type VoiceRealtimeSessionConfig = Readonly<Record<string, unknown>>;
 
-export function createDefaultVoiceRealtimeSessionConfig(): VoiceRealtimeSessionConfig {
+export type VoiceRealtimeToolResultCommand = {
+  readonly callId: string;
+  readonly result: PetAssistantToolResult;
+};
+
+export function createDefaultVoiceRealtimeSessionConfig(model = VOICE_REALTIME_MODEL): VoiceRealtimeSessionConfig {
   return {
     type: "realtime",
-    model: VOICE_REALTIME_MODEL,
+    model,
+    instructions: "You are the OpenPets Pet Assistant.",
     output_modalities: ["audio"],
     audio: {
       input: {
+        transcription: { model: "gpt-realtime-whisper" },
         turn_detection: {
           type: "server_vad",
           create_response: true,
@@ -39,6 +47,8 @@ export type VoiceConversationEvent =
   | { readonly type: "response-audio-started" }
   | { readonly type: "response-audio-stopped" }
   | { readonly type: "response-completed" }
+  | { readonly type: "transcript"; readonly entryId: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string }
+  | { readonly type: "tool-call"; readonly callId: string; readonly name: string; readonly arguments: string }
   | { readonly type: "interrupted" }
   | { readonly type: "error"; readonly error: unknown }
   | { readonly type: "closed"; readonly reason?: string };
@@ -55,6 +65,7 @@ export type VoiceConversationSnapshot = {
 
 export type VoiceConversationTransportContext = {
   readonly sessionId: string;
+  readonly generation: number;
   readonly session: VoiceRealtimeSessionConfig;
   readonly signal: AbortSignal;
   readonly emit: (event: VoiceConversationEvent) => void;
@@ -64,6 +75,7 @@ export interface VoiceConversationTransport {
   start(): Promise<void>;
   setMuted(muted: boolean): void | Promise<void>;
   close(): Promise<void>;
+  sendToolResult?(command: VoiceRealtimeToolResultCommand): void | Promise<void>;
 }
 
 export type VoiceConversationTransportFactory = (context: VoiceConversationTransportContext) => VoiceConversationTransport;
@@ -73,6 +85,7 @@ export type VoiceConversationServiceOptions = {
   readonly privacyIndicator: VoicePrivacyIndicator;
   readonly transportFactory: VoiceConversationTransportFactory;
   readonly sessionFactory?: () => VoiceRealtimeSessionConfig;
+  readonly onEvent?: (event: VoiceConversationEvent) => void;
 };
 
 export class VoiceConversationCancelledError extends Error {
@@ -111,6 +124,7 @@ export class VoiceConversationService {
   readonly #privacyIndicator: VoicePrivacyIndicator;
   readonly #transportFactory: VoiceConversationTransportFactory;
   readonly #sessionFactory: () => VoiceRealtimeSessionConfig;
+  readonly #onEvent?: (event: VoiceConversationEvent) => void;
   #active: ActiveConversation | null = null;
   #nextGeneration = 0;
   #lastError: Error | null = null;
@@ -122,6 +136,7 @@ export class VoiceConversationService {
     this.#privacyIndicator = options.privacyIndicator;
     this.#transportFactory = options.transportFactory;
     this.#sessionFactory = options.sessionFactory ?? createDefaultVoiceRealtimeSessionConfig;
+    this.#onEvent = options.onEvent;
   }
 
   snapshot(): VoiceConversationSnapshot {
@@ -161,6 +176,7 @@ export class VoiceConversationService {
     try {
       active.transport = this.#transportFactory({
         sessionId: active.sessionId,
+        generation: active.generation,
         session: this.#sessionFactory(),
         signal: active.controller.signal,
         emit: (event) => this.#handleEvent(active, event),
@@ -202,6 +218,13 @@ export class VoiceConversationService {
 
   async unmute(): Promise<void> {
     await this.#setMuted(false);
+  }
+
+  async sendToolResult(command: VoiceRealtimeToolResultCommand): Promise<boolean> {
+    const active = this.#active;
+    if (!active || active.closing || !active.transport?.sendToolResult || !this.#isCurrent(active)) return false;
+    await active.transport.sendToolResult(command);
+    return this.#isCurrent(active) && !active.closing;
   }
 
   async shutdown(): Promise<void> {
@@ -247,6 +270,7 @@ export class VoiceConversationService {
 
   #handleEvent(active: ActiveConversation, event: VoiceConversationEvent): void {
     if (!this.#isCurrent(active) || active.closing) return;
+    try { this.#onEvent?.(event); } catch (error) { this.#lastError = normalizeError(error); }
     switch (event.type) {
       case "microphone-acquired":
         if (!active.indicatorLive) {

--- a/apps/desktop/src/voice-realtime-assistant.ts
+++ b/apps/desktop/src/voice-realtime-assistant.ts
@@ -1,0 +1,320 @@
+import type { PetAssistantService } from "./pet-assistant-service.js";
+import type { PetAssistantRealtimeSession, PetAssistantRealtimeTurn, PetAssistantToolCall } from "./pet-assistant-types.js";
+import { PET_ASSISTANT_CONVERSATION_ID } from "./pet-assistant-conversation.js";
+import type { PetAssistantModalityCoordinator, PetAssistantModalityLease } from "./pet-assistant-modality.js";
+import type { HostProviderOperations, ProviderOperationSnapshot } from "./provider-service.js";
+import { VoiceConversationService, type VoiceConversationEvent, type VoiceConversationTransportFactory, type VoiceRealtimeSessionConfig } from "./voice-conversation.js";
+import type { VoiceMicrophoneArbiter } from "./voice-microphone-arbiter.js";
+import type { VoicePrivacyIndicator } from "./voice-privacy-indicator.js";
+import type { VoiceAssistantSessionEvent, VoiceAssistantSessionEventInput, VoiceAssistantSessionListener, VoiceAssistantSessionSnapshot, VoiceAssistantSessionLike } from "./voice-assistant-session.js";
+
+export type RealtimeVoiceSessionOptions = {
+  readonly provider: HostProviderOperations;
+  readonly assistant: PetAssistantService;
+  readonly microphoneArbiter: VoiceMicrophoneArbiter;
+  readonly privacyIndicator: VoicePrivacyIndicator;
+  readonly modalityCoordinator: PetAssistantModalityCoordinator;
+  readonly transportFactory: (provider: ProviderOperationSnapshot) => VoiceConversationTransportFactory;
+  readonly turnIdPrefix?: string;
+};
+
+export function buildOpenAIRealtimeSessionConfig(model: string, realtime: Pick<PetAssistantRealtimeSession, "tools" | "instructions">): VoiceRealtimeSessionConfig {
+  const tools = realtime.tools.map((tool) => ({ type: "function", name: tool.name, description: tool.description, parameters: tool.inputSchema }));
+  return Object.freeze({
+    type: "realtime",
+    model,
+    instructions: realtime.instructions,
+    output_modalities: ["audio"],
+    audio: {
+      input: {
+        transcription: { model: "gpt-realtime-whisper" },
+        turn_detection: { type: "server_vad", create_response: true, interrupt_response: true },
+      },
+      output: {},
+    },
+    tools: Object.freeze(tools),
+    tool_choice: tools.length === 0 ? "none" : "auto",
+  });
+}
+
+/** Native Realtime session that shares the Talk surface and canonical assistant authority. */
+export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessionLike {
+  readonly #options: RealtimeVoiceSessionOptions;
+  readonly #listeners = new Set<VoiceAssistantSessionListener>();
+  readonly #turnIdPrefix: string;
+  #snapshot: VoiceAssistantSessionSnapshot;
+  #conversation: VoiceConversationService | null = null;
+  #realtime: PetAssistantRealtimeSession | null = null;
+  #turn: PetAssistantRealtimeTurn | null = null;
+  #turnController: AbortController | null = null;
+  #modalityLease: PetAssistantModalityLease | null = null;
+  #sessionController: AbortController | null = null;
+  #startPromise: Promise<void> | null = null;
+  #endPromise: Promise<void> | null = null;
+  #ended = false;
+  #muted = false;
+  #generation = 0;
+  #sequence = 1;
+  #turnOrdinal = 0;
+  #lastAssistantTranscript: string | undefined;
+  #interruptionCount = 0;
+  #toolCalls = new Set<string>();
+  #pendingToolCalls = 0;
+  #responseCompleted = false;
+  #hasToolCall = false;
+  #awaitingToolFollowup = false;
+
+  constructor(options: RealtimeVoiceSessionOptions) {
+    this.#options = options;
+    this.#turnIdPrefix = options.turnIdPrefix ?? "realtime-turn";
+    this.#snapshot = freeze({ status: "idle", activity: null, muted: false, conversationId: PET_ASSISTANT_CONVERSATION_ID, generation: 0, turnId: null, userTranscript: null, assistantTranscript: null, interruptionCount: 0, error: null });
+  }
+
+  snapshot(): VoiceAssistantSessionSnapshot { return this.#snapshot; }
+
+  subscribe(listener: VoiceAssistantSessionListener): () => void {
+    this.#listeners.add(listener);
+    return () => { this.#listeners.delete(listener); };
+  }
+
+  async start(): Promise<void> {
+    if (this.#startPromise) return this.#startPromise;
+    if (this.#ended) throw new Error("Voice assistant session has ended.");
+    this.#startPromise = this.#startInternal();
+    try { await this.#startPromise; } finally { this.#startPromise = null; }
+  }
+
+  async retry(): Promise<void> {
+    if (this.#ended) throw new Error("Voice assistant session has ended.");
+    if (this.#snapshot.status === "paused") await this.start();
+  }
+
+  async mute(): Promise<void> {
+    if (!this.#conversation || this.#ended) throw new Error("Voice assistant session is not active.");
+    if (this.#muted) return;
+    this.#muted = true;
+    await this.#conversation.mute();
+    this.#setSnapshot({ status: "muted", muted: true, activity: null });
+  }
+
+  async unmute(): Promise<void> {
+    if (!this.#conversation || this.#ended) throw new Error("Voice assistant session is not active.");
+    if (!this.#muted) return;
+    this.#muted = false;
+    await this.#conversation.unmute();
+    this.#setSnapshot({ status: "active", muted: false, activity: "listening" });
+  }
+
+  async interrupt(): Promise<void> {
+    if (this.#ended) return;
+    this.#interruptionCount += 1;
+    await this.#cancelTurn("Realtime response was interrupted.");
+    this.#setSnapshot({ status: this.#muted ? "muted" : "active", activity: this.#muted ? null : "listening", interruptionCount: this.#interruptionCount });
+    this.#emit({ type: "interrupted", generation: this.#generation, turnId: this.#snapshot.turnId });
+  }
+
+  async end(): Promise<void> { await this.#end("ended"); }
+  async shutdown(): Promise<void> { await this.#end("shutdown"); }
+
+  async #startInternal(): Promise<void> {
+    const lease = this.#options.modalityCoordinator.acquire("voice");
+    this.#modalityLease = lease;
+    this.#sessionController = new AbortController();
+    ++this.#generation;
+    try {
+      // Both snapshots are captured before WebRTC negotiation and remain fixed.
+      const provider = await this.#options.provider.snapshot("realtime");
+      const realtime = await this.#options.assistant.openRealtimeSession(this.#sessionController.signal);
+      this.#realtime = realtime;
+      const conversation = new VoiceConversationService({
+        microphoneArbiter: this.#options.microphoneArbiter,
+        privacyIndicator: this.#options.privacyIndicator,
+        sessionFactory: () => buildOpenAIRealtimeSessionConfig(provider.profile.model, realtime),
+        transportFactory: this.#options.transportFactory(provider),
+        onEvent: (event) => this.#handleConversationEvent(event),
+      });
+      this.#conversation = conversation;
+      await conversation.start();
+      this.#setSnapshot({ status: "active", activity: "listening", muted: false, error: null });
+    } catch (error) {
+      await this.#realtime?.close().catch(() => undefined);
+      await this.#conversation?.close().catch(() => undefined);
+      this.#realtime = null;
+      this.#conversation = null;
+      this.#sessionController = null;
+      this.#modalityLease?.release();
+      this.#modalityLease = null;
+      this.#setSnapshot({ status: "ended", activity: null, error: { scope: "session", message: errorMessage(error) } });
+      throw error;
+    }
+  }
+
+  #handleConversationEvent(event: VoiceConversationEvent): void {
+    if (this.#ended) return;
+    if (event.type === "speech-started") {
+      this.#setSnapshot({ status: this.#muted ? "muted" : "active", activity: this.#muted ? null : "listening" });
+      if (!this.#turn) this.#beginTurn();
+    } else if (event.type === "speech-stopped") {
+      this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
+    } else if (event.type === "response-started") {
+      this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
+    } else if (event.type === "response-audio-started") {
+      this.#setSnapshot({ activity: this.#muted ? null : "speaking" });
+    } else if (event.type === "response-audio-stopped") {
+      this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
+    } else if (event.type === "response-completed") {
+      this.#completeTurn();
+    } else if (event.type === "interrupted") {
+      void this.interrupt().catch(() => undefined);
+    } else if (event.type === "transcript") {
+      this.#handleTranscript(event);
+    } else if (event.type === "tool-call") {
+      void this.#handleToolCall(event).catch((error) => this.#fail(error));
+    } else if (event.type === "error" || event.type === "closed") {
+      this.#fail(event.type === "error" ? event.error : new Error(event.reason ?? "Realtime transport closed."));
+    }
+  }
+
+  #handleTranscript(event: Extract<VoiceConversationEvent, { readonly type: "transcript" }>): void {
+    const turn = this.#turn ?? this.#beginTurn();
+    const text = event.text.trim();
+    if (!text) return;
+    if (event.status === "final") turn.recordTranscript(event.speaker, text);
+    if (event.speaker === "user") this.#setSnapshot({ userTranscript: text, turnId: turn.turnId });
+    else {
+      this.#lastAssistantTranscript = text;
+      this.#setSnapshot({ assistantTranscript: text, turnId: turn.turnId });
+    }
+    this.#emit({ type: "transcript", turnId: turn.turnId, speaker: event.speaker, kind: event.status, text });
+  }
+
+  async #handleToolCall(event: Extract<VoiceConversationEvent, { readonly type: "tool-call" }>): Promise<void> {
+    const turn = this.#turn ?? this.#beginTurn();
+    if (this.#toolCalls.has(event.callId)) return;
+    this.#toolCalls.add(event.callId);
+    this.#hasToolCall = true;
+    this.#awaitingToolFollowup = false;
+    this.#pendingToolCalls += 1;
+    try {
+      let argumentsValue: unknown;
+      try { argumentsValue = JSON.parse(event.arguments); } catch { argumentsValue = undefined; }
+      const call: PetAssistantToolCall = { id: event.callId, name: event.name, arguments: argumentsValue };
+      if (!isPlainObject(argumentsValue)) {
+        await this.#conversation?.sendToolResult({ callId: event.callId, result: { status: "rejected", reason: "Capability arguments must be a strict JSON object." } });
+        return;
+      }
+      turn.recordToolCall(call);
+      this.#setSnapshot({ activity: this.#muted ? null : "acting", turnId: turn.turnId });
+      const result = await turn.executeToolCall(call, this.#turnController?.signal ?? this.#sessionController!.signal);
+      if (this.#turn === turn && !this.#ended) await this.#conversation?.sendToolResult({ callId: event.callId, result });
+    } finally {
+      this.#pendingToolCalls -= 1;
+      this.#completeTurnIfReady();
+    }
+  }
+
+  #beginTurn(): PetAssistantRealtimeTurn {
+    if (!this.#realtime || !this.#sessionController) throw new Error("Realtime assistant is not ready.");
+    if (this.#turn) return this.#turn;
+    this.#turnController = new AbortController();
+    const turn = this.#realtime.beginTurn(`${this.#turnIdPrefix}-${++this.#turnOrdinal}`, this.#turnController.signal);
+    this.#turn = turn;
+    this.#toolCalls = new Set();
+    this.#pendingToolCalls = 0;
+    this.#responseCompleted = false;
+    this.#hasToolCall = false;
+    this.#awaitingToolFollowup = false;
+    this.#setSnapshot({ turnId: turn.turnId, userTranscript: null, assistantTranscript: null });
+    return turn;
+  }
+
+  #completeTurn(): void {
+    this.#responseCompleted = true;
+    this.#completeTurnIfReady();
+  }
+
+  #completeTurnIfReady(): void {
+    const turn = this.#turn;
+    if (!turn || !this.#responseCompleted || this.#pendingToolCalls > 0) return;
+    if (this.#hasToolCall && !this.#awaitingToolFollowup) {
+      this.#awaitingToolFollowup = true;
+      this.#responseCompleted = false;
+      return;
+    }
+    const result = turn.complete(this.#lastAssistantTranscript);
+    this.#turn = null;
+    this.#turnController = null;
+    this.#lastAssistantTranscript = undefined;
+    this.#responseCompleted = false;
+    this.#emit({ type: "turn-settled", turnId: result.turnId, outcome: result.status });
+    this.#setSnapshot({ activity: this.#muted ? null : "listening", turnId: null });
+  }
+
+  async #cancelTurn(reason: string): Promise<void> {
+    const turn = this.#turn;
+    if (!turn) return;
+    this.#turnController?.abort();
+    const result = await turn.cancel();
+    this.#turn = null;
+    this.#turnController = null;
+    this.#lastAssistantTranscript = undefined;
+    this.#pendingToolCalls = 0;
+    this.#responseCompleted = false;
+    this.#hasToolCall = false;
+    this.#awaitingToolFollowup = false;
+    this.#emit({ type: "turn-settled", turnId: result.turnId, outcome: result.status });
+    void reason;
+  }
+
+  async #end(reason: "ended" | "shutdown"): Promise<void> {
+    if (this.#endPromise) return this.#endPromise;
+    if (this.#ended) return;
+    this.#endPromise = (async () => {
+      this.#ended = true;
+      this.#setSnapshot({ status: "ending", activity: null });
+      await this.#cancelTurn("Realtime session ended.").catch(() => undefined);
+      this.#sessionController?.abort();
+      await this.#conversation?.close().catch(() => undefined);
+      await this.#realtime?.close().catch(() => undefined);
+      this.#conversation = null;
+      this.#realtime = null;
+      this.#modalityLease?.release();
+      this.#modalityLease = null;
+      this.#setSnapshot({ status: "ended", activity: null });
+      this.#emit({ type: "ended", reason });
+    })();
+    await this.#endPromise;
+  }
+
+  #fail(error: unknown): void {
+    if (this.#ended) return;
+    this.#setSnapshot({ status: "paused", activity: null, error: { scope: "session", message: errorMessage(error) } });
+    void this.end().catch(() => undefined);
+  }
+
+  #setSnapshot(patch: Partial<VoiceAssistantSessionSnapshot>): void {
+    this.#snapshot = freeze({ ...this.#snapshot, ...patch, generation: this.#generation });
+    this.#emit({ type: "snapshot", snapshot: this.#snapshot });
+  }
+
+  #emit(event: VoiceAssistantSessionEventInput): void {
+    const immutable = freeze({ ...event, sequence: this.#sequence++ }) as VoiceAssistantSessionEvent;
+    for (const listener of [...this.#listeners]) {
+      try { listener(immutable); } catch { /* observers cannot affect cleanup */ }
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function errorMessage(error: unknown): string { return error instanceof Error && error.message ? error.message : String(error); }
+
+function freeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value as Record<string, unknown>)) freeze(child);
+  return Object.freeze(value);
+}

--- a/apps/desktop/src/voice-realtime-assistant.ts
+++ b/apps/desktop/src/voice-realtime-assistant.ts
@@ -63,6 +63,12 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
   #responseCompleted = false;
   #hasToolCall = false;
   #awaitingToolFollowup = false;
+  readonly #responseBindings = new Map<string, string>();
+  readonly #closedResponseIds = new Set<string>();
+  readonly #itemBindings = new Map<string, string>();
+  readonly #retiredItemIds = new Set<string>();
+  #activeResponseId: string | null = null;
+  #activeInputItemId: string | null = null;
 
   constructor(options: RealtimeVoiceSessionOptions) {
     this.#options = options;
@@ -152,19 +158,26 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
   #handleConversationEvent(event: VoiceConversationEvent): void {
     if (this.#ended) return;
     if (event.type === "speech-started") {
+      const turn = this.#bindInputItem(event.itemId);
+      if (!turn) return;
       this.#setSnapshot({ status: this.#muted ? "muted" : "active", activity: this.#muted ? null : "listening" });
-      if (!this.#turn) this.#beginTurn();
     } else if (event.type === "speech-stopped") {
+      if (!this.#isCurrentInputItem(event.itemId)) return;
       this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
     } else if (event.type === "response-started") {
+      if (!this.#bindResponse(event.responseId)) return;
       this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
     } else if (event.type === "response-audio-started") {
+      if (!this.#isCurrentResponse(event.responseId)) return;
       this.#setSnapshot({ activity: this.#muted ? null : "speaking" });
     } else if (event.type === "response-audio-stopped") {
+      if (!this.#isCurrentResponse(event.responseId)) return;
       this.#setSnapshot({ activity: this.#muted ? null : "thinking" });
     } else if (event.type === "response-completed") {
+      if (!this.#closeResponse(event.responseId)) return;
       this.#completeTurn();
     } else if (event.type === "interrupted") {
+      if (event.responseId && !this.#retireResponse(event.responseId)) return;
       void this.interrupt().catch(() => undefined);
     } else if (event.type === "transcript") {
       this.#handleTranscript(event);
@@ -176,7 +189,8 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
   }
 
   #handleTranscript(event: Extract<VoiceConversationEvent, { readonly type: "transcript" }>): void {
-    const turn = this.#turn ?? this.#beginTurn();
+    const turn = this.#resolveItemTurn(event.itemId, event.responseId);
+    if (!turn) return;
     const text = event.text.trim();
     if (!text) return;
     if (event.status === "final") turn.recordTranscript(event.speaker, text);
@@ -189,7 +203,8 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
   }
 
   async #handleToolCall(event: Extract<VoiceConversationEvent, { readonly type: "tool-call" }>): Promise<void> {
-    const turn = this.#turn ?? this.#beginTurn();
+    const turn = this.#resolveItemTurn(event.itemId, event.responseId);
+    if (!turn) return;
     if (this.#toolCalls.has(event.callId)) return;
     this.#toolCalls.add(event.callId);
     this.#hasToolCall = true;
@@ -228,6 +243,60 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
     return turn;
   }
 
+  #bindInputItem(itemId: string): PetAssistantRealtimeTurn | null {
+    const existingTurnId = this.#itemBindings.get(itemId);
+    if (existingTurnId && existingTurnId !== this.#turn?.turnId) return null;
+    if (this.#activeInputItemId === itemId) return this.#turn;
+    if (this.#activeInputItemId) this.#retiredItemIds.add(this.#activeInputItemId);
+    const turn = this.#turn ?? this.#beginTurn();
+    this.#itemBindings.set(itemId, turn.turnId);
+    this.#activeInputItemId = itemId;
+    return turn;
+  }
+
+  #bindResponse(responseId: string): PetAssistantRealtimeTurn | null {
+    if (this.#closedResponseIds.has(responseId)) return null;
+    const existingTurnId = this.#responseBindings.get(responseId);
+    if (existingTurnId) {
+      return existingTurnId === this.#turn?.turnId && this.#activeResponseId === responseId ? this.#turn : null;
+    }
+    const turn = this.#turn;
+    if (!turn || this.#activeResponseId) return null;
+    this.#responseBindings.set(responseId, turn.turnId);
+    this.#activeResponseId = responseId;
+    return turn;
+  }
+
+  #resolveItemTurn(itemId: string, responseId?: string): PetAssistantRealtimeTurn | null {
+    const turn = this.#turn;
+    if (!turn) return null;
+    if (responseId && !this.#isCurrentResponse(responseId)) return null;
+    if (this.#retiredItemIds.has(itemId)) return null;
+    const existingTurnId = this.#itemBindings.get(itemId);
+    if (existingTurnId && existingTurnId !== turn.turnId) return null;
+    this.#itemBindings.set(itemId, turn.turnId);
+    return turn;
+  }
+
+  #isCurrentInputItem(itemId: string): boolean {
+    return this.#activeInputItemId === itemId && this.#itemBindings.get(itemId) === this.#turn?.turnId;
+  }
+
+  #isCurrentResponse(responseId: string): boolean {
+    return this.#activeResponseId === responseId && this.#responseBindings.get(responseId) === this.#turn?.turnId && !this.#closedResponseIds.has(responseId);
+  }
+
+  #retireResponse(responseId: string): boolean {
+    if (!this.#isCurrentResponse(responseId)) return false;
+    this.#closedResponseIds.add(responseId);
+    this.#activeResponseId = null;
+    return true;
+  }
+
+  #closeResponse(responseId: string): boolean {
+    return this.#retireResponse(responseId);
+  }
+
   #completeTurn(): void {
     this.#responseCompleted = true;
     this.#completeTurnIfReady();
@@ -254,7 +323,6 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
     const turn = this.#turn;
     if (!turn) return;
     this.#turnController?.abort();
-    const result = await turn.cancel();
     this.#turn = null;
     this.#turnController = null;
     this.#lastAssistantTranscript = undefined;
@@ -262,7 +330,13 @@ export class OpenAIRealtimeVoiceAssistantSession implements VoiceAssistantSessio
     this.#responseCompleted = false;
     this.#hasToolCall = false;
     this.#awaitingToolFollowup = false;
+    if (this.#activeResponseId) this.#closedResponseIds.add(this.#activeResponseId);
+    this.#activeResponseId = null;
+    if (this.#activeInputItemId) this.#retiredItemIds.add(this.#activeInputItemId);
+    this.#activeInputItemId = null;
+    const result = await turn.cancel();
     this.#emit({ type: "turn-settled", turnId: result.turnId, outcome: result.status });
+    this.#setSnapshot({ turnId: null });
     void reason;
   }
 

--- a/apps/desktop/src/voice-realtime-electron.ts
+++ b/apps/desktop/src/voice-realtime-electron.ts
@@ -228,6 +228,23 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
       this.#context.emit({ type: "microphone-released" });
       return;
     }
+    if (type === "speech-started" || type === "speech-stopped") {
+      const itemId = normalizeProviderId(payload.itemId);
+      if (itemId) this.#context.emit({ type, itemId });
+      return;
+    }
+    if (type === "response-started" || type === "response-audio-started" || type === "response-audio-stopped" || type === "response-completed") {
+      const responseId = normalizeProviderId(payload.responseId);
+      if (responseId) this.#context.emit({ type, responseId });
+      return;
+    }
+    if (type === "interrupted") {
+      const responseId = payload.responseId === undefined ? undefined : normalizeProviderId(payload.responseId);
+      const itemId = payload.itemId === undefined ? undefined : normalizeProviderId(payload.itemId);
+      if ((payload.responseId !== undefined && !responseId) || (payload.itemId !== undefined && !itemId)) return;
+      this.#context.emit({ type, ...(responseId ? { responseId } : {}), ...(itemId ? { itemId } : {}) });
+      return;
+    }
     if (isConversationEvent(type)) this.#context.emit({ type } as VoiceConversationEvent);
   }
 
@@ -283,20 +300,33 @@ function isValidRendererEnvelope(value: unknown, sessionId: string, generation: 
   try { return Buffer.byteLength(JSON.stringify(value), "utf8") <= VOICE_REALTIME_MAX_EVENT_BYTES; } catch { return false; }
 }
 
-function normalizeToolCall(value: Record<string, unknown>): { readonly callId: string; readonly name: string; readonly arguments: string } | null {
+function normalizeToolCall(value: Record<string, unknown>): { readonly callId: string; readonly itemId: string; readonly responseId: string; readonly name: string; readonly arguments: string } | null {
+  const responseId = normalizeProviderId(value.responseId);
+  const itemId = normalizeProviderId(value.itemId);
+  if (!responseId || !itemId) return null;
   if (typeof value.callId !== "string" || value.callId.trim() === "" || Buffer.byteLength(value.callId, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES || !/^[A-Za-z0-9_-]+$/.test(value.callId)) return null;
   if (typeof value.name !== "string" || value.name.trim() === "" || Buffer.byteLength(value.name, "utf8") > VOICE_REALTIME_MAX_TOOL_NAME_BYTES || !/^[A-Za-z0-9_-]+$/.test(value.name)) return null;
   if (typeof value.arguments !== "string" || Buffer.byteLength(value.arguments, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) return null;
   if (!parseStrictJsonObject(value.arguments)) return null;
-  return { callId: value.callId, name: value.name, arguments: value.arguments };
+  return { callId: value.callId, itemId, responseId, name: value.name, arguments: value.arguments };
 }
 
-function normalizeTranscript(value: Record<string, unknown>): { readonly entryId: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string } | null {
+function normalizeTranscript(value: Record<string, unknown>): { readonly entryId: string; readonly itemId: string; readonly responseId?: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string } | null {
   if (typeof value.entryId !== "string" || value.entryId.trim() === "" || Buffer.byteLength(value.entryId, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES) return null;
+  const itemId = normalizeProviderId(value.itemId);
+  if (!itemId) return null;
+  const responseId = value.responseId === undefined ? undefined : normalizeProviderId(value.responseId);
+  if (value.responseId !== undefined && !responseId) return null;
   if (value.speaker !== "user" && value.speaker !== "assistant") return null;
   if (value.status !== "partial" && value.status !== "final") return null;
   if (typeof value.text !== "string" || value.text.trim() === "" || Buffer.byteLength(value.text, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) return null;
-  return { entryId: value.entryId, speaker: value.speaker, status: value.status, text: value.text };
+  if (value.speaker === "assistant" && !responseId) return null;
+  return { entryId: value.entryId, itemId, ...(responseId ? { responseId } : {}), speaker: value.speaker, status: value.status, text: value.text };
+}
+
+function normalizeProviderId(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim() === "" || Buffer.byteLength(value, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES || !/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  return value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/voice-realtime-electron.ts
+++ b/apps/desktop/src/voice-realtime-electron.ts
@@ -9,12 +9,15 @@ import type {
   VoiceConversationTransportContext,
   VoiceConversationTransportFactory,
   VoiceRealtimeSessionConfig,
+  VoiceRealtimeToolResultCommand,
 } from "./voice-conversation.js";
+import { createOpenAIRealtimeToolResultEvents, parseStrictJsonObject, VOICE_REALTIME_MAX_CALL_ID_BYTES, VOICE_REALTIME_MAX_EVENT_BYTES, VOICE_REALTIME_MAX_TOOL_NAME_BYTES } from "./voice-realtime-protocol.js";
 
 const VOICE_REALTIME_PARTITION_PREFIX = "openpets-voice-realtime-";
 const VOICE_REALTIME_COMMAND_CHANNEL = "openpets:voice-realtime-command";
 const VOICE_REALTIME_EVENT_CHANNEL = "openpets:voice-realtime-event";
 const VOICE_REALTIME_MAX_SDP_BYTES = 256 * 1024;
+export { VOICE_REALTIME_MAX_CALL_ID_BYTES, VOICE_REALTIME_MAX_EVENT_BYTES, VOICE_REALTIME_MAX_TOOL_NAME_BYTES } from "./voice-realtime-protocol.js";
 
 export const VOICE_REALTIME_RENDERER_CLOSE_TIMEOUT_MS = 500;
 
@@ -48,6 +51,8 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
   #desiredMuted = false;
   #closing = false;
   #closePromise: Promise<void> | null = null;
+  readonly #acceptedToolCalls = new Set<string>();
+  readonly #sentToolResults = new Set<string>();
 
   constructor(context: VoiceConversationTransportContext, options: ElectronVoiceRealtimeTransportOptions) {
     this.#context = context;
@@ -139,7 +144,7 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
     this.#closePromise = (async () => {
       try {
         if (this.#loaded && !this.#window.isDestroyed()) {
-          try { this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "close", sessionId: this.#context.sessionId }); } catch { /* renderer may already be gone */ }
+          try { this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "close", sessionId: this.#context.sessionId, generation: this.#context.generation }); } catch { /* renderer may already be gone */ }
           await Promise.race([this.#rendererClosed, delay(this.#options.rendererCloseTimeoutMs ?? VOICE_REALTIME_RENDERER_CLOSE_TIMEOUT_MS)]);
         }
       } finally {
@@ -151,12 +156,19 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
     await this.#closePromise;
   }
 
+  async sendToolResult(command: VoiceRealtimeToolResultCommand): Promise<void> {
+    if (this.#closing || this.#window.isDestroyed() || !this.#acceptedToolCalls.has(command.callId) || this.#sentToolResults.has(command.callId)) return;
+    const messages = createOpenAIRealtimeToolResultEvents(command.callId, command.result);
+    this.#sentToolResults.add(command.callId);
+    for (const message of messages) this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "provider-event", sessionId: this.#context.sessionId, generation: this.#context.generation, message });
+  }
+
   async #startInternal(): Promise<void> {
     try {
       await this.#window.loadFile(join(app.getAppPath(), "assets", "voice-realtime.html"));
       if (this.#closing || this.#context.signal.aborted) throw new Error("Voice realtime transport was cancelled.");
       this.#loaded = true;
-      this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "start", sessionId: this.#context.sessionId });
+       this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "start", sessionId: this.#context.sessionId, generation: this.#context.generation });
       await this.#startCompletion;
     } catch (error) {
       throw normalizeError(error);
@@ -164,7 +176,7 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
   }
 
   #handleRendererEvent(event: IpcMainEvent, payload: unknown): void {
-    if (event.sender !== this.#window.webContents || !isRecord(payload) || payload.sessionId !== this.#context.sessionId || this.#closing) return;
+    if (event.sender !== this.#window.webContents || !isValidRendererEnvelope(payload, this.#context.sessionId, this.#context.generation) || this.#closing) return;
     const type = payload.type;
     if (type === "microphone-acquired") {
       this.#microphoneReady = true;
@@ -182,6 +194,19 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
         return;
       }
       void this.#negotiate(payload.sdp);
+      return;
+    }
+    if (type === "tool-call") {
+      const call = normalizeToolCall(payload);
+      if (!call || this.#acceptedToolCalls.has(call.callId)) return;
+      this.#acceptedToolCalls.add(call.callId);
+      this.#context.emit({ type: "tool-call", ...call });
+      return;
+    }
+    if (type === "transcript") {
+      const transcript = normalizeTranscript(payload);
+      if (!transcript) return;
+      this.#context.emit({ type: "transcript", ...transcript });
       return;
     }
     if (type === "connected") {
@@ -212,7 +237,7 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
       const answer = await this.#options.negotiate(offer, this.#context.session, this.#context.signal);
       if (this.#closing || this.#context.signal.aborted) return;
       if (!isValidSdp(answer)) throw new Error("OpenAI realtime negotiation returned an invalid session description.");
-      this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "answer", sessionId: this.#context.sessionId, sdp: answer });
+       this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "answer", sessionId: this.#context.sessionId, generation: this.#context.generation, sdp: answer });
     } catch (error) {
       this.#fail(error);
     }
@@ -239,7 +264,7 @@ class ElectronVoiceRealtimeTransport implements VoiceConversationTransport {
 
   #sendMuteIfReady(): void {
     if (!this.#microphoneReady || this.#closing || this.#window.isDestroyed()) return;
-    this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "mute", sessionId: this.#context.sessionId, muted: this.#desiredMuted });
+    this.#window.webContents.send(VOICE_REALTIME_COMMAND_CHANNEL, { type: "mute", sessionId: this.#context.sessionId, generation: this.#context.generation, muted: this.#desiredMuted });
   }
 }
 
@@ -251,6 +276,27 @@ function isConversationEvent(value: unknown): value is Exclude<VoiceConversation
     || value === "response-audio-stopped"
     || value === "response-completed"
     || value === "interrupted";
+}
+
+function isValidRendererEnvelope(value: unknown, sessionId: string, generation: number): value is Record<string, unknown> {
+  if (!isRecord(value) || value.sessionId !== sessionId || value.generation !== generation || typeof value.type !== "string") return false;
+  try { return Buffer.byteLength(JSON.stringify(value), "utf8") <= VOICE_REALTIME_MAX_EVENT_BYTES; } catch { return false; }
+}
+
+function normalizeToolCall(value: Record<string, unknown>): { readonly callId: string; readonly name: string; readonly arguments: string } | null {
+  if (typeof value.callId !== "string" || value.callId.trim() === "" || Buffer.byteLength(value.callId, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES || !/^[A-Za-z0-9_-]+$/.test(value.callId)) return null;
+  if (typeof value.name !== "string" || value.name.trim() === "" || Buffer.byteLength(value.name, "utf8") > VOICE_REALTIME_MAX_TOOL_NAME_BYTES || !/^[A-Za-z0-9_-]+$/.test(value.name)) return null;
+  if (typeof value.arguments !== "string" || Buffer.byteLength(value.arguments, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) return null;
+  if (!parseStrictJsonObject(value.arguments)) return null;
+  return { callId: value.callId, name: value.name, arguments: value.arguments };
+}
+
+function normalizeTranscript(value: Record<string, unknown>): { readonly entryId: string; readonly speaker: "user" | "assistant"; readonly status: "partial" | "final"; readonly text: string } | null {
+  if (typeof value.entryId !== "string" || value.entryId.trim() === "" || Buffer.byteLength(value.entryId, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES) return null;
+  if (value.speaker !== "user" && value.speaker !== "assistant") return null;
+  if (value.status !== "partial" && value.status !== "final") return null;
+  if (typeof value.text !== "string" || value.text.trim() === "" || Buffer.byteLength(value.text, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) return null;
+  return { entryId: value.entryId, speaker: value.speaker, status: value.status, text: value.text };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/voice-realtime-protocol.ts
+++ b/apps/desktop/src/voice-realtime-protocol.ts
@@ -1,0 +1,28 @@
+import type { PetAssistantToolResult } from "./pet-assistant-types.js";
+
+export const VOICE_REALTIME_MAX_EVENT_BYTES = 64 * 1024;
+export const VOICE_REALTIME_MAX_CALL_ID_BYTES = 256;
+export const VOICE_REALTIME_MAX_TOOL_NAME_BYTES = 256;
+
+/** Provider wire encoding stays in this adapter-only module. */
+export function createOpenAIRealtimeToolResultEvents(callId: string, result: PetAssistantToolResult): readonly string[] {
+  if (!/^[A-Za-z0-9_-]+$/.test(callId) || Buffer.byteLength(callId, "utf8") > VOICE_REALTIME_MAX_CALL_ID_BYTES) throw new Error("Realtime tool call id is invalid.");
+  const output = JSON.stringify(result);
+  if (Buffer.byteLength(output, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) throw new Error("Realtime capability result is too large.");
+  return Object.freeze([
+    JSON.stringify({ type: "conversation.item.create", item: { type: "function_call_output", call_id: callId, output } }),
+    JSON.stringify({ type: "response.create" }),
+  ]);
+}
+
+export function parseStrictJsonObject(value: string): Record<string, unknown> | null {
+  if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > VOICE_REALTIME_MAX_EVENT_BYTES) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const prototype = Object.getPrototypeOf(parsed);
+    return prototype === Object.prototype || prototype === null ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/tests/voice-conversation.test.ts
+++ b/apps/desktop/tests/voice-conversation.test.ts
@@ -253,14 +253,14 @@ for (const failure of [
   const current = fixture({ autoConnect: true });
   await current.service.start();
   const transport = current.transports[0]!;
-  transport.emit({ type: "response-started" });
-  transport.emit({ type: "response-audio-started" });
-  transport.emit({ type: "speech-started" });
+  transport.emit({ type: "response-started", responseId: "response-1" });
+  transport.emit({ type: "response-audio-started", responseId: "response-1" });
+  transport.emit({ type: "speech-started", itemId: "item-1" });
   assert.equal(current.service.snapshot().activity, "user-speaking");
   assert.equal(current.service.snapshot().interruptionCount, 1);
-  transport.emit({ type: "speech-stopped" });
+  transport.emit({ type: "speech-stopped", itemId: "item-1" });
   assert.equal(current.service.snapshot().activity, "thinking");
-  transport.emit({ type: "response-completed" });
+  transport.emit({ type: "response-completed", responseId: "response-1" });
   assert.equal(current.service.snapshot().activity, "idle");
   await current.service.close();
 }
@@ -274,7 +274,7 @@ for (const failure of [
   assert.equal(transport.closeCount, 1);
   assert.equal(current.microphoneArbiter.activeOwner, null);
   assert.match(current.service.snapshot().error ?? "", /renderer crashed/);
-  transport.emit({ type: "response-audio-started" });
+  transport.emit({ type: "response-audio-started", responseId: "response-1" });
   assert.equal(current.service.snapshot().activity, "idle");
 }
 
@@ -288,7 +288,7 @@ for (const failure of [
   const newTransport = current.transports[1]!;
   assert.notEqual(current.transports[0]!.resources.windowAlive, newTransport.resources.windowAlive);
   assert.notEqual(current.transports[0], newTransport);
-  oldTransport.emit({ type: "response-audio-started" });
+  oldTransport.emit({ type: "response-audio-started", responseId: "response-1" });
   assert.equal(current.service.snapshot().activity, "idle");
   assert.equal(current.service.snapshot().generation, 2);
   await current.service.close();

--- a/apps/desktop/tests/voice-realtime-assistant.test.ts
+++ b/apps/desktop/tests/voice-realtime-assistant.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+
+import { PetAssistantConversationController, PET_ASSISTANT_CONVERSATION_ID } from "../src/pet-assistant-conversation.js";
+import { PetAssistantModalityCoordinator } from "../src/pet-assistant-modality.js";
+import { PetAssistantService } from "../src/pet-assistant-service.js";
+import { petAssistantToolName } from "../src/pet-assistant-tools.js";
+import type { PetAssistantCapabilityRuntime, PetAssistantGenerationHandle, PetAssistantTextModel } from "../src/pet-assistant-types.js";
+import type { HostProviderOperations, ProviderOperationSnapshot } from "../src/provider-service.js";
+import { VoiceMicrophoneArbiter } from "../src/voice-microphone-arbiter.js";
+import { VoicePrivacyIndicator, type VoicePrivacyIndicatorSurface } from "../src/voice-privacy-indicator.js";
+import { OpenAIRealtimeVoiceAssistantSession, buildOpenAIRealtimeSessionConfig } from "../src/voice-realtime-assistant.js";
+import { createOpenAIRealtimeToolResultEvents, parseStrictJsonObject } from "../src/voice-realtime-protocol.js";
+import type { VoiceConversationEvent, VoiceConversationTransport, VoiceConversationTransportContext } from "../src/voice-conversation.js";
+
+class Surface implements VoicePrivacyIndicatorSurface {
+  show(): void {}
+  hide(): void {}
+  destroy(): void {}
+}
+
+class Transport implements VoiceConversationTransport {
+  readonly context: VoiceConversationTransportContext;
+  readonly sent: string[] = [];
+  closeCount = 0;
+
+  constructor(context: VoiceConversationTransportContext) { this.context = context; }
+  async start(): Promise<void> {
+    this.context.emit({ type: "microphone-acquired" });
+    this.context.emit({ type: "negotiating" });
+    this.context.emit({ type: "connected" });
+  }
+  setMuted(): void {}
+  async close(): Promise<void> { this.closeCount += 1; }
+  async sendToolResult(command: { readonly callId: string; readonly result: unknown }): Promise<void> {
+    this.sent.push(JSON.stringify(command));
+  }
+  emit(event: VoiceConversationEvent): void { this.context.emit(event); }
+}
+
+const handle = { generation: 1 } as PetAssistantGenerationHandle;
+const capability = { pluginId: "focus.buddy", capability: { id: "start", description: "Start focus", inputSchema: { type: "object" } }, handle };
+const toolName = petAssistantToolName("focus.buddy", "start");
+
+function provider(): HostProviderOperations {
+  const snapshot: ProviderOperationSnapshot = { role: "realtime", profile: { id: "native", label: "Native", adapter: "openai-realtime", model: "gpt-realtime-2.1", baseUrl: "https://api.openai.com/v1" } };
+  return {
+    snapshot: async () => snapshot,
+    negotiateRealtime: async () => "v=0\r\no=answer",
+  } as unknown as HostProviderOperations;
+}
+
+function model(): PetAssistantTextModel { return { generate: async () => ({ type: "text", text: "unused" }) }; }
+
+async function flush(): Promise<void> {
+  for (let index = 0; index < 30; index += 1) await Promise.resolve();
+}
+
+function fixture(options: { readonly runtime?: PetAssistantCapabilityRuntime } = {}) {
+  const runtime = options.runtime ?? { snapshot: () => ({ capabilities: [capability] }), execute: async () => ({ ok: true, result: { started: true } }) };
+  const assistant = new PetAssistantService(model(), runtime);
+  const surface = new Surface();
+  const indicator = new VoicePrivacyIndicator(() => surface);
+  const transports: Transport[] = [];
+  const session = new OpenAIRealtimeVoiceAssistantSession({
+    provider: provider(),
+    assistant,
+    microphoneArbiter: new VoiceMicrophoneArbiter(),
+    privacyIndicator: indicator,
+    modalityCoordinator: new PetAssistantModalityCoordinator(),
+    transportFactory: () => (context) => {
+      const transport = new Transport(context);
+      transports.push(transport);
+      return transport;
+    },
+  });
+  return { assistant, session, transports, indicator };
+}
+
+// Canonical tools are translated to the current Realtime schema, including the deliberate empty-tool mode.
+{
+  const noTools = buildOpenAIRealtimeSessionConfig("gpt-realtime-2.1", { instructions: "rules", tools: [] });
+  assert.deepEqual(noTools.tools, []);
+  assert.equal(noTools.tool_choice, "none");
+  const withTools = buildOpenAIRealtimeSessionConfig("gpt-realtime-2.1", { instructions: "rules", tools: [{ name: "op_tool", description: "Tool", inputSchema: { type: "object" } }] });
+  assert.deepEqual(withTools.tools, [{ type: "function", name: "op_tool", description: "Tool", parameters: { type: "object" } }]);
+  assert.equal(withTools.tool_choice, "auto");
+}
+
+// Tool output uses function_call_output followed by response.create, preserving structured status.
+{
+  const events = createOpenAIRealtimeToolResultEvents("call_1", { status: "rejected", reason: "missing", missingInformation: true });
+  assert.deepEqual(events.map((event) => JSON.parse(event).type), ["conversation.item.create", "response.create"]);
+  assert.equal(JSON.parse(events[0]!).item.output, JSON.stringify({ status: "rejected", reason: "missing", missingInformation: true }));
+  assert.equal(parseStrictJsonObject("[]"), null);
+  assert.equal(parseStrictJsonObject("not-json"), null);
+}
+
+// A valid provider function call executes once through PetAssistantService and projects a truthful action result.
+{
+  let executions = 0;
+  const current = fixture({ runtime: { snapshot: () => ({ capabilities: [capability] }), execute: async () => { executions += 1; return { ok: true, result: { started: true } }; } } });
+  const projection = new PetAssistantConversationController(current.assistant);
+  current.session.subscribe((event) => {
+    if (event.type === "transcript") projection.applyNormalizedVoiceTranscript({ type: "transcript", sequence: event.sequence, conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: event.turnId, entryId: `entry-${event.sequence}`, speaker: event.speaker, text: event.text, status: event.kind });
+  });
+  await current.session.start();
+  const transport = current.transports[0]!;
+  transport.emit({ type: "speech-started" });
+  transport.emit({ type: "transcript", entryId: "input-1", speaker: "user", status: "final", text: "Start focus" });
+  transport.emit({ type: "tool-call", callId: "call_1", name: toolName, arguments: JSON.stringify({ minutes: 25 }) });
+  transport.emit({ type: "response-completed" });
+  await flush();
+  assert.equal(executions, 1);
+  assert.match(transport.sent[0] ?? "", /completed/);
+  transport.emit({ type: "transcript", entryId: "output-1", speaker: "assistant", status: "final", text: "Focus started." });
+  transport.emit({ type: "response-completed" });
+  await flush();
+  const action = projection.getSnapshot().items.find((item) => item.kind === "action");
+  assert.equal(action?.kind === "action" ? action.status : "missing", "completed");
+  await current.session.end();
+  projection.dispose();
+  await current.assistant.stop();
+}
+
+// Malformed, non-object, and unknown calls never execute and preserve unavailable/rejected outcomes.
+{
+  let executions = 0;
+  const current = fixture({ runtime: { snapshot: () => ({ capabilities: [capability] }), execute: async () => { executions += 1; return { ok: true, result: {} }; } } });
+  await current.session.start();
+  const transport = current.transports[0]!;
+  transport.emit({ type: "speech-started" });
+  transport.emit({ type: "tool-call", callId: "bad_json", name: toolName, arguments: "{bad" });
+  transport.emit({ type: "tool-call", callId: "array_args", name: toolName, arguments: "[]" });
+  transport.emit({ type: "tool-call", callId: "unknown", name: "op_missing", arguments: "{}" });
+  await flush();
+  assert.equal(executions, 0);
+  assert.match(current.transports[0]?.sent.join(" ") ?? "", /rejected/);
+  assert.match(current.transports[0]?.sent.join(" ") ?? "", /unavailable/);
+  await current.session.end();
+  await current.assistant.stop();
+}
+
+// Duplicate completion and stale events are ignored; an interrupted side effect remains indeterminate and cannot enter a new session.
+{
+  let release!: () => void;
+  let started!: () => void;
+  const startedPromise = new Promise<void>((resolve) => { started = resolve; });
+  const runtime: PetAssistantCapabilityRuntime = {
+    snapshot: () => ({ capabilities: [capability] }),
+    execute: async () => { started(); await new Promise<void>((resolve) => { release = resolve; }); return { ok: true, result: {} }; },
+  };
+  const current = fixture({ runtime });
+  await current.session.start();
+  const oldTransport = current.transports[0]!;
+  oldTransport.emit({ type: "speech-started" });
+  oldTransport.emit({ type: "tool-call", callId: "running", name: toolName, arguments: "{}" });
+  await startedPromise;
+  await current.session.interrupt();
+  release();
+  await flush();
+  assert.equal(current.transports[0]?.sent.some((value) => value.includes("running")), false, "late result must not be sent after interruption");
+  oldTransport.emit({ type: "tool-call", callId: "running", name: toolName, arguments: "{}" });
+  assert.equal(current.transports[0]?.sent.length, 0);
+  await current.session.end();
+  assert.equal(oldTransport.closeCount, 1);
+  await current.assistant.stop();
+}
+
+console.log("OpenAI Realtime Pet Assistant adapter tests passed.");

--- a/apps/desktop/tests/voice-realtime-assistant.test.ts
+++ b/apps/desktop/tests/voice-realtime-assistant.test.ts
@@ -105,19 +105,80 @@ function fixture(options: { readonly runtime?: PetAssistantCapabilityRuntime } =
   });
   await current.session.start();
   const transport = current.transports[0]!;
-  transport.emit({ type: "speech-started" });
-  transport.emit({ type: "transcript", entryId: "input-1", speaker: "user", status: "final", text: "Start focus" });
-  transport.emit({ type: "tool-call", callId: "call_1", name: toolName, arguments: JSON.stringify({ minutes: 25 }) });
-  transport.emit({ type: "response-completed" });
+  transport.emit({ type: "speech-started", itemId: "input-1" });
+  transport.emit({ type: "transcript", entryId: "input-1", itemId: "input-1", speaker: "user", status: "final", text: "Start focus" });
+  transport.emit({ type: "response-started", responseId: "response-1" });
+  transport.emit({ type: "tool-call", responseId: "response-1", itemId: "call-item-1", callId: "call_1", name: toolName, arguments: JSON.stringify({ minutes: 25 }) });
+  transport.emit({ type: "response-completed", responseId: "response-1" });
   await flush();
   assert.equal(executions, 1);
   assert.match(transport.sent[0] ?? "", /completed/);
-  transport.emit({ type: "transcript", entryId: "output-1", speaker: "assistant", status: "final", text: "Focus started." });
-  transport.emit({ type: "response-completed" });
+  transport.emit({ type: "response-started", responseId: "response-2" });
+  transport.emit({ type: "transcript", entryId: "stale-output-1", itemId: "stale-output-1", responseId: "response-1", speaker: "assistant", status: "final", text: "stale response" });
+  transport.emit({ type: "response-completed", responseId: "response-1" });
+  assert.equal(current.session.snapshot().assistantTranscript, null);
+  transport.emit({ type: "transcript", entryId: "output-1", itemId: "output-1", responseId: "response-2", speaker: "assistant", status: "final", text: "Focus started." });
+  transport.emit({ type: "response-completed", responseId: "response-2" });
   await flush();
   const action = projection.getSnapshot().items.find((item) => item.kind === "action");
   assert.equal(action?.kind === "action" ? action.status : "missing", "completed");
   await current.session.end();
+  projection.dispose();
+  await current.assistant.stop();
+}
+
+// Events from an interrupted response cannot mutate, settle, or execute against its replacement turn.
+{
+  let executions = 0;
+  const current = fixture({ runtime: { snapshot: () => ({ capabilities: [capability] }), execute: async () => { executions += 1; return { ok: true, result: {} }; } } });
+  const projection = new PetAssistantConversationController(current.assistant);
+  const events: Array<{ readonly type: string; readonly turnId?: string; readonly text?: string }> = [];
+  current.session.subscribe((event) => {
+    if (event.type === "transcript") {
+      events.push({ type: event.type, turnId: event.turnId, text: event.text });
+      projection.applyNormalizedVoiceTranscript({ type: "transcript", sequence: event.sequence, conversationId: PET_ASSISTANT_CONVERSATION_ID, turnId: event.turnId, entryId: `race-${event.sequence}`, speaker: event.speaker, text: event.text, status: event.kind });
+    }
+    if (event.type === "turn-settled") events.push({ type: event.type, turnId: event.turnId });
+  });
+  await current.session.start();
+  const transport = current.transports[0]!;
+
+  transport.emit({ type: "speech-started", itemId: "race-input-a" });
+  transport.emit({ type: "response-started", responseId: "race-response-a" });
+  transport.emit({ type: "transcript", entryId: "race-input-a", itemId: "race-input-a", speaker: "user", status: "final", text: "Turn A" });
+  transport.emit({ type: "transcript", entryId: "race-output-a", itemId: "race-output-a", responseId: "race-response-a", speaker: "assistant", status: "partial", text: "A partial" });
+  const turnA = current.session.snapshot().turnId;
+  assert.ok(turnA);
+
+  await current.session.interrupt();
+  transport.emit({ type: "speech-started", itemId: "race-input-b" });
+  transport.emit({ type: "response-started", responseId: "race-response-b" });
+  const turnB = current.session.snapshot().turnId;
+  assert.ok(turnB);
+  assert.notEqual(turnA, turnB);
+
+  transport.emit({ type: "speech-stopped", itemId: "race-input-a" });
+  transport.emit({ type: "response-audio-started", responseId: "race-response-a" });
+  assert.equal(current.session.snapshot().activity, "thinking");
+  transport.emit({ type: "transcript", entryId: "race-output-a-final", itemId: "race-output-a", responseId: "race-response-a", speaker: "assistant", status: "final", text: "A terminal text" });
+  transport.emit({ type: "tool-call", responseId: "race-response-a", itemId: "race-call-a", callId: "race-call-a", name: toolName, arguments: "{}" });
+  transport.emit({ type: "response-completed", responseId: "race-response-a" });
+  assert.equal(current.session.snapshot().turnId, turnB);
+  assert.equal(current.session.snapshot().assistantTranscript, null);
+  assert.equal(executions, 0);
+  assert.equal(events.some((event) => event.turnId === turnB && event.text === "A terminal text"), false);
+  assert.equal(projection.getSnapshot().items.some((item) => item.kind === "message" && item.text === "A terminal text"), false);
+
+  transport.emit({ type: "transcript", entryId: "race-output-b", itemId: "race-output-b", responseId: "race-response-b", speaker: "assistant", status: "final", text: "B terminal text" });
+  transport.emit({ type: "response-completed", responseId: "race-response-b" });
+  await flush();
+  assert.equal(current.session.snapshot().turnId, null);
+  assert.equal(current.session.snapshot().assistantTranscript, "B terminal text");
+  assert.equal(events.some((event) => event.turnId === turnB && event.text === "B terminal text"), true);
+
+  await current.session.end();
+  transport.emit({ type: "response-completed", responseId: "race-response-a" });
+  assert.equal(current.session.snapshot().status, "ended");
   projection.dispose();
   await current.assistant.stop();
 }
@@ -128,10 +189,11 @@ function fixture(options: { readonly runtime?: PetAssistantCapabilityRuntime } =
   const current = fixture({ runtime: { snapshot: () => ({ capabilities: [capability] }), execute: async () => { executions += 1; return { ok: true, result: {} }; } } });
   await current.session.start();
   const transport = current.transports[0]!;
-  transport.emit({ type: "speech-started" });
-  transport.emit({ type: "tool-call", callId: "bad_json", name: toolName, arguments: "{bad" });
-  transport.emit({ type: "tool-call", callId: "array_args", name: toolName, arguments: "[]" });
-  transport.emit({ type: "tool-call", callId: "unknown", name: "op_missing", arguments: "{}" });
+  transport.emit({ type: "speech-started", itemId: "input-2" });
+  transport.emit({ type: "response-started", responseId: "response-3" });
+  transport.emit({ type: "tool-call", responseId: "response-3", itemId: "bad-item", callId: "bad_json", name: toolName, arguments: "{bad" });
+  transport.emit({ type: "tool-call", responseId: "response-3", itemId: "array-item", callId: "array_args", name: toolName, arguments: "[]" });
+  transport.emit({ type: "tool-call", responseId: "response-3", itemId: "unknown-item", callId: "unknown", name: "op_missing", arguments: "{}" });
   await flush();
   assert.equal(executions, 0);
   assert.match(current.transports[0]?.sent.join(" ") ?? "", /rejected/);
@@ -152,14 +214,15 @@ function fixture(options: { readonly runtime?: PetAssistantCapabilityRuntime } =
   const current = fixture({ runtime });
   await current.session.start();
   const oldTransport = current.transports[0]!;
-  oldTransport.emit({ type: "speech-started" });
-  oldTransport.emit({ type: "tool-call", callId: "running", name: toolName, arguments: "{}" });
+  oldTransport.emit({ type: "speech-started", itemId: "input-3" });
+  oldTransport.emit({ type: "response-started", responseId: "response-4" });
+  oldTransport.emit({ type: "tool-call", responseId: "response-4", itemId: "running-item", callId: "running", name: toolName, arguments: "{}" });
   await startedPromise;
   await current.session.interrupt();
   release();
   await flush();
   assert.equal(current.transports[0]?.sent.some((value) => value.includes("running")), false, "late result must not be sent after interruption");
-  oldTransport.emit({ type: "tool-call", callId: "running", name: toolName, arguments: "{}" });
+  oldTransport.emit({ type: "tool-call", responseId: "response-4", itemId: "running-item", callId: "running", name: toolName, arguments: "{}" });
   assert.equal(current.transports[0]?.sent.length, 0);
   await current.session.end();
   assert.equal(oldTransport.closeCount, 1);

--- a/apps/desktop/voice-realtime-preload.cjs
+++ b/apps/desktop/voice-realtime-preload.cjs
@@ -2,7 +2,7 @@
 
 const COMMAND_CHANNEL = "openpets:voice-realtime-command";
 const EVENT_CHANNEL = "openpets:voice-realtime-event";
-const MAX_EVENT_BYTES = 512 * 1024;
+const MAX_EVENT_BYTES = 64 * 1024;
 const commandListeners = new Set();
 
 require("electron").ipcRenderer.on(COMMAND_CHANNEL, (_event, command) => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,10 +200,16 @@ flows worth holding in memory. Each links to the doc that details it.
   a host-owned temporary session, shows the privacy indicator only after microphone
   acquisition succeeds, transcribes through the configured provider, and cleans up
   on success, cancellation, timeout, teardown, or shutdown. It is never ambient.
-- **Realtime voice foundation.** The host contains a private, one-conversation
-  WebRTC lifecycle with a shared microphone lease, generation-safe cleanup, and
-  OpenAI-only SDP negotiation. It has no UI, tray surface, plugin SDK method,
-  permission, tools, transcripts, memory, or generic TTS integration yet.
+- **Realtime voice adapter.** The host contains an optional optimized OpenAI
+  Realtime adapter over the same Pet Assistant conversation. A hidden sandboxed
+  renderer validates and normalizes provider events; the main process validates
+  them again and routes bounded tool calls through the generation-pinned
+  PetAssistantService seam. Canonical capability outcomes are returned as
+  structured `function_call_output` items followed by `response.create`.
+  Normalized transcripts and canonical activity/action events project into the
+  shared Conversation surface. Provider wire events stop at this adapter;
+  Realtime is not exposed to plugins and does not add memory or local-machine
+  authority.
 - **Configuring an agent.** The CLI or Control Center detects the agent, writes
   MCP config + hooks/rules atomically, and installs a memory/instructions file.
   OpenClaw is the separate native-plugin path: its status is read from the
@@ -236,7 +242,7 @@ These hold everywhere; the rest of the docs assume them.
   explicitly cancellable, visibly indicated while a media track is live, and
   bounded by separate microphone-acquisition and transcription timeouts.
 - **Voice resource ownership is centralized.** Assistant, plugin one-shot, and
-  private Realtime lanes release their own leases/tracks; only the shared voice
+  native Realtime lanes release their own leases/tracks; only the shared voice
   resource owner destroys the privacy indicator after every lane has stopped.
 - **Pet Assistant lifecycle is bounded.** The host loop is stopped and active
   turns are cancelled before plugin teardown; capability handles remain pinned

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,10 +206,12 @@ flows worth holding in memory. Each links to the doc that details it.
   them again and routes bounded tool calls through the generation-pinned
   PetAssistantService seam. Canonical capability outcomes are returned as
   structured `function_call_output` items followed by `response.create`.
-  Normalized transcripts and canonical activity/action events project into the
-  shared Conversation surface. Provider wire events stop at this adapter;
-  Realtime is not exposed to plugins and does not add memory or local-machine
-  authority.
+  Provider response IDs and input item IDs are carried through normalization and
+  bound to the active canonical turn; retired response/item identities are
+  dropped deterministically. Normalized transcripts and canonical activity/action
+  events project into the shared Conversation surface. Provider wire events stop
+  at this adapter; Realtime is not exposed to plugins and does not add memory or
+  local-machine authority.
 - **Configuring an agent.** The CLI or Control Center detects the agent, writes
   MCP config + hooks/rules atomically, and installs a memory/instructions file.
   OpenClaw is the separate native-plugin path: its status is read from the

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -300,14 +300,18 @@ transcription** while provider transcription is pending; the control disappears
 when the operation settles.
 
 The private `VoiceConversationService` and hidden, sandboxed realtime renderer
-remain infrastructure only. The service owns one realtime lane, shares the
-microphone lease with one-shot listening, tracks interruptions and mute state,
-rejects stale events, and releases only its own track/lease on close. It never
-destroys the shared privacy indicator; `voice-resource-owner.ts` performs that
-final teardown after the assistant, plugin one-shot, and realtime lanes stop.
-The renderer owns `getUserMedia`, WebRTC, the data channel, and remote audio; the
-host keeps the OpenAI credential and performs bounded SDP negotiation. Realtime
-protocol work remains deferred to #139.
+remain host infrastructure. When the explicitly selected text profile uses the
+native `openai-realtime` adapter, the Talk surface creates the optional
+`OpenAIRealtimeVoiceAssistantSession`; other text profiles keep the generic
+STT -> Pet Assistant -> TTS path. The realtime lane shares the microphone and
+modality leases, tracks interruptions and mute state, rejects stale events, and
+releases only its own resources on close. It never destroys the shared privacy
+indicator; `voice-resource-owner.ts` performs final teardown after every lane
+stops. The renderer owns `getUserMedia`, WebRTC, the data channel, and remote
+audio. It emits only bounded normalized transcripts and tool-call requests; the
+host keeps credentials, builds canonical tools, executes capabilities through
+the Pet Assistant service, and encodes provider-specific results back to
+Realtime. No plugin SDK route or plugin permission exposes this adapter.
 
 #### Generic host voice session and Talk controls (#147, #150)
 
@@ -317,8 +321,8 @@ releases the microphone reservation and the next activation creates a fresh
 session. The composition is bounded final-only capture/transcription → canonical
 Pet Assistant → authoritative TTS. Text, STT, and TTS provider profiles are
 independent, with the STT profile snapshotted before capture begins. #150 adds
-bounded host controls and a pet-owned Talk entry, but no provider protocol or
-Realtime behavior. Session transcript events are normalized
+bounded host controls and a pet-owned Talk entry. Generic session transcript
+events and the optional Realtime adapter are normalized
 into the #148 current-session Conversation projection; terminal text is also
 eligible for the #149 host archive, while voice lifecycle itself remains
 host-owned. A single app-lifetime feedback reducer consumes typed and

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -311,7 +311,10 @@ stops. The renderer owns `getUserMedia`, WebRTC, the data channel, and remote
 audio. It emits only bounded normalized transcripts and tool-call requests; the
 host keeps credentials, builds canonical tools, executes capabilities through
 the Pet Assistant service, and encodes provider-specific results back to
-Realtime. No plugin SDK route or plugin permission exposes this adapter.
+Realtime. Response IDs and input item IDs remain attached through the normalized
+event boundary so delayed events from an interrupted response cannot mutate the
+replacement canonical turn. No plugin SDK route or plugin permission exposes
+this adapter.
 
 #### Generic host voice session and Talk controls (#147, #150)
 

--- a/docs/openpets_v4.md
+++ b/docs/openpets_v4.md
@@ -117,20 +117,45 @@ pet slot so cleanup does not erase unrelated plugin display state.
 
 An activation owns one session and its microphone reservation. Ending releases
 that reservation; a later activation creates a fresh session. Assistant,
-plugin one-shot, and private Realtime lanes release only their own work. A
+plugin one-shot and native Realtime lane release only their own work. A
 shared host resource owner destroys the privacy indicator only after all lanes
 have stopped. #150 adds activation controls and the shared Conversation
-projection hookup without changing provider protocol or Realtime behavior;
+projection hookup while keeping provider authority host-owned;
 retained history is host-owned, owner-deletable in the Control Center, and
 remains separate from the active projection.
 
-The current #138/#146/#145 implementation has no chat surface or editable
+The current implementation has a shared Conversation surface but no editable
 sensitive-action confirmation surface. #149 provides host-side
 transcript/history persistence and its Control Center local-history surface.
 The Control Center already provides editable provider
 profiles and communication preferences on the host. Conversation surfaces stay
 on top of the host contract rather than moving provider or capability authority
 into plugins.
+
+### #139 optional OpenAI Realtime adapter
+
+The native `openai-realtime` text profile selects an optimized Realtime path for
+the existing Talk surface. It is optional: all other provider selections keep
+the generic STT -> Pet Assistant -> TTS path, and no fourth provider role is
+introduced. The provider profile model, credential, endpoint, and allowed
+headers are snapshotted once at activation.
+
+The hidden sandboxed renderer contains OpenAI wire decoding. It emits only
+bounded normalized user/assistant transcript events and completed function-call
+requests. Electron main validates sender, session, generation, identifiers,
+strict object arguments, duplicate state, and payload bounds again. The
+host-owned Pet Assistant service snapshots the current capabilities, builds the
+canonical provider-safe tool names, and executes calls through its
+generation-pinned capability runtime. Structured completed, unavailable,
+rejected, indeterminate, and explicit missing-information outcomes are returned
+to Realtime and projected into the same Conversation/action/feedback state as
+typed and generic voice turns.
+
+Closing, interruption, renderer loss, provider failure, plugin reload/disable,
+and generation replacement reject late events. A side-effecting invocation
+that cannot produce a trustworthy result remains indeterminate and is not
+blindly retried. Realtime is not a plugin API, does not expose filesystem or
+shell access, and does not add semantic memory.
 
 ## v4 outcomes
 

--- a/docs/openpets_v4.md
+++ b/docs/openpets_v4.md
@@ -143,9 +143,11 @@ headers are snapshotted once at activation.
 The hidden sandboxed renderer contains OpenAI wire decoding. It emits only
 bounded normalized user/assistant transcript events and completed function-call
 requests. Electron main validates sender, session, generation, identifiers,
-strict object arguments, duplicate state, and payload bounds again. The
-host-owned Pet Assistant service snapshots the current capabilities, builds the
-canonical provider-safe tool names, and executes calls through its
+strict object arguments, duplicate state, and payload bounds again. Provider
+response and input item identifiers remain attached through this boundary; the
+adapter binds them to the active canonical turn and drops retired response/item
+events deterministically. The host-owned Pet Assistant service snapshots the
+current capabilities, builds the canonical provider-safe tool names, and executes calls through its
 generation-pinned capability runtime. Structured completed, unavailable,
 rejected, indeterminate, and explicit missing-information outcomes are returned
 to Realtime and projected into the same Conversation/action/feedback state as

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -178,10 +178,10 @@ conversation/tool loop, provider adapter, generation-pinned routing adapter,
 and bounded lifecycle. Issue #146 adds a host-owned persisted personality
 profile, but it does not move personality or authority into plugins. Assistant
 requests do not route through `ctx.ai` or gain unrestricted plugin authority.
-The current integration has no chat/voice UI, transcript or conversation
-persistence, or sensitive-action confirmation UX; later issues add those
-product surfaces. Provider-profile management is implemented in the Control
-Center and uses the host-owned bridge described below.
+The current integration has shared chat/voice Conversation projection and
+host-owned local history, while sensitive-action confirmation remains separate.
+Provider-profile management is implemented in the Control Center and uses the
+host-owned bridge described below.
 
 Network access is gated per call by the **intersection** of manifest-declared
 permissions and the user's persisted approvals. A stale approval never grants a
@@ -233,11 +233,12 @@ state. Plugins do not own the microphone, privacy surface, renderer playback
 lifecycle, or generic assistant session.
 
 `voice-resource-owner.ts` is the sole owner of the shared microphone arbiter,
-capture service, and privacy indicator. Plugin one-shot listening, the private
+capture service, and privacy indicator. Plugin one-shot listening, the native
 Realtime lane, and the generic assistant lane release only their own tracks and
 leases. The shared owner destroys the privacy surface once, after every lane has
-stopped during app teardown. This does not add a public voice conversation API or
-make Realtime part of the plugin contract; #139 remains deferred.
+stopped during app teardown. The optional Realtime adapter remains host-private;
+it does not add a public voice conversation API or make Realtime part of the
+plugin contract.
 
 Generic `openai-compatible-text` is the codec for OpenAI, Ollama, LM Studio,
 vLLM, MiniMax chat, and cloud gateways. Anthropic remains native because its
@@ -247,10 +248,13 @@ audio. TTS is explicit system voice, MiniMax hex audio, ElevenLabs audio, or a
 bounded OpenAI-compatible speech profile. An external TTS error is surfaced and
 does not silently fall back to system speech.
 
-Realtime is host-private and derives only from the selected text profile. It
-requires an explicitly native `openai-realtime` profile,
-reuses that profile's base URL, credential, and allowed headers, and fails with
-`provider.realtime.unsupported` without fetching for other profiles.
+Realtime is an optional host-private optimized adapter and derives only from
+the selected text profile. It requires an explicitly native
+`openai-realtime` profile, reuses that profile's model, base URL, credential,
+and allowed headers, and fails with `provider.realtime.unsupported` without
+fetching for other profiles. The selected profile is pinned for the active
+session; generic STT -> Pet Assistant -> TTS remains the path for other text
+profiles.
 
 The public plugin-facing `voice.listen` capability remains one-shot push-to-talk,
 never ambient. The host captures in a hidden, isolated microphone window and displays
@@ -266,15 +270,19 @@ The host-owned tray menu provides **Stop microphone listening** during
 acquisition/recording and **Cancel transcription** while transcription is
 pending; cancellation is not a public plugin SDK method.
 
-Separately, the desktop has a Phase 1 host-private realtime conversation
-foundation. It is not exposed through Plugin SDK v3, has no plugin permission,
-and plugins cannot start it. Realtime uses a dedicated hidden sandboxed Electron
-WebRTC renderer and host-side OpenAI negotiation. One-shot capture and realtime
-conversation share an exclusive host microphone lease, so they cannot run at the
-same time; both use the host-owned microphone privacy indicator and lifecycle.
-Realtime cleanup also participates in the shared plugin voice shutdown path. UI,
-Talk-to-Pet, public SDK exposure, plugin permissions, tools, memory, transcripts,
-and wake words remain deferred.
+Separately, the desktop provides the optional host-private OpenAI Realtime
+adapter through the existing Talk surface. It is not exposed through Plugin SDK
+v3, has no plugin permission, and plugins cannot start it. A dedicated hidden
+sandboxed Electron WebRTC renderer performs provider-wire decoding and emits
+only normalized transcripts and completed tool-call requests. The main process
+validates those events again, while the host Pet Assistant service owns current
+capability discovery, canonical provider-safe tool names, generation-pinned
+execution, structured results, and Conversation projection. One-shot capture,
+generic voice, and Realtime share exclusive microphone/modality ownership and
+the host privacy indicator. Realtime cleanup participates in the shared
+shutdown path; provider failures and stale generations cannot become successful
+capability outcomes. There is no public SDK Realtime API, unrestricted machine
+access, semantic memory, or wake-word behavior.
 
 ### Display deliveries
 


### PR DESCRIPTION
## Summary
- add the optional native OpenAI Realtime adapter over the canonical Pet Assistant conversation
- keep provider wire decoding in the sandboxed renderer/main transport boundary and route capabilities through generation-pinned host authority
- project normalized transcripts and action outcomes into the shared Conversation/Talk surface
- remove the unused duplicate plugin voice Realtime runtime
- add deterministic ordering, validation, lifecycle, and tool-result coverage plus architecture docs

Closes #139

## Validation
- pnpm --filter @open-pets/desktop typecheck
- pnpm --filter @open-pets/desktop build
- pnpm docs:build
- focused Realtime and related voice tests
- git diff --check

The full desktop test runner is blocked in this Windows environment by the existing claude-memory symlink test requiring symlink privileges. Two existing dist checks also fail on Windows due their platform/line-ending assumptions; the changed focused tests and builds pass.