### PR TITLE
fix(desktop): repair Codex v2 previews and imports

### DIFF
--- a/apps/desktop/codemap.md
+++ b/apps/desktop/codemap.md
@@ -27,7 +27,7 @@ OpenPets desktop companion application. Tray-first Electron app providing animat
 
 ## Flow
 
-**Startup**: `main.ts` → `installAppLifecycle()` → `initializeAppState()` → `initializeLogger()` → `createAppTray()` → `startLocalIpcServer()` → initialize plugin service with JavaScript host/SDK bridge → construct Pet Assistant host and local conversation archive → optionally `showDefaultPet()`
+**Startup**: `main.ts` → `installAppLifecycle()` → `initializeLogger()` → `initializeAppState()` → safely repair eligible legacy Codex V2 import markers → `createAppTray()` → `startLocalIpcServer()` → initialize plugin service with JavaScript host/SDK bridge → construct Pet Assistant host and local conversation archive → optionally `showDefaultPet()`
 
 **Pet Display**: IPC Request → `local-ipc.ts` → `LeaseManager.acquire()` → `agent-pet-controller.ts` → `pet-window.ts` → HTML/CSS spritesheet animation with reaction-to-animation mapping
 

--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -29,6 +29,8 @@ const behaviorTests = [
   ".test-dist/tests/reaction-animation-mapping.test.js",
   ".test-dist/tests/zip-safety.test.js",
   ".test-dist/tests/codex-pets.test.js",
+  ".test-dist/tests/codex-pet-migration.test.js",
+  ".test-dist/tests/control-center-pet-preview.test.js",
   ".test-dist/tests/claude-memory.test.js",
   ".test-dist/tests/plugin-config.test.js",
   ".test-dist/tests/plugin-assets.test.js",

--- a/apps/desktop/src/codemap.md
+++ b/apps/desktop/src/codemap.md
@@ -28,6 +28,7 @@ main.ts
 ├── lifecycle.ts (app events, cleanup)
 ├── logger.ts (structured logging init)
 ├── app-state.ts (state init)
+├── codex-pet-migration.ts (safe legacy V2 marker repair)
 ├── plugin-service.ts (plugin state/runtime init, JS host wiring)
 ├── tray.ts (tray creation)
 ├── local-ipc.ts (IPC server start)
@@ -234,6 +235,8 @@ main.ts/settings → i18n.setLocaleFromPreference(system/user locale)
 - `pet-file-safety.ts`: Bounded, no-follow regular-file reads shared by pet import and installed-pet rendering
 - `codex-pets.ts`: Import from `~/.codex/pets/` with validation
 - `codex-pets-core.ts`: Codex V1/V2 metadata, exact V2 atlas, and neutral-pose layout validation
+- `codex-pet-migration.ts`: Idempotent startup repair for legacy Codex V2 imports gated by canonical source, exact local atlas validation, and byte hash equality
+- `installed-pet-layout.ts`: Bounded installed-manifest reader shared by pet windows and Control Center sprite previews
 - `catalog.ts`: Remote catalog fetch with V3 pagination support, search, fixture fallback
 - `catalog-validation.ts`: CatalogV2/V3 schema validation
 - `zip-safety.ts`: ZIP entry path validation (traversal prevention, case collision detection)

--- a/apps/desktop/src/codex-pet-migration.ts
+++ b/apps/desktop/src/codex-pet-migration.ts
@@ -1,0 +1,175 @@
+import { createHash, randomUUID } from "node:crypto";
+import { lstat, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
+
+import { getCodexPetSpriteLayout, maxCodexPetJsonBytes, maxCodexSpritesheetBytes, validateCodexPetMetadata, validateCodexPetSpritesheet, type CodexPetMetadata } from "./codex-pets-core.js";
+import { readBoundedRegularFile } from "./pet-file-safety.js";
+
+export interface LegacyCodexImportRecord {
+  readonly id: string;
+  readonly source?: {
+    readonly kind?: string;
+    readonly path?: string;
+  };
+}
+
+export interface LegacyCodexV2MigrationOptions {
+  readonly codexPetsRoot: string;
+  readonly installedPetsRoot: string;
+}
+
+export type LegacyCodexV2MigrationSkipReason =
+  | "already-current"
+  | "invalid-pet-id"
+  | "source-path-mismatch"
+  | "source-unavailable"
+  | "source-manifest-invalid"
+  | "source-not-v2"
+  | "local-unavailable"
+  | "local-manifest-invalid"
+  | "local-atlas-invalid"
+  | "atlas-hash-mismatch"
+  | "repair-failed";
+
+export type LegacyCodexV2MigrationEntry =
+  | { readonly id: string; readonly status: "repaired" }
+  | { readonly id: string; readonly status: "skipped"; readonly reason: LegacyCodexV2MigrationSkipReason };
+
+export interface LegacyCodexV2MigrationResult {
+  readonly repaired: number;
+  readonly skipped: number;
+  readonly entries: readonly LegacyCodexV2MigrationEntry[];
+}
+
+class SkipMigration extends Error {
+  constructor(readonly reason: LegacyCodexV2MigrationSkipReason) {
+    super(reason);
+  }
+}
+
+export async function migrateLegacyCodexV2Imports(records: readonly LegacyCodexImportRecord[], options: LegacyCodexV2MigrationOptions): Promise<LegacyCodexV2MigrationResult> {
+  const entries: LegacyCodexV2MigrationEntry[] = [];
+
+  for (const record of records) {
+    if (record.source?.kind !== "codex") continue;
+    try {
+      await migrateLegacyCodexV2Import(record, options);
+      entries.push({ id: record.id, status: "repaired" });
+    } catch (error) {
+      entries.push({
+        id: record.id,
+        status: "skipped",
+        reason: error instanceof SkipMigration ? error.reason : "repair-failed",
+      });
+    }
+  }
+
+  return {
+    repaired: entries.filter((entry) => entry.status === "repaired").length,
+    skipped: entries.filter((entry) => entry.status === "skipped").length,
+    entries,
+  };
+}
+
+export function summarizeLegacyCodexV2MigrationSkips(result: LegacyCodexV2MigrationResult): Partial<Record<LegacyCodexV2MigrationSkipReason, number>> {
+  const reasons: Partial<Record<LegacyCodexV2MigrationSkipReason, number>> = {};
+  for (const entry of result.entries) {
+    if (entry.status !== "skipped") continue;
+    reasons[entry.reason] = (reasons[entry.reason] ?? 0) + 1;
+  }
+  return reasons;
+}
+
+async function migrateLegacyCodexV2Import(record: LegacyCodexImportRecord, options: LegacyCodexV2MigrationOptions): Promise<void> {
+  if (!isSafePetId(record.id)) throw new SkipMigration("invalid-pet-id");
+
+  const localDir = resolve(options.installedPetsRoot, record.id);
+  try {
+    await assertCanonicalChildDirectory(options.installedPetsRoot, localDir);
+  } catch {
+    throw new SkipMigration("local-unavailable");
+  }
+
+  const localMetadataRecord = await readMetadataRecord(localDir, record.id, "local-manifest-invalid");
+  const localMetadata = localMetadataRecord.metadata;
+  if (getCodexPetSpriteLayout(localMetadata).version === 2) throw new SkipMigration("already-current");
+
+  const sourceDir = resolve(record.source?.path ?? "");
+  const expectedSourceDir = resolve(options.codexPetsRoot, record.id);
+  if (sourceDir !== expectedSourceDir) throw new SkipMigration("source-path-mismatch");
+  try {
+    await assertCanonicalChildDirectory(options.codexPetsRoot, sourceDir);
+  } catch {
+    throw new SkipMigration("source-unavailable");
+  }
+
+  const sourceMetadata = (await readMetadataRecord(sourceDir, record.id, "source-manifest-invalid")).metadata;
+  if (sourceMetadata.spriteVersionNumber !== 2) throw new SkipMigration("source-not-v2");
+
+  let localAtlas: Buffer;
+  try {
+    localAtlas = await readBoundedRegularFile(join(localDir, localMetadata.spritesheetPath), maxCodexSpritesheetBytes, "Installed Codex spritesheet");
+    await validateCodexPetSpritesheet(localAtlas, sourceMetadata);
+  } catch {
+    throw new SkipMigration("local-atlas-invalid");
+  }
+
+  let sourceAtlas: Buffer;
+  try {
+    sourceAtlas = await readBoundedRegularFile(join(sourceDir, sourceMetadata.spritesheetPath), maxCodexSpritesheetBytes, "Source Codex spritesheet");
+  } catch {
+    throw new SkipMigration("source-unavailable");
+  }
+
+  if (sha256(sourceAtlas) !== sha256(localAtlas)) throw new SkipMigration("atlas-hash-mismatch");
+
+  try {
+    await writeMetadataAtomically(localDir, { ...localMetadataRecord.manifest, spriteVersionNumber: 2 });
+    const repairedMetadata = (await readMetadataRecord(localDir, record.id, "repair-failed")).metadata;
+    if (repairedMetadata.spriteVersionNumber !== 2) throw new Error("Codex V2 marker was not persisted.");
+  } catch (error) {
+    if (error instanceof SkipMigration && error.reason === "repair-failed") throw error;
+    throw new SkipMigration("repair-failed");
+  }
+}
+
+async function readMetadataRecord(dir: string, petId: string, reason: LegacyCodexV2MigrationSkipReason): Promise<{ readonly metadata: CodexPetMetadata; readonly manifest: Readonly<Record<string, unknown>> }> {
+  try {
+    const parsed = JSON.parse((await readBoundedRegularFile(join(dir, "pet.json"), maxCodexPetJsonBytes, "Codex pet metadata")).toString("utf8")) as unknown;
+    const metadata = validateCodexPetMetadata(parsed, petId);
+    return { metadata, manifest: parsed as Record<string, unknown> };
+  } catch {
+    throw new SkipMigration(reason);
+  }
+}
+
+async function assertCanonicalChildDirectory(root: string, target: string): Promise<void> {
+  const resolvedRoot = resolve(root);
+  const resolvedTarget = resolve(target);
+  if (resolvedTarget === resolvedRoot || !resolvedTarget.startsWith(`${resolvedRoot}${sep}`)) throw new Error("Path escapes root.");
+
+  const rootStats = await lstat(resolvedRoot);
+  if (rootStats.isSymbolicLink() || !rootStats.isDirectory() || await realpath(resolvedRoot) !== resolvedRoot) throw new Error("Root is not canonical.");
+
+  const targetStats = await lstat(resolvedTarget);
+  if (targetStats.isSymbolicLink() || !targetStats.isDirectory() || await realpath(resolvedTarget) !== resolvedTarget) throw new Error("Directory is not canonical.");
+}
+
+async function writeMetadataAtomically(dir: string, metadata: Readonly<Record<string, unknown>>): Promise<void> {
+  const metadataPath = join(dir, "pet.json");
+  const tempPath = join(dir, `.pet.json.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(tempPath, `${JSON.stringify(metadata, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await rename(tempPath, metadataPath);
+  } finally {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+  }
+}
+
+function sha256(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isSafePetId(value: string): boolean {
+  return /^[a-z0-9][a-z0-9_-]{0,63}$/.test(value) && value !== "builtin";
+}

--- a/apps/desktop/src/codex-pets.ts
+++ b/apps/desktop/src/codex-pets.ts
@@ -5,7 +5,8 @@ import { basename, join, resolve, sep } from "node:path";
 import sharp from "sharp";
 
 import { getAppStateSnapshot, installPetState, type OpenPetsStateV1 } from "./app-state.js";
-import { maxCodexPetJsonBytes, maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata, validateCodexPetSpritesheet, type CodexPetMetadata } from "./codex-pets-core.js";
+import { migrateLegacyCodexV2Imports, type LegacyCodexV2MigrationResult } from "./codex-pet-migration.js";
+import { getCodexPetSpriteLayout, maxCodexPetJsonBytes, maxCodexPets, maxCodexSpritesheetBytes, maxCodexThumbnailSourceBytes, validateCodexPetMetadata, validateCodexPetSpritesheet, type CodexPetMetadata, type CodexPetSpriteLayout } from "./codex-pets-core.js";
 import { readBoundedRegularFile } from "./pet-file-safety.js";
 import { withPetOperation } from "./pet-installation.js";
 import { assertInsideRoot, assertSafePetId, getInstalledPetDir, getPetsRoot } from "./pet-paths.js";
@@ -25,6 +26,14 @@ export interface CodexPetUiItem {
   readonly description: string;
   readonly preview: string;
   readonly spritesheet: string;
+  readonly spriteLayout: CodexPetSpriteLayout;
+}
+
+export async function migrateLegacyCodexV2ImportsAtStartup(): Promise<LegacyCodexV2MigrationResult> {
+  return migrateLegacyCodexV2Imports(getAppStateSnapshot().pets.installed, {
+    codexPetsRoot,
+    installedPetsRoot: getPetsRoot(),
+  });
 }
 
 export async function getCodexPetsUiState(): Promise<CodexPetUiState> {
@@ -104,13 +113,15 @@ async function tryReadCodexPet(root: string, dir: string, folderName: string): P
     const metadata = await readCodexPetMetadata(root, dir, folderName);
     const spritesheetPath = join(dir, metadata.spritesheetPath);
     await validateSpritesheet(spritesheetPath, metadata);
-    const preview = await createCodexThumbnailDataUrl(spritesheetPath);
+    const spriteLayout = getCodexPetSpriteLayout(metadata);
+    const preview = await createCodexThumbnailDataUrl(spritesheetPath, spriteLayout);
     return {
       id: metadata.id,
       displayName: metadata.displayName,
       description: metadata.description,
       preview,
       spritesheet: `openpets-codex://spritesheet/${encodeURIComponent(metadata.id)}`,
+      spriteLayout,
     };
   } catch (error) {
     console.error(`Skipping invalid Codex pet at ${dir}.`, error);
@@ -142,20 +153,21 @@ async function validateSpritesheet(path: string, metadata: CodexPetMetadata): Pr
   await validateCodexPetSpritesheet(await readBoundedRegularFile(path, maxCodexSpritesheetBytes, "spritesheet.webp"), metadata);
 }
 
-async function createCodexThumbnailDataUrl(path: string): Promise<string> {
+async function createCodexThumbnailDataUrl(path: string, spriteLayout: CodexPetSpriteLayout): Promise<string> {
   const stats = await lstat(path);
   if (stats.isSymbolicLink() || !stats.isFile() || stats.size <= 0 || stats.size > maxCodexThumbnailSourceBytes) return "";
-  const cacheKey = `${path}:${stats.size}:${stats.mtimeMs}`;
+  const cacheKey = `${path}:v${spriteLayout.version}:${stats.size}:${stats.mtimeMs}`;
   const cached = codexThumbnailCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   const image = sharp(path, { limitInputPixels: 50_000_000 });
   const metadata = await image.metadata();
   if (!metadata.width || !metadata.height) return "";
-  const width = Math.min(192, metadata.width);
-  const height = Math.min(208, metadata.height);
+  const width = Math.min(spriteLayout.frameWidth, metadata.width);
+  const height = Math.min(spriteLayout.frameHeight, metadata.height);
+  const left = spriteLayout.neutralPose ? spriteLayout.neutralPose.column * spriteLayout.frameWidth : 0;
   const thumbnail = await sharp(path, { limitInputPixels: 50_000_000 })
-    .extract({ left: 0, top: 0, width, height })
+    .extract({ left, top: 0, width, height })
     .resize(54, 58, { fit: "fill" })
     .png()
     .toBuffer();

--- a/apps/desktop/src/installed-pet-layout.ts
+++ b/apps/desktop/src/installed-pet-layout.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+
+import { getCodexPetSpriteLayout, maxCodexPetJsonBytes, validateCodexPetMetadata, type CodexPetSpriteLayout } from "./codex-pets-core.js";
+import { readBoundedRegularFile } from "./pet-file-safety.js";
+import { getInstalledPetDir } from "./pet-paths.js";
+
+export async function readInstalledPetSpriteLayout(petId: string): Promise<CodexPetSpriteLayout> {
+  const metadataPath = join(getInstalledPetDir(petId), "pet.json");
+  const metadata = validateCodexPetMetadata(
+    JSON.parse((await readBoundedRegularFile(metadataPath, maxCodexPetJsonBytes, "Installed pet metadata")).toString("utf8")) as unknown,
+    petId,
+  );
+  return getCodexPetSpriteLayout(metadata);
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -4,6 +4,8 @@ import { delimiter, join, resolve } from "node:path";
 
 import { getAppStateSnapshot, initializeAppState, releaseStartupInstallLock } from "./app-state.js";
 import { createAppIcon } from "./assets.js";
+import { summarizeLegacyCodexV2MigrationSkips } from "./codex-pet-migration.js";
+import { migrateLegacyCodexV2ImportsAtStartup } from "./codex-pets.js";
 import { setLocaleFromPreference } from "./i18n/index.js";
 import { applyExternalPetReaction, applyExternalPetSay, getDefaultPetPaused, installDefaultPetDisplayHandlers, isDefaultPetVisible, shouldOpenDefaultPetOnLaunch, showDefaultPet } from "./default-pet-controller.js";
 import { installAppLifecycle } from "./lifecycle.js";
@@ -102,6 +104,19 @@ if (!gotSingleInstanceLock) {
     }
 
     initializeAppState();
+    try {
+      const migration = await migrateLegacyCodexV2ImportsAtStartup();
+      info("state", "Codex V2 import metadata migration completed", {
+        repaired: migration.repaired,
+        skipped: migration.skipped,
+        entries: migration.entries,
+        skipReasons: summarizeLegacyCodexV2MigrationSkips(migration),
+      });
+    } catch (migrationError) {
+      warn("state", "Codex V2 import metadata migration unavailable; continuing startup", {
+        error: migrationError instanceof Error ? migrationError.message : String(migrationError),
+      });
+    }
     initializeVoiceAssistantShortcut(globalShortcut, () => {
       void import("./voice-assistant-host.js").then(({ toggleVoiceAssistant }) => toggleVoiceAssistant()).catch((error: unknown) => logError("app", "voice shortcut toggle failed", error));
     }, getAppStateSnapshot().preferences.voiceAssistantShortcut);

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -5,11 +5,11 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { getAppStateSnapshot, markPetBroken, type PetScaleValue } from "./app-state.js";
-import { getCodexPetSpriteLayout, getCodexPetSpritePosition, maxCodexPetJsonBytes, validateCodexPetMetadata, type CodexPetSpriteLayout } from "./codex-pets-core.js";
+import { getCodexPetSpritePosition, type CodexPetSpriteLayout } from "./codex-pets-core.js";
 import { clampToNearestDisplayIfOffscreen, clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosition, isCrossDisplayRoamingEnabled, type Point } from "./display.js";
 import { builtInPet } from "./built-in-pet.js";
+import { readInstalledPetSpriteLayout } from "./installed-pet-layout.js";
 import { getInstalledPetDir } from "./pet-paths.js";
-import { readBoundedRegularFile } from "./pet-file-safety.js";
 import { getActiveLocale, getActiveLocaleLang, t } from "./i18n/index.js";
 import { defaultMediaDurationMs, type OpenPetsReaction } from "./local-ipc-protocol.js";
 import { pickReactionMessage } from "./reaction-messages.js";
@@ -1115,15 +1115,6 @@ async function createInstalledPetRender(petId: string, displayName: string, paus
         </body>
       </html>`,
   };
-}
-
-async function readInstalledPetSpriteLayout(petId: string): Promise<CodexPetSpriteLayout> {
-  const metadataPath = join(getInstalledPetDir(petId), "pet.json");
-  const metadata = validateCodexPetMetadata(
-    JSON.parse((await readBoundedRegularFile(metadataPath, maxCodexPetJsonBytes, "Installed pet metadata")).toString("utf8")) as unknown,
-    petId,
-  );
-  return getCodexPetSpriteLayout(metadata);
 }
 
 function createPetBodyMarkup(stageLabel: string, bubble: string, spriteMarkup: string, pinnedBubble = "", hasPinned = false): string {

--- a/apps/desktop/src/renderer/src/codemap.md
+++ b/apps/desktop/src/renderer/src/codemap.md
@@ -9,7 +9,7 @@ React/Tailwind source for the Control Center management UI. This renderer presen
 - **Route Shell**: In-renderer route state supports `dashboard`, `conversation`, `pets`, `integrations`, `plugins`, and `settings`; tray actions retarget the singleton window through route-change events.
 - **Conversation**: `conversation/ConversationView.tsx` renders the active typed/Talk session plus a separate Local history panel for opening archived messages, returning to the active session, deleting one message, and clearing the archive. `conversation-state.ts` validates live snapshots/events; `history-state.ts` validates and updates archived history without mutating the active session.
 - **Dashboard**: Reads a narrowed dashboard snapshot for default pet preview, install/catalog counts, plugin health, update status, and activity totals.
-- **Pets**: Combines installed pets, catalog v3 pages/search, Codex imports, filters, detail panes, set-default/install/import/remove actions, and animated sprite previews.
+- **Pets**: Combines installed pets, catalog v3 pages/search, Codex imports, filters, detail panes, set-default/install/import/remove actions, and version-aware V1/V2 sprite previews, including the static V2 neutral cell.
 - **Integrations**: Card-first setup UI for Claude Code, OpenCode, Cursor, Pi guidance, and OpenClaw native-plugin setup, including command mode/path controls and preview/action flows.
 - **Plugins**: Gallery-first plugin hub for installed/catalog/local/broken filters, catalog refresh, local load, install/update/uninstall, enable/disable, config modal, command execution, runtime/status display, and broken-state feedback.
 - **Settings**: Startup, launch-at-login, pet scale, host Pet Assistant personality, reaction-animation mapping, model and speech provider profiles (Text & reasoning, STT, TTS), realtime status, host capability gates, update check, default-pet position reset, and pet reaction previews.
@@ -18,6 +18,7 @@ React/Tailwind source for the Control Center management UI. This renderer presen
 ## Key Files
 
 - `main.tsx`: Existing route shell and management pages; Conversation is kept in focused files under `conversation/` and receives the narrow history bridge through the Control Center API type.
+- `pet-preview-state.ts`: Pure 8×9/8×11 preview model that preserves V1 frame animation and selects V2's neutral frame.
 - `conversation/history-state.ts`: Renderer validation and immutable list updates for local archived messages.
 - `styles.css`: Tailwind base/components/utilities plus glass-card layout, navigation, galleries, modals, status pills, previews, and notifications.
 - `vite-env.d.ts`: Vite/TypeScript renderer environment declarations.

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -6,6 +6,7 @@ import openPetsLogoUrl from "../../../assets/openpets.webp";
 import defaultThumbUrl from "../../../assets/default-pet-thumbnail.png";
 import { ConversationView } from "./conversation/ConversationView.js";
 import type { ConversationEvent, ConversationSnapshot, LocalConversationHistoryMessage, VoiceAssistantTalkEvent, VoiceAssistantSessionSnapshot } from "./conversation/conversation-types.js";
+import { buildPetSpritePreviewModel, type PetSpriteLayout } from "./pet-preview-state.js";
 import { resolveShortcutSaveOutcome } from "./settings-shortcut-state.js";
 
 import claudeLogoUrl from "../../../assets/integrations/claude.svg";
@@ -17,8 +18,8 @@ import windsurfLogoUrl from "../../../assets/integrations/windsurf.svg";
 import zedLogoUrl from "../../../assets/integrations/zed.svg";
 
 type Filter = "all" | "installed" | "featured" | "originals" | "codex";
-type InstalledPet = { id: string; displayName: string; description?: string; builtIn: boolean; protected: boolean; installed: boolean; broken?: boolean; brokenReason?: string; source?: { kind?: "catalog"; preview?: string } | { kind: "codex"; path: string } };
-type PetEntry = { id: string; displayName: string; description?: string; searchText?: string; preview?: string; thumbnail?: string; spritesheet?: string; category?: "western" | "asian"; original?: boolean; featured?: boolean; catalogPage?: number; sourceKind?: "installed" | "catalog" | "codex"; installed?: boolean; builtIn?: boolean; protected?: boolean; broken?: boolean; brokenReason?: string };
+type InstalledPet = { id: string; displayName: string; description?: string; builtIn: boolean; protected: boolean; installed: boolean; broken?: boolean; brokenReason?: string; spriteLayout?: PetSpriteLayout; source?: { kind?: "catalog"; preview?: string } | { kind: "codex"; path: string } };
+type PetEntry = { id: string; displayName: string; description?: string; searchText?: string; preview?: string; thumbnail?: string; spritesheet?: string; spriteLayout?: PetSpriteLayout; category?: "western" | "asian"; original?: boolean; featured?: boolean; catalogPage?: number; sourceKind?: "installed" | "catalog" | "codex"; installed?: boolean; builtIn?: boolean; protected?: boolean; broken?: boolean; brokenReason?: string };
 type SearchPetEntry = Pick<PetEntry, "id" | "displayName" | "category" | "original" | "featured"> & { searchText?: string; catalogPage?: number };
 type StateSnapshot = { preferences: { defaultPetId: string }; pets: { installed: InstalledPet[] } };
 type CatalogState = { pets: PetEntry[]; source: string; error?: string; page?: number; pageCount?: number; total?: number; categories?: { id: "western" | "asian"; label: string; count: number }[]; originalsCount?: number; featuredCount?: number };
@@ -43,8 +44,8 @@ type LanTopologyIssue = { code: "self_reference" | "missing_reverse"; host: stri
 type LanStatusSnapshot = { mode: "off" | "server" | "client"; localHost: string; serverUrl: string; port: number; auth: "token" | "none"; authSource: "env" | "stored" | "generated" | "none"; authInsecure: boolean; tokenHint: string | null; topologyHosts: number; topologyLinks: number; topologyIssues: LanTopologyIssue[]; currentHost: string | null; clients: Array<{ host: string; lastSeen: number; position?: { x: number; y: number } }>; updatedAt: number; persistedCurrentHost: string | null; persistedUpdatedAt: number | null };
 type UpdateStatus = { state: "idle" | "checking" | "available" | "current" | "error"; currentVersion: string; latestVersion?: string; releaseUrl?: string; checkedAt?: number; error?: string };
 type DashboardActivity = { messagesSent: number; reactionsSent: number; reactionCounts: Record<string, number>; perPetActivityCounts: Record<string, number>; lastActivityAt?: number };
-type DashboardSnapshot = { defaultPet: { id: string; displayName: string; previewSpriteUrl: string }; installedPetCount: number; catalog: { source: string; total?: number; page?: number; pageCount?: number; error?: string }; plugins: { installed: number; enabled: number; broken: number }; updateStatus: UpdateStatus; activity: DashboardActivity };
-type ReactionAnimationSettings = { reactions: { id: string; label: string; description: string; defaultAnimation: UserSelectableAnimationState }[]; animations: { id: UserSelectableAnimationState; label: string; description: string }[]; sprite: { frameWidth: number; frameHeight: number; columns: number; rows: number; states: Record<UserSelectableAnimationState, { row: number; frames: number; durationMs: number; iterations?: number | "infinite" }> }; overrides: ReactionAnimationOverrides; previewSpriteUrl: string; waitingAnimationDurationMs: number; waitingAnimationDurationOptions: { value: number; label: string }[] };
+type DashboardSnapshot = { defaultPet: { id: string; displayName: string; previewSpriteUrl: string; spriteLayout: PetSpriteLayout }; installedPetCount: number; catalog: { source: string; total?: number; page?: number; pageCount?: number; error?: string }; plugins: { installed: number; enabled: number; broken: number }; updateStatus: UpdateStatus; activity: DashboardActivity };
+type ReactionAnimationSettings = { reactions: { id: string; label: string; description: string; defaultAnimation: UserSelectableAnimationState }[]; animations: { id: UserSelectableAnimationState; label: string; description: string }[]; sprite: PetSpriteLayout & { states: Record<UserSelectableAnimationState, { row: number; frames: number; durationMs: number; iterations?: number | "infinite" }> }; overrides: ReactionAnimationOverrides; previewSpriteUrl: string; waitingAnimationDurationMs: number; waitingAnimationDurationOptions: { value: number; label: string }[] };
 type PluginFilter = "all" | "installed" | "catalog" | "local" | "broken";
 type PluginPermission =
   | "pet:speak" | "pet:reaction" | "pet:move" | "timer" | "schedule" | "storage" | "status" | "commands" | "network"
@@ -700,7 +701,7 @@ function DashboardView({ onNavigate }: { onNavigate: (route: Route) => void }) {
           </div>
         </div>
         <div className="dashboard-hero-pet">
-          <SpriteFrame src={defaultPet.previewSpriteUrl} label={defaultPet.displayName} state="idle" size="detail" />
+          <SpriteFrame src={defaultPet.previewSpriteUrl} label={defaultPet.displayName} spriteLayout={defaultPet.spriteLayout} state="idle" size="detail" />
         </div>
       </section>
 
@@ -1057,16 +1058,18 @@ const spriteStates = {
   happy: { row: 4, frames: 5, duration: "1.35s" },
 } as const;
 
-function SpriteFrame({ src, label, state = "idle", size = "detail" }: { src?: string; label: string; state?: "idle" | "thinking" | "happy" | "wave"; size?: "thumb" | "detail" | "mini" }) {
+function SpriteFrame({ src, label, spriteLayout, state = "idle", size = "detail" }: { src?: string; label: string; spriteLayout?: PetSpriteLayout; state?: "idle" | "thinking" | "happy" | "wave"; size?: "thumb" | "detail" | "mini" }) {
   const safeSrc = safePetImage(src);
   if (!safeSrc) return <img src={defaultThumbUrl} alt="" />;
   const frame = spriteFrameSizes[size];
   const sprite = spriteStates[state];
-  const xValues = Array.from({ length: sprite.frames }, (_, index) => String(-index * frame.width)).join(";");
-  const y = -sprite.row * frame.height;
+  const preview = buildPetSpritePreviewModel(spriteLayout, sprite, state === "idle");
+  const xValues = preview.frameColumns.map((column) => String(-column * frame.width)).join(";");
+  const x = -(preview.frameColumns[0] ?? 0) * frame.width;
+  const y = -preview.row * frame.height;
   return <svg className={`sprite-frame sprite-${state} sprite-${size}`} width={frame.width} height={frame.height} viewBox={`0 0 ${frame.width} ${frame.height}`} role="img" aria-label={label}>
-    <image href={safeSrc} x="0" y={y} width={frame.width * 8} height={frame.height * 9} preserveAspectRatio="none" onError={() => logPetsError("sprite-failed", { label, state, size, src: imageDebug(safeSrc) })}>
-      <animate attributeName="x" values={xValues} dur={sprite.duration} repeatCount="indefinite" calcMode="discrete" />
+    <image href={safeSrc} x={x} y={y} width={frame.width * preview.atlasColumns} height={frame.height * preview.atlasRows} preserveAspectRatio="none" onError={() => logPetsError("sprite-failed", { label, state, size, src: imageDebug(safeSrc) })}>
+      {preview.animated && <animate attributeName="x" values={xValues} dur={sprite.duration} repeatCount="indefinite" calcMode="discrete" />}
     </image>
   </svg>;
 }
@@ -1216,14 +1219,16 @@ function ReactionPreviewSprite({ settings, state }: { settings: ReactionAnimatio
   const { t } = useI18n();
   const frame = { width: settings.sprite.frameWidth, height: settings.sprite.frameHeight };
   const sprite = settings.sprite.states[state] ?? settings.sprite.states.idle;
-  const xValues = Array.from({ length: sprite.frames }, (_, index) => String(-index * frame.width)).join(";");
-  const y = -sprite.row * frame.height;
+  const preview = buildPetSpritePreviewModel(settings.sprite, sprite, state === "idle");
+  const xValues = preview.frameColumns.map((column) => String(-column * frame.width)).join(";");
+  const x = -(preview.frameColumns[0] ?? 0) * frame.width;
+  const y = -preview.row * frame.height;
 
   return (
     <div className="reaction-preview-sprite-shell">
       <svg className="reaction-preview-sprite" width={frame.width} height={frame.height} viewBox={`0 0 ${frame.width} ${frame.height}`} role="img" aria-label={t("settings.reactions.previewAria", { state })}>
-        <image href={settings.previewSpriteUrl} x="0" y={y} width={frame.width * settings.sprite.columns} height={frame.height * settings.sprite.rows} preserveAspectRatio="none">
-          <animate attributeName="x" values={xValues} dur={`${sprite.durationMs}ms`} repeatCount="indefinite" calcMode="discrete" />
+        <image href={settings.previewSpriteUrl} x={x} y={y} width={frame.width * preview.atlasColumns} height={frame.height * preview.atlasRows} preserveAspectRatio="none">
+          {preview.animated && <animate attributeName="x" values={xValues} dur={`${sprite.durationMs}ms`} repeatCount="indefinite" calcMode="discrete" />}
         </image>
       </svg>
     </div>
@@ -5066,6 +5071,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
       const localSpritesheet = p.id && !catalogPet && !codexPet && !p.builtIn ? installedPetSpritesheetUrl(p.id) : undefined;
       const spritesheet = safePetImage(codexPet?.spritesheet) || safePetImage(catalogPet?.spritesheet) || safePetImage(localSpritesheet);
       const preview = safePetImage(codexPet?.preview) || safePetImage(catalogPet?.preview) || safePetImage(catalogPet?.thumbnail) || safePetImage(p.source && "preview" in p.source ? (p.source as { preview?: string }).preview : undefined) || safePetImage(localSpritesheet) || defaultThumbUrl;
+      const spriteLayout = codexPet?.spriteLayout ?? catalogPet?.spriteLayout ?? p.spriteLayout;
       const category = catalogPet?.category;
       const original = catalogPet?.original;
       const featured = catalogPet?.featured;
@@ -5073,6 +5079,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
         ...p,
         spritesheet,
         preview,
+        spriteLayout,
         category,
         original,
         featured,
@@ -5163,7 +5170,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
 
   useEffect(() => {
     if (!selected) return;
-    logPetsEvent("selected-pet", { id: selected.id, sourceKind: selected.sourceKind, installed: selected.installed, builtIn: selected.builtIn, preview: imageDebug(selected.preview), spritesheet: imageDebug(selected.spritesheet), hasSafePreview: Boolean(safePetImage(selected.preview)), hasSafeSpritesheet: Boolean(safePetImage(selected.spritesheet)), catalogPages: Object.keys(catalogPages).join(",") });
+    logPetsEvent("selected-pet", { id: selected.id, sourceKind: selected.sourceKind, installed: selected.installed, builtIn: selected.builtIn, spriteVersion: selected.spriteLayout?.version, spriteRows: selected.spriteLayout?.rows, preview: imageDebug(selected.preview), spritesheet: imageDebug(selected.spritesheet), hasSafePreview: Boolean(safePetImage(selected.preview)), hasSafeSpritesheet: Boolean(safePetImage(selected.spritesheet)), catalogPages: Object.keys(catalogPages).join(",") });
   }, [selected]);
 
   const statusText = useMemo(() => {
@@ -5327,7 +5334,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
                 >
                   <span className="thumb">
                     {useSpritesheetFrame ? (
-                      <SpriteFrame src={pet.spritesheet} label={t("pets.spriteLabel.thumbnail", { name: pet.displayName })} size="thumb" />
+                      <SpriteFrame src={pet.spritesheet} label={t("pets.spriteLabel.thumbnail", { name: pet.displayName })} spriteLayout={pet.spriteLayout} size="thumb" />
                     ) : (
                       <PetImage src={pet.preview} debugLabel={`${pet.id}:card`} />
                     )}
@@ -5437,7 +5444,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
                 <div className="plugin-inspector-head">
                   <span className="plugin-inspector-icon">
                     {safePetImage(selected.spritesheet) ? (
-                      <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.thumb", { name: selected.displayName })} size="thumb" />
+                      <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.thumb", { name: selected.displayName })} spriteLayout={selected.spriteLayout} size="thumb" />
                     ) : (
                       <PetImage src={selected.preview} debugLabel={`${selected.id}:thumb`} />
                     )}
@@ -5454,7 +5461,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
                     <p className="desc">{selected.description || selected.id}</p>
                     <div className="stage">
                       {safePetImage(selected.spritesheet) ? (
-                        <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.animatedPreview", { name: selected.displayName })} />
+                        <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.animatedPreview", { name: selected.displayName })} spriteLayout={selected.spriteLayout} />
                       ) : (
                         <PetImage src={selected.preview} debugLabel={`${selected.id}:detail-fallback`} />
                       )}
@@ -5479,7 +5486,7 @@ function ControlCenter({ onAppearanceThemeChange }: { onAppearanceThemeChange: (
                         { label: t("pets.detail.preview.wave"), state: "wave" as const },
                       ].map((previewState) => (
                         <article key={previewState.state} className="pet-preview-item">
-                          <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.statePreview", { name: selected.displayName, state: previewState.label })} state={previewState.state} size="mini" />
+                          <SpriteFrame src={selected.spritesheet} label={t("pets.spriteLabel.statePreview", { name: selected.displayName, state: previewState.label })} spriteLayout={selected.spriteLayout} state={previewState.state} size="mini" />
                           <span className="text-xs font-bold text-slatecopy">{previewState.label}</span>
                         </article>
                       ))}

--- a/apps/desktop/src/renderer/src/pet-preview-state.ts
+++ b/apps/desktop/src/renderer/src/pet-preview-state.ts
@@ -1,0 +1,49 @@
+export interface PetSpriteLayout {
+  readonly version: 1 | 2;
+  readonly frameWidth: number;
+  readonly frameHeight: number;
+  readonly columns: number;
+  readonly rows: number;
+  readonly neutralPose?: {
+    readonly row: number;
+    readonly column: number;
+  };
+}
+
+export interface PetSpritePreviewModel {
+  readonly atlasColumns: number;
+  readonly atlasRows: number;
+  readonly row: number;
+  readonly frameColumns: readonly number[];
+  readonly animated: boolean;
+}
+
+export const defaultPetSpriteLayout: PetSpriteLayout = {
+  version: 1,
+  frameWidth: 192,
+  frameHeight: 208,
+  columns: 8,
+  rows: 9,
+};
+
+export function buildPetSpritePreviewModel(
+  layout: PetSpriteLayout | undefined,
+  state: { readonly row: number; readonly frames: number },
+  useNeutralPose = false,
+): PetSpritePreviewModel {
+  const resolvedLayout = layout ?? defaultPetSpriteLayout;
+  const neutralPose = useNeutralPose && state.row === resolvedLayout.neutralPose?.row
+    ? resolvedLayout.neutralPose
+    : undefined;
+  const frameColumns = neutralPose
+    ? [neutralPose.column]
+    : Array.from({ length: state.frames }, (_, index) => index);
+
+  return {
+    atlasColumns: resolvedLayout.columns,
+    atlasRows: resolvedLayout.rows,
+    row: neutralPose?.row ?? state.row,
+    frameColumns,
+    animated: !neutralPose && frameColumns.length > 1,
+  };
+}

--- a/apps/desktop/src/windows.ts
+++ b/apps/desktop/src/windows.ts
@@ -11,10 +11,12 @@ import { applyRoamingToAllPets } from "./pet-roaming-controller.js";
 import { createAppIcon } from "./assets.js";
 import { getCatalogPageUiState, getCatalogSearchUiState, getCatalogUiState } from "./catalog.js";
 import { getCodexPetsUiState, importCodexPet, readCodexPetSpritesheet } from "./codex-pets.js";
+import { codexV1SpriteLayout, type CodexPetSpriteLayout } from "./codex-pets-core.js";
 import { setConfinementEnabled } from "./confinement-manager.js";
 import { setCrossDisplayRoamingEnabled } from "./display.js";
 import { getActiveLocale, getActiveMessages, LOCALE_LABELS, SUPPORTED_LOCALES, setLocaleFromPreference, t, type Locale, type LocalePreference } from "./i18n/index.js";
 import { recoverDefaultPetMouseInterop, refreshDefaultPetContent, resetDefaultPetToInitialPosition } from "./default-pet-controller.js";
+import { readInstalledPetSpriteLayout } from "./installed-pet-layout.js";
 import { getLanStatusSnapshot } from "./lan-controller.js";
 import { validatePreferencePatch } from "./preference-patch.js";
 import { installPet, installPetFromFolder, installPetFromZipFile, removePet, setDefaultInstalledPet } from "./pet-installation.js";
@@ -103,9 +105,20 @@ function syncDockVisibilityForInternalUi(): void {
   }
 }
 
-function getPetsStateSnapshot(): { preferences: { defaultPetId: string }; pets: ReturnType<typeof getAppStateSnapshot>["pets"] } {
+async function getPetsStateSnapshot(): Promise<{
+  preferences: { defaultPetId: string };
+  pets: { installed: ReadonlyArray<ReturnType<typeof getAppStateSnapshot>["pets"]["installed"][number] & { readonly spriteLayout?: CodexPetSpriteLayout }> };
+}> {
   const state = getAppStateSnapshot();
-  return { preferences: { defaultPetId: state.preferences.defaultPetId }, pets: state.pets };
+  const installed = await Promise.all(state.pets.installed.map(async (pet) => {
+    if (pet.builtIn) return { ...pet, spriteLayout: codexV1SpriteLayout };
+    try {
+      return { ...pet, spriteLayout: await readInstalledPetSpriteLayout(pet.id) };
+    } catch {
+      return pet;
+    }
+  }));
+  return { preferences: { defaultPetId: state.preferences.defaultPetId }, pets: { installed } };
 }
 
 function getSettingsStateSnapshot(): {
@@ -154,7 +167,7 @@ function getI18nSnapshot(): {
 }
 
 async function getDashboardSnapshot(): Promise<{
-  readonly defaultPet: { readonly id: string; readonly displayName: string; readonly previewSpriteUrl: string };
+  readonly defaultPet: { readonly id: string; readonly displayName: string; readonly previewSpriteUrl: string; readonly spriteLayout: CodexPetSpriteLayout };
   readonly installedPetCount: number;
   readonly catalog: { readonly source: string; readonly total?: number; readonly page?: number; readonly pageCount?: number; readonly error?: string };
   readonly plugins: { readonly installed: number; readonly enabled: number; readonly broken: number };
@@ -178,6 +191,7 @@ async function getDashboardSnapshot(): Promise<{
       id: defaultPet?.id ?? state.preferences.defaultPetId,
       displayName: defaultPet?.displayName ?? "OpenPets",
       previewSpriteUrl: `openpets-pet-preview://spritesheet/default?v=${encodeURIComponent(preview.version)}`,
+      spriteLayout: preview.spriteLayout,
     },
     installedPetCount: state.pets.installed.length,
     catalog: {
@@ -1094,7 +1108,7 @@ async function getReactionAnimationSettingsSnapshot(): Promise<unknown> {
       label: t(`settings.animation.${animation.id}.label`),
       description: t(`settings.animation.${animation.id}.description`),
     })),
-    sprite: { ...defaultPetSprite, states: getConfiguredSpriteStates(state.preferences.waitingAnimationDurationMs) },
+    sprite: { ...defaultPetSprite, ...preview.spriteLayout, states: getConfiguredSpriteStates(state.preferences.waitingAnimationDurationMs) },
     waitingAnimationDurationMs: state.preferences.waitingAnimationDurationMs,
     waitingAnimationDurationOptions: waitingAnimationDurationOptions.map((option) => ({
       value: option.value,
@@ -1107,23 +1121,25 @@ async function getReactionAnimationSettingsSnapshot(): Promise<unknown> {
   };
 }
 
-async function getDefaultPetPreviewSpriteInfo(): Promise<{ readonly path: string; readonly version: string }> {
+async function getDefaultPetPreviewSpriteInfo(): Promise<{ readonly path: string; readonly version: string; readonly spriteLayout: CodexPetSpriteLayout }> {
   const state = getAppStateSnapshot();
   const selected = state.pets.installed.find((pet) => pet.id === state.preferences.defaultPetId);
   const builtInPath = join(app.getAppPath(), "assets", defaultPetSprite.fileName);
-  const candidatePath = selected && !selected.broken && !selected.builtIn
+  const usesInstalledCandidate = Boolean(selected && !selected.broken && !selected.builtIn);
+  const candidatePath = usesInstalledCandidate && selected
     ? join(getInstalledPetDir(selected.id), "spritesheet.webp")
     : builtInPath;
   try {
     const spritesheet = await stat(candidatePath);
     if (spritesheet.isFile() && spritesheet.size > 0 && spritesheet.size <= 100 * 1024 * 1024) {
-      return { path: candidatePath, version: `${selected?.id ?? "builtin"}-${Math.round(spritesheet.mtimeMs)}-${spritesheet.size}` };
+      const spriteLayout = usesInstalledCandidate && selected ? await readInstalledPetSpriteLayout(selected.id) : codexV1SpriteLayout;
+      return { path: candidatePath, version: `${usesInstalledCandidate && selected ? selected.id : "builtin"}-${Math.round(spritesheet.mtimeMs)}-${spritesheet.size}`, spriteLayout };
     }
   } catch {
     // Fall back to the bundled pet if an installed default disappears while Settings is open.
   }
   const fallback = await stat(builtInPath);
-  return { path: builtInPath, version: `builtin-${Math.round(fallback.mtimeMs)}-${fallback.size}` };
+  return { path: builtInPath, version: `builtin-${Math.round(fallback.mtimeMs)}-${fallback.size}`, spriteLayout: codexV1SpriteLayout };
 }
 
 function getLaunchAtLoginState(): { supported: boolean; enabled: boolean } {

--- a/apps/desktop/tests/codex-pet-migration.test.ts
+++ b/apps/desktop/tests/codex-pet-migration.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import sharp from "sharp";
+
+import { migrateLegacyCodexV2Imports } from "../src/codex-pet-migration.js";
+
+const baseDir = await realpath(await mkdtemp(join(tmpdir(), "openpets-codex-v2-migration-")));
+const codexPetsRoot = join(baseDir, "codex-pets");
+const installedPetsRoot = join(baseDir, "installed-pets");
+await mkdir(codexPetsRoot, { recursive: true });
+await mkdir(installedPetsRoot, { recursive: true });
+
+const v1Manifest = (id: string) => ({
+  id,
+  displayName: id,
+  description: `${id} test pet`,
+  spritesheetPath: "spritesheet.webp",
+});
+const v2Manifest = (id: string) => ({ ...v1Manifest(id), spriteVersionNumber: 2 });
+
+async function createAtlas(width: number, height: number, color: { r: number; g: number; b: number }): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { ...color, alpha: 0.5 },
+    },
+  }).webp().toBuffer();
+}
+
+async function writePet(root: string, id: string, manifest: Record<string, unknown>, atlas: Buffer): Promise<string> {
+  const dir = join(root, id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "pet.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(join(dir, "spritesheet.webp"), atlas);
+  return dir;
+}
+
+try {
+  const validAtlas = await createAtlas(1536, 2288, { r: 12, g: 34, b: 56 });
+  const repairId = "repairable";
+  const repairSource = await writePet(codexPetsRoot, repairId, v2Manifest(repairId), validAtlas);
+  await writePet(installedPetsRoot, repairId, { ...v1Manifest(repairId), importedBy: "legacy-openpets" }, validAtlas);
+
+  const first = await migrateLegacyCodexV2Imports(
+    [{ id: repairId, source: { kind: "codex", path: repairSource } }],
+    { codexPetsRoot, installedPetsRoot },
+  );
+  assert.deepEqual(first, {
+    repaired: 1,
+    skipped: 0,
+    entries: [{ id: repairId, status: "repaired" }],
+  });
+  const repairedManifest = JSON.parse(await readFile(join(installedPetsRoot, repairId, "pet.json"), "utf8"));
+  assert.equal(repairedManifest.spriteVersionNumber, 2);
+  assert.equal(repairedManifest.importedBy, "legacy-openpets", "the repair changes only the missing marker");
+
+  await rm(repairSource, { recursive: true, force: true });
+  const second = await migrateLegacyCodexV2Imports(
+    [{ id: repairId, source: { kind: "codex", path: repairSource } }],
+    { codexPetsRoot, installedPetsRoot },
+  );
+  assert.deepEqual(second, {
+    repaired: 0,
+    skipped: 1,
+    entries: [{ id: repairId, status: "skipped", reason: "already-current" }],
+  }, "a repaired import is idempotently reported as already current even when its source is no longer available");
+
+  const v1SourceId = "v1-source";
+  const v1Source = await writePet(codexPetsRoot, v1SourceId, v1Manifest(v1SourceId), validAtlas);
+  await writePet(installedPetsRoot, v1SourceId, v1Manifest(v1SourceId), validAtlas);
+  const v1SourceResult = await migrateLegacyCodexV2Imports(
+    [{ id: v1SourceId, source: { kind: "codex", path: v1Source } }],
+    { codexPetsRoot, installedPetsRoot },
+  );
+  assert.deepEqual(v1SourceResult.entries, [{ id: v1SourceId, status: "skipped", reason: "source-not-v2" }]);
+
+  const mismatchId = "hash-mismatch";
+  const mismatchSourceAtlas = await createAtlas(1536, 2288, { r: 240, g: 20, b: 30 });
+  const mismatchLocalAtlas = await createAtlas(1536, 2288, { r: 20, g: 30, b: 240 });
+  const mismatchSource = await writePet(codexPetsRoot, mismatchId, v2Manifest(mismatchId), mismatchSourceAtlas);
+  await writePet(installedPetsRoot, mismatchId, v1Manifest(mismatchId), mismatchLocalAtlas);
+  const mismatchResult = await migrateLegacyCodexV2Imports(
+    [{ id: mismatchId, source: { kind: "codex", path: mismatchSource } }],
+    { codexPetsRoot, installedPetsRoot },
+  );
+  assert.deepEqual(mismatchResult.entries, [{ id: mismatchId, status: "skipped", reason: "atlas-hash-mismatch" }]);
+  assert.equal("spriteVersionNumber" in JSON.parse(await readFile(join(installedPetsRoot, mismatchId, "pet.json"), "utf8")), false);
+
+  const wrongSizeId = "wrong-size";
+  const wrongSizeAtlas = await createAtlas(1536, 2080, { r: 80, g: 90, b: 100 });
+  const wrongSizeSource = await writePet(codexPetsRoot, wrongSizeId, v2Manifest(wrongSizeId), wrongSizeAtlas);
+  await writePet(installedPetsRoot, wrongSizeId, v1Manifest(wrongSizeId), wrongSizeAtlas);
+  const wrongSizeResult = await migrateLegacyCodexV2Imports(
+    [{ id: wrongSizeId, source: { kind: "codex", path: wrongSizeSource } }],
+    { codexPetsRoot, installedPetsRoot },
+  );
+  assert.deepEqual(wrongSizeResult.entries, [{ id: wrongSizeId, status: "skipped", reason: "local-atlas-invalid" }]);
+  assert.equal("spriteVersionNumber" in JSON.parse(await readFile(join(installedPetsRoot, wrongSizeId, "pet.json"), "utf8")), false);
+
+  console.log("Legacy Codex V2 import migration behavior passed.");
+} finally {
+  await rm(baseDir, { recursive: true, force: true });
+}

--- a/apps/desktop/tests/control-center-pet-preview.test.ts
+++ b/apps/desktop/tests/control-center-pet-preview.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+
+import { buildPetSpritePreviewModel, defaultPetSpriteLayout } from "../src/renderer/src/pet-preview-state.js";
+
+assert.deepEqual(
+  buildPetSpritePreviewModel(defaultPetSpriteLayout, { row: 0, frames: 6 }, true),
+  {
+    atlasColumns: 8,
+    atlasRows: 9,
+    row: 0,
+    frameColumns: [0, 1, 2, 3, 4, 5],
+    animated: true,
+  },
+  "V1 previews retain the existing six-frame idle animation on the 8x9 atlas",
+);
+
+const v2Layout = {
+  version: 2,
+  frameWidth: 192,
+  frameHeight: 208,
+  columns: 8,
+  rows: 11,
+  neutralPose: { row: 0, column: 6 },
+} as const;
+
+assert.deepEqual(
+  buildPetSpritePreviewModel(v2Layout, { row: 0, frames: 6 }, true),
+  {
+    atlasColumns: 8,
+    atlasRows: 11,
+    row: 0,
+    frameColumns: [6],
+    animated: false,
+  },
+  "V2 idle previews show the static neutral frame at row 0, column 6",
+);
+
+assert.deepEqual(
+  buildPetSpritePreviewModel(v2Layout, { row: 8, frames: 6 }, false),
+  {
+    atlasColumns: 8,
+    atlasRows: 11,
+    row: 8,
+    frameColumns: [0, 1, 2, 3, 4, 5],
+    animated: true,
+  },
+  "V2 reaction previews retain their normal animated frame range on the 8x11 atlas",
+);
+
+console.log("Control Center Codex V1/V2 preview behavior passed.");

--- a/docs/pets.md
+++ b/docs/pets.md
@@ -256,11 +256,29 @@ the existing runtime is idle. This matches the released
 [Malou V2 manifest](https://raw.githubusercontent.com/mySebbe/malou-codex-pet/v2.0.0/dist/malou/pet.json)
 and its [8×11 atlas specification](https://raw.githubusercontent.com/mySebbe/malou-codex-pet/v2.0.0/metadata/atlas.json).
 
+The Control Center carries that sprite layout with Codex-source and installed
+pet entries. Its Pets, Dashboard, and Settings previews therefore scale V1
+atlases as 8×9, V2 atlases as 8×11, and show the static V2 neutral cell instead
+of treating the extra rows as part of a nine-row animation.
+
+At startup, OpenPets also performs an idempotent repair for Codex V2 imports
+created by older releases that copied the 11-row atlas but dropped the version
+marker from the installed `pet.json`. It restores only that marker, and only
+when the persisted source still points to the expected canonical Codex pet,
+the source manifest is valid V2, the local atlas passes the exact V2
+`1536×2288` contract, and SHA-256 hashes of the source and local atlas bytes
+match. Already-current and unverifiable imports are skipped; per-pet results,
+repaired/skipped counts, and skip reasons are logged, and a migration problem
+never prevents the desktop app from starting.
+
 V2's sixteen look-direction cells (rows 9–10) are retained in the imported
 atlas but are not individually selected: OpenPets currently emits only idle,
 left-run, and right-run motion, not a two-dimensional gaze target. It therefore
 does not invent directional behavior or claim full gaze support. A future gaze
 API can map those cells directly without changing the import contract.
+
+Codex integration remains import-only: OpenPets does not write installed or
+catalog pets back into `~/.codex/pets/`.
 
 ## Image protocols & CSP
 


### PR DESCRIPTION
## Summary

- propagate Codex sprite layout metadata into installed/Codex pet entries and use 8×9 or 8×11 geometry in Pets, Dashboard, and Settings previews
- render the Codex V2 neutral pose from row 0, column 6 instead of scaling the 11-row atlas as a 9-row sheet
- migrate legacy Codex V2 imports by restoring only the missing marker when canonical paths, V2 metadata, exact atlas validation, and raw SHA-256 equality all agree
- report per-pet repaired/skipped migration results without making startup depend on migration success
- document the maintained V2 preview and migration behavior; keep reverse export outside OpenPets

## Tests

- `pnpm_config_verify_deps_before_run=false pnpm --filter @open-pets/desktop typecheck`
- `pnpm_config_verify_deps_before_run=false pnpm --filter @open-pets/desktop exec tsc -p tsconfig.tests.json`
- `node apps/desktop/.test-dist/tests/codex-pets.test.js`
- `node apps/desktop/.test-dist/tests/codex-pet-migration.test.js`
- `node apps/desktop/.test-dist/tests/control-center-pet-preview.test.js`
- `git diff --check`

The full `pnpm_config_verify_deps_before_run=false pnpm --filter @open-pets/desktop check` passes typecheck, production builds, and all new behavior tests. It later fails in the unchanged `provider-credential-deletion.test.js` because plain Node cannot import Electron's `net` named export from `electron`.
