### PR TITLE
fix(linux): fall back to normal windows when layer-shell helper cannot start

### DIFF
--- a/apps/desktop/src/agent-pet-controller.ts
+++ b/apps/desktop/src/agent-pet-controller.ts
@@ -194,6 +194,18 @@ function getOrCreateAgentPetWindow(petId: string): BrowserWindow {
     badge,
     onCloseRequested: () => dismissAgentPetForActiveLease(petId),
     onBubbleDismissed: (token) => handleBubbleDismissed(petId, token),
+    onWindowReplaced: (replacement) => {
+      agentPetWindows.set(petId, replacement);
+      const currentDisplay = transientDisplays.get(petId) ?? null;
+      const currentBadge = statusBadges.get(petId) ?? null;
+      void loadExplicitPetContent(replacement, petId, currentDisplay, currentBadge, getCurrentDismissToken(petId, currentDisplay, currentBadge), getPreferredPetScale());
+      replacement.on("closed", () => {
+        if (agentPetWindows.get(petId) !== replacement) return;
+        unregisterRoamingPet(petId);
+        agentPetWindows.delete(petId);
+        clearAgentDisplay(petId);
+      });
+    },
     onFocusSessionWindow: () => {
       const confinement = getConfinementState(petId);
       if (confinement?.terminalOwnerPid) {
@@ -206,6 +218,7 @@ function getOrCreateAgentPetWindow(petId: string): BrowserWindow {
   const windowId = window.id;
 
   window.on("closed", () => {
+    if (agentPetWindows.get(petId) !== window) return;
     info("pet.agent", "closed", { petId, windowId, activeWindowsBeforeDelete: agentPetWindows.size });
     // Unregister from the motion engine BEFORE deleting the window map entry
     // to prevent the shared ticker from touching the destroyed window.

--- a/apps/desktop/src/default-pet-controller.ts
+++ b/apps/desktop/src/default-pet-controller.ts
@@ -345,11 +345,23 @@ function getOrCreateDefaultPetWindow(): BrowserWindow {
     onBubbleAction: (token, actionId) => defaultPetBubbleArbiter.handleAction(token, actionId),
     onBubbleSubmit: (token, values) => defaultPetBubbleArbiter.handleSubmit(token, values),
     onPetEvent: (name, payload) => publishPluginPetEvent("default", name, payload),
+    onWindowReplaced: (replacement) => {
+      defaultPetWindow = replacement;
+      void loadDefaultPetContent(replacement, paused, getRenderedDisplay(), getRenderedBadge(), getCurrentDismissToken(), getDefaultPetPluginBubbles());
+      const replacementId = replacement.id;
+      replacement.on("closed", () => {
+        if (defaultPetWindow !== replacement) return;
+        info("pet.default", "closed", { windowId: replacementId });
+        defaultPetWindow = null;
+      });
+    },
   }, getCurrentDismissToken());
-  const windowId = defaultPetWindow.id;
+  const createdWindow = defaultPetWindow;
+  const windowId = createdWindow.id;
   info("pet.default", "created", { windowId, position, paused, petId: getAppStateSnapshot().preferences.defaultPetId });
 
-  defaultPetWindow.on("closed", () => {
+  createdWindow.on("closed", () => {
+    if (defaultPetWindow !== createdWindow) return;
     info("pet.default", "closed", { windowId });
     defaultPetWindow = null;
   });

--- a/apps/desktop/src/lan-pet-controller.ts
+++ b/apps/desktop/src/lan-pet-controller.ts
@@ -5,7 +5,7 @@ import { clampToVisibleWorkArea, defaultPetWindowSize, getDefaultPetInitialPosit
 import { debug, info, warn } from "./logger.js";
 import { planLanPetPresence, resolveRenderableLanPetId } from "./lan-pet-presence.js";
 import type { LanPetRecord, LanPoint } from "./lan-state.js";
-import { createAgentPetWindow, getTransientDisplayDurationMs, loadExplicitPetContent, readWindowPosition } from "./pet-window.js";
+import { createAgentPetWindow, getTransientDisplayDurationMs, loadExplicitPetContent, readWindowPosition, type PetTransientDisplay } from "./pet-window.js";
 import type { OpenPetsReaction } from "./local-ipc-protocol.js";
 import { registerRoamingPet, unregisterRoamingPet } from "./pet-roaming-controller.js";
 
@@ -14,13 +14,14 @@ type VisitingPetWindow = {
   readonly requestedPetId: string;
   readonly renderedPetId: string;
   readonly motionHandleId: string;
-  readonly window: BrowserWindow;
+  window: BrowserWindow;
 };
 
 const visitingPetWindows = new Map<string, VisitingPetWindow>();
 const dismissedOwnerHosts = new Set<string>();
 const unavailablePetWarnings = new Set<string>();
 const displayClearTimers = new Map<string, NodeJS.Timeout>();
+const activeDisplays = new Map<string, PetTransientDisplay>();
 
 export function syncLanVisitingPets(localHost: string, pets: readonly LanPetRecord[]): void {
   const plan = planLanPetPresence(localHost, pets, [...visitingPetWindows.keys()]);
@@ -55,9 +56,11 @@ export function applyLanVisitingPetSay(ownerHost: string, message: string, react
   const existingTimer = displayClearTimers.get(ownerHost);
   if (existingTimer) clearTimeout(existingTimer);
   const display = { message, reaction, suppressReactionMessage: true, dismissToken: `lan-work:${ownerHost}:${sequence}` };
+  activeDisplays.set(ownerHost, display);
   void loadExplicitPetContent(entry.window, entry.renderedPetId, display, null, display.dismissToken, getAppStateSnapshot().preferences.petScale as PetScaleValue);
   const timer = setTimeout(() => {
     displayClearTimers.delete(ownerHost);
+    activeDisplays.delete(ownerHost);
     const current = visitingPetWindows.get(ownerHost);
     if (current && !current.window.isDestroyed()) void loadExplicitPetContent(current.window, current.renderedPetId);
   }, getTransientDisplayDurationMs(display));
@@ -114,6 +117,19 @@ function showLanVisitingPet(pet: LanPetRecord): void {
       dismissedOwnerHosts.add(pet.ownerHost);
       closeLanVisitingPet(pet.ownerHost);
     },
+    onWindowReplaced: (replacement) => {
+      const current = visitingPetWindows.get(pet.ownerHost);
+      if (!current) return;
+      current.window = replacement;
+      const currentDisplay = activeDisplays.get(pet.ownerHost) ?? null;
+      void loadExplicitPetContent(replacement, renderedPetId, currentDisplay, null, currentDisplay?.dismissToken, getAppStateSnapshot().preferences.petScale as PetScaleValue);
+      replacement.once("closed", () => {
+        const latest = visitingPetWindows.get(pet.ownerHost);
+        if (latest?.window !== replacement) return;
+        unregisterRoamingPet(motionHandleId);
+        visitingPetWindows.delete(pet.ownerHost);
+      });
+    },
   });
   const entry: VisitingPetWindow = {
     ownerHost: pet.ownerHost,
@@ -141,6 +157,7 @@ function closeLanVisitingPet(ownerHost: string): void {
   const displayTimer = displayClearTimers.get(ownerHost);
   if (displayTimer) clearTimeout(displayTimer);
   displayClearTimers.delete(ownerHost);
+  activeDisplays.delete(ownerHost);
   const entry = visitingPetWindows.get(ownerHost);
   if (!entry) return;
   visitingPetWindows.delete(ownerHost);

--- a/apps/desktop/src/pet-window.ts
+++ b/apps/desktop/src/pet-window.ts
@@ -40,6 +40,8 @@ export interface DefaultPetWindowOptions extends PetWindowInteractionHooks {
   readonly onHideRequested: () => void;
   readonly onTalkRequested?: () => void;
   readonly onTalkLabelRequested?: () => Promise<string>;
+  /** Called when an asynchronous layer-shell failure rebuilds this pet as a normal window. */
+  readonly onWindowReplaced?: (window: BrowserWindow) => void;
 }
 
 export interface AgentPetWindowOptions extends PetWindowInteractionHooks {
@@ -57,6 +59,8 @@ export interface AgentPetWindowOptions extends PetWindowInteractionHooks {
    * When provided, a "Focus session window" item is added to the right-click menu.
    */
   readonly onFocusSessionWindow?: () => void;
+  /** Called when an asynchronous layer-shell failure rebuilds this pet as a normal window. */
+  readonly onWindowReplaced?: (window: BrowserWindow) => void;
 }
 
 /** Plugin-arbiter bubble content for one pet surface (both slots). */
@@ -161,9 +165,25 @@ export function isPetWindowDragging(window: BrowserWindow): boolean {
 }
 
 export function createDefaultPetWindow(options: DefaultPetWindowOptions, dismissToken?: string): BrowserWindow {
-  const window = createBasePetWindow("OpenPets — Default Pet", options.position, {
-    hasInteractiveInput: petPluginBubblesHaveInteractiveInput(options.pluginBubbles ?? null),
-  });
+  const window = createBasePetWindow(
+    "OpenPets — Default Pet",
+    options.position,
+    { hasInteractiveInput: petPluginBubblesHaveInteractiveInput(options.pluginBubbles ?? null) },
+    (fallbackPosition, wasVisible) => {
+      // layer-shell backend failed asynchronously — rebuild as a normal window
+      // at the pet's latest tracked position, not its original spawn point.
+      info("pet.window", "layer-shell failed; rebuilding default pet as a normal window", { position: fallbackPosition, wasVisible });
+      const replacement = createBasePetWindowWithMode("OpenPets — Default Pet", fallbackPosition, { hasInteractiveInput: petPluginBubblesHaveInteractiveInput(options.pluginBubbles ?? null) }, false);
+      installDefaultPetWindow(replacement, options, dismissToken);
+      options.onWindowReplaced?.(replacement);
+      if (wasVisible) replacement.showInactive();
+    },
+  );
+  if (!window.isDestroyed()) installDefaultPetWindow(window, options, dismissToken);
+  return window;
+}
+
+function installDefaultPetWindow(window: BrowserWindow, options: DefaultPetWindowOptions, dismissToken?: string): void {
   info("pet.window", "default window create", { windowId: window.id, position: options.position, paused: options.paused, hasDisplay: Boolean(options.display), badge: options.badge });
   installMousePassthroughAndDrag(window, options);
   installMotionStatePublisher(window);
@@ -185,18 +205,33 @@ export function createDefaultPetWindow(options: DefaultPetWindowOptions, dismiss
   });
 
   void loadDefaultPetContent(window, options.paused, options.display, options.badge, dismissToken, options.pluginBubbles ?? null);
-
-  return window;
 }
 
 export function createAgentPetWindow(options: AgentPetWindowOptions, dismissToken?: string): BrowserWindow {
-  const window = createBasePetWindow(`OpenPets — ${options.displayName}`, options.position);
+  const window = createBasePetWindow(
+    `OpenPets — ${options.displayName}`,
+    options.position,
+    {},
+    (fallbackPosition, wasVisible) => {
+      // layer-shell backend failed asynchronously — rebuild as a normal window
+      // at the pet's latest tracked position, not its original spawn point.
+      info("pet.window", "layer-shell failed; rebuilding agent pet as a normal window", { petId: options.petId, position: fallbackPosition, wasVisible });
+      const replacement = createBasePetWindowWithMode(`OpenPets — ${options.displayName}`, fallbackPosition, {}, false);
+      installAgentPetWindow(replacement, options, dismissToken);
+      options.onWindowReplaced?.(replacement);
+      if (wasVisible) replacement.showInactive();
+    },
+  );
+  if (!window.isDestroyed()) installAgentPetWindow(window, options, dismissToken);
+  return window;
+}
+
+function installAgentPetWindow(window: BrowserWindow, options: AgentPetWindowOptions, dismissToken?: string): void {
   info("pet.window", "agent window create", { windowId: window.id, petId: options.petId, displayName: options.displayName, position: options.position, hasDisplay: Boolean(options.display), badge: options.badge });
   installMousePassthroughAndDrag(window, options);
   installMotionStatePublisher(window);
   installPetContextMenu(window, { label: t("pet.menu.closePet"), click: options.onCloseRequested, focusSessionWindow: options.onFocusSessionWindow });
   void loadExplicitPetContent(window, options.petId, options.display, options.badge, dismissToken, options.scale);
-  return window;
 }
 
 export function recoverPetMouseInterop(window: BrowserWindow, reason: string): void {
@@ -700,8 +735,8 @@ function isScreenPoint(value: unknown): value is { readonly screenX: number; rea
   return typeof value === "object" && value !== null && typeof (value as { readonly screenX?: unknown }).screenX === "number" && typeof (value as { readonly screenY?: unknown }).screenY === "number";
 }
 
-function createBasePetWindow(title: string, position: Point, focusOptions: { readonly hasInteractiveInput?: boolean } = {}): BrowserWindow {
-  return createBasePetWindowWithMode(title, position, focusOptions, shouldUseLayerShellBackend());
+function createBasePetWindow(title: string, position: Point, focusOptions: { readonly hasInteractiveInput?: boolean } = {}, onLayerShellFatal?: (position: Point, wasVisible: boolean) => void): BrowserWindow {
+  return createBasePetWindowWithMode(title, position, focusOptions, shouldUseLayerShellBackend(), onLayerShellFatal);
 }
 
 /**
@@ -713,7 +748,7 @@ export function shouldUseLayerShellBackend(): boolean {
   return isLayerShellBackendRequested(process.platform, process.env) && isLayerShellHelperAvailable();
 }
 
-function createBasePetWindowWithMode(title: string, position: Point, focusOptions: { readonly hasInteractiveInput?: boolean }, useLayerShell: boolean): BrowserWindow {
+function createBasePetWindowWithMode(title: string, position: Point, focusOptions: { readonly hasInteractiveInput?: boolean }, useLayerShell: boolean, onLayerShellFatal?: (position: Point, wasVisible: boolean) => void): BrowserWindow {
   const effectiveWaylandBackend = isEffectiveWaylandBackend();
   const focusable = shouldPetWindowBeFocusable(process.platform, effectiveWaylandBackend, focusOptions.hasInteractiveInput === true);
   const window = new BrowserWindow({
@@ -814,7 +849,28 @@ function createBasePetWindowWithMode(title: string, position: Point, focusOption
       // display-facing methods on the instance so the rest of the pet stack
       // (controllers, motion engine, content loading) keeps working unchanged
       // while the visible carrier is the helper's overlay surface.
-      adoptPetWindowForLayerShell(window, position);
+      const surface = adoptPetWindowForLayerShell(window, position);
+      // Asynchronous startup/runtime failure (helper cannot start, keeps
+      // dying, never becomes ready) — tear the offscreen window down and let
+      // the caller rebuild the pet as a normal visible window.
+      surface.onFatal = () => {
+        if (window.isDestroyed()) return;
+        logError("pet.window", "layer-shell backend fatal; falling back to a normal window", {});
+        // Build and publish the replacement first. The old window's `closed`
+        // listener can then see that it no longer owns the controller slot and
+        // must not clear the replacement's state.
+        try {
+          onLayerShellFatal?.(readWindowPosition(window), window.isVisible());
+        } catch (error) {
+          logError("pet.window", "normal-window fallback failed", error instanceof Error ? error : { error });
+        } finally {
+          try {
+            if (!window.isDestroyed()) window.destroy();
+          } catch {
+            // window may already be gone
+          }
+        }
+      };
     } catch (error) {
       logError("pet.window", "layer-shell adoption failed; falling back to a normal window", error instanceof Error ? error : { error });
       if (!window.isDestroyed()) window.destroy();

--- a/apps/desktop/src/plugin-pet-registry.ts
+++ b/apps/desktop/src/plugin-pet-registry.ts
@@ -79,7 +79,15 @@ export function onPluginPetsChange(listener: (pets: PluginPetInfo[]) => void): (
 function refreshSpawnedPet(pet: SpawnedPet): void {
   if (!pet.window || pet.window.isDestroyed()) return;
   void loadExplicitPetContent(pet.window, pet.petId, null, pet.statusReaction, undefined, pet.scale, pet.bubbles.transient || pet.bubbles.pinned ? pet.bubbles : null).then(() => {
-    if (pet.window && !pet.window.isDestroyed() && pet.spriteOverride) setPetSpriteOverride(pet.window, pet.spriteOverride);
+    if (!pet.window || pet.window.isDestroyed()) return;
+    if (pet.spriteOverride) {
+      setPetSpriteOverride(pet.window, pet.spriteOverride);
+      return;
+    }
+    if (pet.currentAnimation !== "idle" && pet.currentAnimation !== "sprite") {
+      const spriteState = resolveReactionSpriteState(pet.currentAnimation as OpenPetsReaction, getAppStateSnapshot().preferences.reactionAnimationOverrides);
+      setPetReactionState(pet.window, spriteState);
+    }
   });
 }
 
@@ -129,9 +137,14 @@ export async function spawnPluginPet(opts: { pluginId: string; petId: string; na
     onBubbleAction: (token, actionId) => pet.arbiter.handleAction(token, actionId),
     onBubbleSubmit: (token, values) => pet.arbiter.handleSubmit(token, values),
     onPetEvent: (name, payload) => publishPluginPetEvent(handleId, name, payload),
+    onWindowReplaced: (replacement) => {
+      pet.window = replacement;
+      replacement.once("closed", () => { if (pet.window === replacement) pet.window = null; });
+      refreshSpawnedPet(pet);
+    },
   });
   pet.window = window;
-  window.once("closed", () => { pet.window = null; });
+  window.once("closed", () => { if (pet.window === window) pet.window = null; });
   window.showInactive();
   spawnedPets.set(handleId, pet);
   info("plugin", "plugin pet spawned", { handleId, petId: opts.petId, pluginId: opts.pluginId });

--- a/apps/desktop/src/wayland-layer-backend.ts
+++ b/apps/desktop/src/wayland-layer-backend.ts
@@ -171,6 +171,19 @@ class LayerShellSurface {
   readonly height: number;
   private frameOffset = { x: 0, y: 0 };
 
+  /**
+   * Fatal backend failure (helper cannot start / keeps dying). When set, the
+   * owner should tear down the offscreen pet and rebuild it as a normal
+   * window so the pet stays visible even when layer-shell is unavailable.
+   */
+  onFatal: (() => void) | null = null;
+  private restartCount = 0;
+  private startupTimer: NodeJS.Timeout | null = null;
+  private stabilityTimer: NodeJS.Timeout | null = null;
+  private static readonly MAX_RESTARTS = 2;
+  private static readonly STARTUP_TIMEOUT_MS = 10_000;
+  private static readonly STABLE_RUNTIME_MS = 30_000;
+
   private readonly socketPath: string;
   private readonly helperPath: string;
   private helper: ReturnType<typeof import("node:child_process").spawn> | null = null;
@@ -178,6 +191,8 @@ class LayerShellSurface {
   private connected = false;
   private ready = false;
   private destroyed = false;
+  /** Invalidates delayed socket retries from an exited/replaced helper. */
+  private connectionGeneration = 0;
   private position: Point;
   private visible = true;
   /** Commands queued while the socket is still connecting. */
@@ -195,6 +210,7 @@ class LayerShellSurface {
 
   /** Spawn the helper and open the socket. Must be called once. */
   start(): void {
+    this.restartCount = 0;
     const child = spawnHelper(this.helperPath, this.socketPath, this.width, this.height, this.position);
     if (!child) {
       throw new Error(`failed to spawn ${this.helperPath}`);
@@ -204,17 +220,31 @@ class LayerShellSurface {
 
     // The helper binds its socket shortly after launch; retry the connect so
     // we never lose the race against a fresh process.
-    this.connectWithRetry(0);
+    const generation = ++this.connectionGeneration;
+    this.connectWithRetry(0, generation);
+    this.armStartupTimer();
   }
 
   /**
    * The helper process exited (crash, lock screen, session teardown) — spawn
    * a fresh one and re-establish the surface so the pet does not vanish until
-   * the whole app is restarted.
+   * the whole app is restarted. If it keeps dying (e.g. the compositor does
+   * not actually provide wlr-layer-shell), give up and ask the owner to fall
+   * back to a normal window instead of restarting forever.
    */
   private restart(): void {
     if (this.destroyed) return;
-    info("pet.wayland", "helper exited; restarting layer-shell surface", { socketPath: this.socketPath });
+    this.clearStabilityTimer();
+    this.restartCount += 1;
+    if (this.restartCount > LayerShellSurface.MAX_RESTARTS) {
+      logError("pet.wayland", "helper kept failing; giving up on layer-shell", {
+        socketPath: this.socketPath,
+        restartCount: this.restartCount,
+      });
+      this.fatal();
+      return;
+    }
+    info("pet.wayland", "helper exited; restarting layer-shell surface", { socketPath: this.socketPath, restartCount: this.restartCount });
     if (this.socket) {
       try {
         this.socket.destroy();
@@ -237,37 +267,122 @@ class LayerShellSurface {
     const child = spawnHelper(this.helperPath, this.socketPath, this.width, this.height, this.position);
     if (!child) {
       logError("pet.wayland", "helper restart failed", { socketPath: this.socketPath });
+      this.fatal();
       return;
     }
     this.helper = child;
     child.on("exit", () => this.restart());
-    this.connectWithRetry(0);
+    const generation = ++this.connectionGeneration;
+    this.connectWithRetry(0, generation);
     if (!this.visible) this.write(encodeMessage(TAG_HIDE, Buffer.alloc(0)));
+    this.armStartupTimer();
   }
 
-  private connectWithRetry(attempt: number): void {
+  /** Start a timer that gives up if the helper never reports READY. */
+  private armStartupTimer(): void {
+    this.clearStartupTimer();
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null;
+      debug("pet.wayland", "helper did not become ready in time", { socketPath: this.socketPath });
+      this.fatal();
+    }, LayerShellSurface.STARTUP_TIMEOUT_MS);
+  }
+
+  private clearStartupTimer(): void {
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+  }
+
+  /** A READY helper must stay alive for a while before failures are forgiven. */
+  private armStabilityTimer(): void {
+    this.clearStabilityTimer();
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      this.restartCount = 0;
+      debug("pet.wayland", "helper runtime considered stable", { socketPath: this.socketPath });
+    }, LayerShellSurface.STABLE_RUNTIME_MS);
+  }
+
+  private clearStabilityTimer(): void {
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
+  }
+
+  /**
+   * Permanently stop the layer-shell backend and notify the owner so it can
+   * rebuild the pet as a normal window.
+   */
+  private fatal(): void {
+    if (this.destroyed) return;
+    this.destroyed = true; // stops the restart loop and any further teardown
+    this.connectionGeneration += 1; // invalidates delayed connect retries
+    this.clearStartupTimer();
+    this.clearStabilityTimer();
+    this.stopFrameStreaming();
+    if (this.socket) {
+      try {
+        this.socket.destroy();
+      } catch {
+        // already closed
+      }
+      this.socket = null;
+    }
+    if (this.helper && !this.helper.killed) {
+      try {
+        this.helper.kill();
+      } catch {
+        // already gone
+      }
+      this.helper = null;
+    }
+    try {
+      if (existsSync(this.socketPath)) unlinkSync(this.socketPath);
+    } catch {
+      // ignore stale socket cleanup failure
+    }
+    logError("pet.wayland", "layer-shell backend fatal; falling back", { socketPath: this.socketPath });
+    this.onFatal?.();
+  }
+
+  private connectWithRetry(attempt: number, generation: number): void {
+    if (this.destroyed || generation !== this.connectionGeneration) return;
     const socket = net.connect(this.socketPath);
     this.socket = socket;
     socket.setNoDelay(true);
 
     socket.on("connect", () => {
+      if (this.destroyed || generation !== this.connectionGeneration) {
+        socket.destroy();
+        return;
+      }
       this.connected = true;
       debug("pet.wayland", "helper socket connected", { socketPath: this.socketPath, attempt });
       this.flushPending();
     });
-    socket.on("data", (chunk: Buffer) => this.handleIncoming(chunk));
+    socket.on("data", (chunk: Buffer) => {
+      if (!this.destroyed && generation === this.connectionGeneration) this.handleIncoming(chunk);
+    });
     socket.on("error", (error) => {
-      const refused = (error as NodeJS.ErrnoException).code === "ECONNREFUSED" || (error as NodeJS.ErrnoException).code === "ENOENT";
-      if (refused && attempt < MAX_CONNECT_ATTEMPTS) {
-        // Not bound yet — tear down and try again shortly.
+      if (this.destroyed || generation !== this.connectionGeneration) {
         socket.destroy();
-        this.socket = null;
-        setTimeout(() => this.connectWithRetry(attempt + 1), CONNECT_RETRY_MS);
+        return;
+      }
+      const refused = (error as NodeJS.ErrnoException).code === "ECONNREFUSED" || (error as NodeJS.ErrnoException).code === "ENOENT";
+      if (refused && attempt < MAX_CONNECT_ATTEMPTS && !this.destroyed && generation === this.connectionGeneration) {
+        // Not bound yet — tear down and try again shortly. The generation
+        // check prevents retries from an exited helper racing a replacement.
+        socket.destroy();
+        if (this.socket === socket) this.socket = null;
+        setTimeout(() => this.connectWithRetry(attempt + 1, generation), CONNECT_RETRY_MS);
         return;
       }
       logError("pet.wayland", "helper socket error", { socketPath: this.socketPath, error: error.message, attempt });
       socket.destroy();
-      this.socket = null;
+      if (this.socket === socket) this.socket = null;
     });
     socket.on("close", () => {
       if (this.socket === socket) {
@@ -303,6 +418,8 @@ class LayerShellSurface {
       const tag = body[0];
       if (tag === TAG_READY && !this.ready) {
         this.ready = true;
+        this.clearStartupTimer();
+        this.armStabilityTimer();
         info("pet.wayland", "helper surface ready (layer-shell configured)");
         this.attachFrameStreaming();
       } else if (tag === TAG_POINTER && body.length >= 13) {
@@ -535,6 +652,9 @@ class LayerShellSurface {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.connectionGeneration += 1;
+    this.clearStartupTimer();
+    this.clearStabilityTimer();
     this.stopFrameStreaming();
     if (this.window && !this.window.isDestroyed() && !this.window.webContents.isDestroyed()) {
       try {
@@ -611,7 +731,7 @@ function spawnHelper(
  * existing pet controllers keep working unchanged. Throws when the helper
  * cannot be started (caller should fall back to a normal window).
  */
-export function adoptPetWindowForLayerShell(window: BrowserWindow, position: Point): BrowserWindow {
+export function adoptPetWindowForLayerShell(window: BrowserWindow, position: Point): LayerShellSurface {
   const helperPath = resolveHelperBinaryPath();
   if (!helperPath) {
     throw new Error("openpets-wayland-helper binary not found");
@@ -640,7 +760,7 @@ export function adoptPetWindowForLayerShell(window: BrowserWindow, position: Poi
     size: [surface.width, surface.height],
     socketPath,
   });
-  return window;
+  return surface;
 }
 
 function resolveRuntimeDir(): string {

--- a/docs/wayland-layer-shell.md
+++ b/docs/wayland-layer-shell.md
@@ -57,8 +57,12 @@ The backend only activates when all of these hold:
 - the native helper binary is available
 
 Otherwise OpenPets falls back to the existing window path unchanged. If the
-helper cannot start at runtime, each pet window logs an error and falls back to
-a normal window.
+helper cannot start or becomes unhealthy at runtime (helper exits before
+`READY`, cannot bind `wlr-layer-shell`, or does not report `READY` within 10
+seconds), OpenPets retries a bounded number of times, then rebuilds the pet as
+a normal `BrowserWindow` at its current tracked position/visibility. Each
+controller adopts the replacement so later state updates keep routing to the
+visible window instead of the old offscreen pet.
 
 ## Build the helper
 


### PR DESCRIPTION
## Summary

Follow-up to #166. When the opt-in Wayland layer-shell helper fails asynchronously (binary exists but the compositor lacks `wlr-layer-shell`, the helper keeps exiting before `READY`, or it never becomes ready in time), OpenPets now stops retrying and rebuilds the pet as a normal visible `BrowserWindow` instead of leaving an invisible offscreen pet.

## What changed

- **Restart cap + startup timeout** in `wayland-layer-backend.ts`: helper exits are retried a bounded number of times, then the backend is marked fatal and falls back. A 10s startup timeout covers the hang case.
- **Connection generation**: delayed socket retries and stale socket errors cannot detach the newly restarted helper connection.
- **Runtime stability guard**: consecutive failures are only forgiven after the helper has stayed `READY` for 30s, preventing configure-then-crash infinite loops.
- **Normal window fallback**: the owner rebuilds the pet with `useLayerShell=false`, preserving the current tracked position and visibility.
- **Ownership handoff**: default, agent, plugin, and LAN pet controllers update their stored `BrowserWindow` reference and guard stale `closed` listeners, so later state updates keep routing to the rebuilt window.
- **State restoration**: replacement windows restore the latest default/agent/LAN content and plugin reaction/sprite state.

## Verification

Manually verified on Arch Linux + Niri:

- Fake helper that exits immediately: falls back to a normal floating pet window, layer count 0.
- Fake helper that hangs: falls back after the 10s timeout.
- Real helper killed once: automatically restarts and the layer surface returns without fallback.
- `pnpm --dir apps/desktop build:main` passes.