### PR TITLE
feat(plugin-sdk): expose optional GPU and disk metrics

### DIFF
--- a/apps/desktop/scripts/run-tests.mjs
+++ b/apps/desktop/scripts/run-tests.mjs
@@ -93,6 +93,7 @@ const behaviorTests = [
   ".test-dist/tests/pet-motion-engine-nan-guard.test.js",
   ".test-dist/tests/pet-roaming-controller.test.js",
   ".test-dist/tests/display.test.js",
+  ".test-dist/tests/system-metrics.test.js",
   ".test-dist/tests/preference-patch.test.js",
   ".test-dist/tests/plugin-agent-activity.test.js",
   ".test-dist/tests/pet-window-wayland-predicate.test.js",

--- a/apps/desktop/src/plugin-host-capabilities.ts
+++ b/apps/desktop/src/plugin-host-capabilities.ts
@@ -31,6 +31,7 @@ import { getAppStateSnapshot } from "./app-state.js";
 import { readSafePluginManifest } from "./plugin-manifest-reader.js";
 import { resolveTrustedPluginSprite } from "./plugin-assets.js";
 import { getPluginService } from "./plugin-service.js";
+import { readExtendedSystemMetrics } from "./system-metrics.js";
 
 /**
  * The Electron implementation of every SDK v3 host capability. Built once at
@@ -43,6 +44,20 @@ const maxPickedFileBytes = 16 * 1024 * 1024;
 type PickedFileEntry = { path: string; name: string; sizeBytes: number };
 
 let cpuSample: { idle: number; total: number } | null = null;
+let extendedMetricsCache: { expiresAt: number; value: Awaited<ReturnType<typeof readExtendedSystemMetrics>> } | null = null;
+let extendedMetricsInFlight: Promise<Awaited<ReturnType<typeof readExtendedSystemMetrics>>> | null = null;
+
+async function cachedExtendedSystemMetrics(): Promise<Awaited<ReturnType<typeof readExtendedSystemMetrics>>> {
+  if (extendedMetricsCache && extendedMetricsCache.expiresAt > Date.now()) return extendedMetricsCache.value;
+  if (extendedMetricsInFlight) return extendedMetricsInFlight;
+  extendedMetricsInFlight = readExtendedSystemMetrics().then((value) => {
+    extendedMetricsCache = { value, expiresAt: Date.now() + 5_000 };
+    return value;
+  }).finally(() => {
+    extendedMetricsInFlight = null;
+  });
+  return extendedMetricsInFlight;
+}
 
 function sampleCpus(): { idle: number; total: number } {
   let idle = 0;
@@ -272,7 +287,7 @@ export function createElectronPluginHostCapabilities(userDataPath: string): Elec
       async metrics() {
         const memory = process.getSystemMemoryInfo();
         const memUsedPercent = memory.total > 0 ? Math.round(Math.min(100, Math.max(0, (1 - memory.free / memory.total) * 100))) : 0;
-        return { cpuPercent: cpuPercent(), memUsedPercent };
+        return { cpuPercent: cpuPercent(), memUsedPercent, ...(await cachedExtendedSystemMetrics()) };
       },
       async openExternal(url) {
         let host: string | undefined;

--- a/apps/desktop/src/plugin-host-capabilities.ts
+++ b/apps/desktop/src/plugin-host-capabilities.ts
@@ -47,16 +47,18 @@ let cpuSample: { idle: number; total: number } | null = null;
 let extendedMetricsCache: { expiresAt: number; value: Awaited<ReturnType<typeof readExtendedSystemMetrics>> } | null = null;
 let extendedMetricsInFlight: Promise<Awaited<ReturnType<typeof readExtendedSystemMetrics>>> | null = null;
 
-async function cachedExtendedSystemMetrics(): Promise<Awaited<ReturnType<typeof readExtendedSystemMetrics>>> {
+function cachedExtendedSystemMetrics(): Awaited<ReturnType<typeof readExtendedSystemMetrics>> {
   if (extendedMetricsCache && extendedMetricsCache.expiresAt > Date.now()) return extendedMetricsCache.value;
-  if (extendedMetricsInFlight) return extendedMetricsInFlight;
-  extendedMetricsInFlight = readExtendedSystemMetrics().then((value) => {
-    extendedMetricsCache = { value, expiresAt: Date.now() + 5_000 };
-    return value;
-  }).finally(() => {
-    extendedMetricsInFlight = null;
-  });
-  return extendedMetricsInFlight;
+  if (!extendedMetricsInFlight) {
+    extendedMetricsInFlight = readExtendedSystemMetrics().then((value) => {
+      extendedMetricsCache = { value, expiresAt: Date.now() + 5_000 };
+      return value;
+    }).catch(() => ({})).finally(() => {
+      extendedMetricsInFlight = null;
+    });
+  }
+  // CPU and memory are always immediate; optional probes populate the next read.
+  return {};
 }
 
 function sampleCpus(): { idle: number; total: number } {
@@ -287,7 +289,7 @@ export function createElectronPluginHostCapabilities(userDataPath: string): Elec
       async metrics() {
         const memory = process.getSystemMemoryInfo();
         const memUsedPercent = memory.total > 0 ? Math.round(Math.min(100, Math.max(0, (1 - memory.free / memory.total) * 100))) : 0;
-        return { cpuPercent: cpuPercent(), memUsedPercent, ...(await cachedExtendedSystemMetrics()) };
+        return { cpuPercent: cpuPercent(), memUsedPercent, ...cachedExtendedSystemMetrics() };
       },
       async openExternal(url) {
         let host: string | undefined;

--- a/apps/desktop/src/plugin-sdk-bridge.ts
+++ b/apps/desktop/src/plugin-sdk-bridge.ts
@@ -202,7 +202,7 @@ export interface PluginHostCapabilities {
   };
   system: {
     info(): Promise<{ platform: "mac" | "win" | "linux"; locale: string; timezone: string; theme: "light" | "dark"; appVersion: string; online: boolean }>;
-    metrics(): Promise<{ cpuPercent: number; memUsedPercent: number; battery?: { percent: number; charging: boolean } }>;
+    metrics(): Promise<{ cpuPercent: number; memUsedPercent: number; gpuPercent?: number; diskUsedPercent?: number; battery?: { percent: number; charging: boolean } }>;
     openExternal(url: string): Promise<void>;
     readClipboardText(): Promise<string>;
     writeClipboardText(text: string): Promise<void>;

--- a/apps/desktop/src/system-metrics.ts
+++ b/apps/desktop/src/system-metrics.ts
@@ -22,10 +22,10 @@ function clampPercent(value: number): number | undefined {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-function percentFromText(text: string): number | undefined {
+function averagePercentFromText(text: string): number | undefined {
   const values = text.match(/\d+(?:\.\d+)?/g)?.map(Number).filter(Number.isFinite) ?? [];
   if (values.length === 0) return undefined;
-  return clampPercent(Math.max(...values));
+  return clampPercent(values.reduce((sum, value) => sum + value, 0) / values.length);
 }
 
 export function gpuPercentFromIoreg(text: string): number | undefined {
@@ -45,6 +45,20 @@ async function defaultRun(command: string, args: string[], timeoutMs = commandTi
   return String(stdout ?? "");
 }
 
+async function linuxGpuPercent(readFile: TextFileReader, readDirectory: DirectoryReader): Promise<number | undefined> {
+  try {
+    const percents = await Promise.all(
+      (await readDirectory("/sys/class/drm"))
+        .filter((entry) => /^card\d+$/.test(entry))
+        .map((entry) => readFile(`/sys/class/drm/${entry}/device/gpu_busy_percent`).then(averagePercentFromText).catch(() => undefined)),
+    );
+    const available = percents.filter((percent): percent is number => percent !== undefined);
+    return available.length > 0 ? Math.round(available.reduce((sum, percent) => sum + percent, 0) / available.length) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function gpuPercentForPlatform(
   platform: NodeJS.Platform,
   run: CommandRunner,
@@ -52,21 +66,16 @@ async function gpuPercentForPlatform(
   readDirectory: DirectoryReader,
 ): Promise<number | undefined> {
   if (platform === "darwin") {
-    try {
-      const percent = gpuPercentFromIoreg(await run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOGPU"]));
-      if (percent !== undefined) return percent;
-    } catch {}
-    try {
-      return gpuPercentFromIoreg(await run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOAccelerator"]));
-    } catch {
-      return undefined;
-    }
+    const [ioGpu, ioAccelerator] = await Promise.all([
+      run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOGPU"]).then(gpuPercentFromIoreg).catch(() => undefined),
+      run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOAccelerator"]).then(gpuPercentFromIoreg).catch(() => undefined),
+    ]);
+    return ioGpu ?? ioAccelerator;
   }
 
-  try {
-    const nvidia = percentFromText(await run("nvidia-smi", ["--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"]));
-    if (nvidia !== undefined) return nvidia;
-  } catch {}
+  const nvidia = run("nvidia-smi", ["--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"])
+    .then(averagePercentFromText)
+    .catch(() => undefined);
 
   if (platform === "win32") {
     const command = [
@@ -74,29 +83,18 @@ async function gpuPercentForPlatform(
       "if (-not $c) { exit 0 };",
       "$samples = $c.CounterSamples | Where-Object { $_.InstanceName -match 'engtype_3D' };",
       "if (-not $samples) { $samples = $c.CounterSamples };",
-      "($samples | Measure-Object -Property CookedValue -Maximum).Maximum",
+      "($samples | Measure-Object -Property CookedValue -Average).Average",
     ].join(" ");
-    try {
-      return percentFromText(await run("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], 4_000));
-    } catch {
-      return undefined;
-    }
+    const windows = run("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command])
+      .then(averagePercentFromText)
+      .catch(() => undefined);
+    const [nvidiaPercent, windowsPercent] = await Promise.all([nvidia, windows]);
+    return nvidiaPercent ?? windowsPercent;
   }
 
   if (platform !== "linux") return undefined;
-  try {
-    const percents: number[] = [];
-    for (const entry of await readDirectory("/sys/class/drm")) {
-      if (!/^card\d+$/.test(entry)) continue;
-      try {
-        const percent = percentFromText(await readFile(`/sys/class/drm/${entry}/device/gpu_busy_percent`));
-        if (percent !== undefined) percents.push(percent);
-      } catch {}
-    }
-    return percents.length > 0 ? Math.max(...percents) : undefined;
-  } catch {
-    return undefined;
-  }
+  const [nvidiaPercent, linuxPercent] = await Promise.all([nvidia, linuxGpuPercent(readFile, readDirectory)]);
+  return nvidiaPercent ?? linuxPercent;
 }
 
 export async function readExtendedSystemMetrics(

--- a/apps/desktop/src/system-metrics.ts
+++ b/apps/desktop/src/system-metrics.ts
@@ -1,0 +1,127 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const commandTimeoutMs = 2_500;
+
+export type ExtendedSystemMetrics = {
+  /** Aggregate GPU utilisation when the platform exposes it. */
+  gpuPercent?: number;
+  /** Used capacity of the system volume, not a per-app or per-file measurement. */
+  diskUsedPercent?: number;
+};
+
+type CommandRunner = (command: string, args: string[], timeoutMs?: number) => Promise<string>;
+type StatFsReader = (path: string) => Promise<{ blocks: number | bigint; bfree: number | bigint }>;
+type TextFileReader = (path: string) => Promise<string>;
+type DirectoryReader = (path: string) => Promise<string[]>;
+
+function clampPercent(value: number): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function percentFromText(text: string): number | undefined {
+  const values = text.match(/\d+(?:\.\d+)?/g)?.map(Number).filter(Number.isFinite) ?? [];
+  if (values.length === 0) return undefined;
+  return clampPercent(Math.max(...values));
+}
+
+export function gpuPercentFromIoreg(text: string): number | undefined {
+  const match = text.match(/(?:Device|Renderer) Utilization %"?\s*=\s*(\d+(?:\.\d+)?)/);
+  return match ? clampPercent(Number(match[1])) : undefined;
+}
+
+export function diskUsedPercentFromStatFs(stat: { blocks: number | bigint; bfree: number | bigint }): number | undefined {
+  const blocks = Number(stat.blocks);
+  const free = Number(stat.bfree);
+  if (!Number.isFinite(blocks) || !Number.isFinite(free) || blocks <= 0) return undefined;
+  return clampPercent(((blocks - free) / blocks) * 100);
+}
+
+async function defaultRun(command: string, args: string[], timeoutMs = commandTimeoutMs): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, { timeout: timeoutMs, windowsHide: true, maxBuffer: 64 * 1024 });
+  return String(stdout ?? "");
+}
+
+async function gpuPercentForPlatform(
+  platform: NodeJS.Platform,
+  run: CommandRunner,
+  readFile: TextFileReader,
+  readDirectory: DirectoryReader,
+): Promise<number | undefined> {
+  if (platform === "darwin") {
+    try {
+      const percent = gpuPercentFromIoreg(await run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOGPU"]));
+      if (percent !== undefined) return percent;
+    } catch {}
+    try {
+      return gpuPercentFromIoreg(await run("ioreg", ["-r", "-d", "2", "-w", "0", "-c", "IOAccelerator"]));
+    } catch {
+      return undefined;
+    }
+  }
+
+  try {
+    const nvidia = percentFromText(await run("nvidia-smi", ["--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"]));
+    if (nvidia !== undefined) return nvidia;
+  } catch {}
+
+  if (platform === "win32") {
+    const command = [
+      "$c = Get-Counter '\\GPU Engine(*)\\Utilization Percentage' -ErrorAction SilentlyContinue;",
+      "if (-not $c) { exit 0 };",
+      "$samples = $c.CounterSamples | Where-Object { $_.InstanceName -match 'engtype_3D' };",
+      "if (-not $samples) { $samples = $c.CounterSamples };",
+      "($samples | Measure-Object -Property CookedValue -Maximum).Maximum",
+    ].join(" ");
+    try {
+      return percentFromText(await run("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], 4_000));
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (platform !== "linux") return undefined;
+  try {
+    const percents: number[] = [];
+    for (const entry of await readDirectory("/sys/class/drm")) {
+      if (!/^card\d+$/.test(entry)) continue;
+      try {
+        const percent = percentFromText(await readFile(`/sys/class/drm/${entry}/device/gpu_busy_percent`));
+        if (percent !== undefined) percents.push(percent);
+      } catch {}
+    }
+    return percents.length > 0 ? Math.max(...percents) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readExtendedSystemMetrics(
+  options: {
+    platform?: NodeJS.Platform;
+    run?: CommandRunner;
+    statfs?: StatFsReader;
+    readFile?: TextFileReader;
+    readDirectory?: DirectoryReader;
+  } = {},
+): Promise<ExtendedSystemMetrics> {
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? defaultRun;
+  const statfs = options.statfs ?? ((path) => fs.statfs(path));
+  const readFile = options.readFile ?? ((path) => fs.readFile(path, "utf8"));
+  const readDirectory = options.readDirectory ?? ((path) => fs.readdir(path));
+  const volumePath = platform === "win32" ? `${process.env.SystemDrive || "C:"}\\` : "/";
+
+  const [gpu, disk] = await Promise.all([
+    gpuPercentForPlatform(platform, run, readFile, readDirectory),
+    statfs(volumePath).then(diskUsedPercentFromStatFs).catch(() => undefined),
+  ]);
+
+  return {
+    ...(gpu === undefined ? {} : { gpuPercent: gpu }),
+    ...(disk === undefined ? {} : { diskUsedPercent: disk }),
+  };
+}

--- a/apps/desktop/tests/system-metrics.test.ts
+++ b/apps/desktop/tests/system-metrics.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+import { diskUsedPercentFromStatFs, gpuPercentFromIoreg, readExtendedSystemMetrics } from "../src/system-metrics.js";
+
+// The SDK exposes aggregate, bounded values only: unavailable hardware omits a metric.
+assert.equal(diskUsedPercentFromStatFs({ blocks: 100, bfree: 25 }), 75);
+assert.equal(diskUsedPercentFromStatFs({ blocks: 0, bfree: 0 }), undefined);
+assert.equal(gpuPercentFromIoreg('"Device Utilization %" = 41'), 41);
+assert.equal(gpuPercentFromIoreg("unavailable"), undefined);
+
+{
+  const metrics = await readExtendedSystemMetrics({
+    platform: "linux",
+    run: async () => { throw new Error("nvidia-smi is unavailable"); },
+    statfs: async () => ({ blocks: 200, bfree: 50 }),
+    readDirectory: async () => ["card0", "renderD128"],
+    readFile: async (path) => {
+      assert.equal(path, "/sys/class/drm/card0/device/gpu_busy_percent");
+      return "37\n";
+    },
+  });
+  assert.deepEqual(metrics, { gpuPercent: 37, diskUsedPercent: 75 });
+}
+
+{
+  let volumePath = "";
+  const metrics = await readExtendedSystemMetrics({
+    platform: "win32",
+    run: async (command, args) => {
+      assert.equal(command, "nvidia-smi");
+      assert.deepEqual(args, ["--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"]);
+      return "61\n";
+    },
+    statfs: async (path) => {
+      volumePath = path;
+      return { blocks: 100, bfree: 40 };
+    },
+    readDirectory: async () => [],
+    readFile: async () => "",
+  });
+  assert.deepEqual(metrics, { gpuPercent: 61, diskUsedPercent: 60 });
+  assert.equal(volumePath, `${process.env.SystemDrive || "C:"}\\`);
+}
+
+console.log("system metrics: all checks passed.");

--- a/apps/desktop/tests/system-metrics.test.ts
+++ b/apps/desktop/tests/system-metrics.test.ts
@@ -13,13 +13,14 @@ assert.equal(gpuPercentFromIoreg("unavailable"), undefined);
     platform: "linux",
     run: async () => { throw new Error("nvidia-smi is unavailable"); },
     statfs: async () => ({ blocks: 200, bfree: 50 }),
-    readDirectory: async () => ["card0", "renderD128"],
+    readDirectory: async () => ["card0", "card1", "renderD128"],
     readFile: async (path) => {
-      assert.equal(path, "/sys/class/drm/card0/device/gpu_busy_percent");
-      return "37\n";
+      if (path === "/sys/class/drm/card0/device/gpu_busy_percent") return "37\n";
+      if (path === "/sys/class/drm/card1/device/gpu_busy_percent") return "63\n";
+      throw new Error(`Unexpected path: ${path}`);
     },
   });
-  assert.deepEqual(metrics, { gpuPercent: 37, diskUsedPercent: 75 });
+  assert.deepEqual(metrics, { gpuPercent: 50, diskUsedPercent: 75 });
 }
 
 {

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -57,7 +57,7 @@ each gated by a permission ([Plugin platform](/plugins)):
 | `ctx.auth` | Host-mediated OAuth/PKCE | `auth` |
 | `ctx.net` | Declared∩approved hosts; public HTTPS + optional local HTTP via `network:local`; non-GET via `network:write` | `network`, `network:write`, `network:local` |
 | `ctx.files` | Scoped file access | `files` |
-| `ctx.system` | System info / clipboard | `system:*`, `clipboard` |
+| `ctx.system` | System info, aggregate CPU/memory and optional GPU/system-volume metrics, clipboard | `system:*`, `clipboard` |
 | `ctx.assets` | Resolve declared asset refs (icons/images/sprites/sounds) | (declared assets) |
 | `ctx.commands` | Register right-click commands | `commands` |
 | `ctx.status` | Publish status text | (status surface) |
@@ -67,6 +67,9 @@ each gated by a permission ([Plugin platform](/plugins)):
 
 The exact signatures live in `packages/sdk/src/index.ts` - that file is the
 contract, so program against it rather than any list copied into a doc.
+`ctx.system.metrics()` always returns aggregate CPU and memory usage; its
+GPU and system-volume fields are optional because host support varies by OS and
+hardware. It never exposes process, application, file, or device identity data.
 `OpenPetsPermission` in the SDK mirrors manifest validation so authors get
 autocomplete for exactly the capabilities they can request.
 

--- a/packages/sdk/src/check-plugin-sdk.ts
+++ b/packages/sdk/src/check-plugin-sdk.ts
@@ -99,6 +99,8 @@ const plugin: OpenPetsPluginDefinition = {
 
 const { ctx, calls, harness } = createMockContext();
 harness.files.provide([{ name: "bell.wav", bytes: new Uint8Array([1, 2, 3]) }]);
+harness.system.setMetrics({ cpuPercent: 12, memUsedPercent: 34, gpuPercent: 56, diskUsedPercent: 78 });
+assert.deepEqual(await ctx.system.metrics(), { cpuPercent: 12, memUsedPercent: 34, gpuPercent: 56, diskUsedPercent: 78 });
 await plugin.start(ctx);
 
 assert.deepEqual(calls.speak, ["Hello!", "Heads up", "Break in 5:00"]);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -889,6 +889,10 @@ export interface OpenPetsSystemMetrics {
   cpuPercent: number;
   /** 0–100. */
   memUsedPercent: number;
+  /** Optional aggregate GPU utilization (0–100) when supported by the host OS. */
+  gpuPercent?: number;
+  /** Optional used capacity (0–100) of the system volume when supported by the host OS. */
+  diskUsedPercent?: number;
   battery?: { percent: number; charging: boolean };
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -889,7 +889,7 @@ export interface OpenPetsSystemMetrics {
   cpuPercent: number;
   /** 0–100. */
   memUsedPercent: number;
-  /** Optional aggregate GPU utilization (0–100) when supported by the host OS. */
+  /** Optional aggregate GPU utilization (0–100) when supported by the host OS and hardware. */
   gpuPercent?: number;
   /** Optional used capacity (0–100) of the system volume when supported by the host OS. */
   diskUsedPercent?: number;

--- a/packages/sdk/src/testing.ts
+++ b/packages/sdk/src/testing.ts
@@ -309,7 +309,7 @@ export interface MockHarnessCore {
   files: { provide(files: Array<{ name: string; text?: string; bytes?: Uint8Array }>): void };
   auth: { mock(tokens: { accessToken: string; refreshToken?: string; expiresAt?: number }): void };
   voice: { mockListen(text: string): void };
-  system: { set(info: Partial<{ platform: "mac" | "win" | "linux"; locale: string; timezone: string; theme: "light" | "dark"; online: boolean }>): void; setMetrics(metrics: { cpuPercent: number; memUsedPercent: number; battery?: { percent: number; charging: boolean } }): void; setClipboard(text: string): void };
+  system: { set(info: Partial<{ platform: "mac" | "win" | "linux"; locale: string; timezone: string; theme: "light" | "dark"; online: boolean }>): void; setMetrics(metrics: { cpuPercent: number; memUsedPercent: number; gpuPercent?: number; diskUsedPercent?: number; battery?: { percent: number; charging: boolean } }): void; setClipboard(text: string): void };
   panel: { sendToPlugin(msg: unknown): void };
 }
 
@@ -342,7 +342,7 @@ export function createMockContext(optionsOrConfig: MockContextOptions | Record<s
   let listenText: string | null = null;
   let clipboardText = "";
   let systemInfo: { platform: "mac" | "win" | "linux"; locale: string; timezone: string; theme: "light" | "dark"; appVersion: string; online: boolean } = { platform: "mac", locale: "en-US", timezone: "UTC", theme: "light", appVersion: "0.0.0-test", online: true };
-  let systemMetrics: { cpuPercent: number; memUsedPercent: number; battery?: { percent: number; charging: boolean } } = { cpuPercent: 5, memUsedPercent: 40 };
+  let systemMetrics: { cpuPercent: number; memUsedPercent: number; gpuPercent?: number; diskUsedPercent?: number; battery?: { percent: number; charging: boolean } } = { cpuPercent: 5, memUsedPercent: 40 };
   let nextId = 0;
   const newId = (prefix: string) => `${prefix}-${++nextId}`;
 


### PR DESCRIPTION
## Summary
- add optional aggregate GPU and system-volume usage fields to `ctx.system.metrics()`
- collect from bounded, host-owned probes with five-second caching and no plugin process or file access
- extend the SDK/test harness contract and document availability semantics

## Validation
- focused system-metrics TypeScript compile and behavior test
- SDK typecheck

The full desktop test build is currently blocked before compilation by pnpm 11 rejecting the repository’s pre-existing unresolved `openclaw` and `tree-sitter-bash` build approvals.