### PR TITLE
fix(desktop): don't read window.webContents after Control Center is destroyed

### DIFF
--- a/apps/desktop/src/windows.ts
+++ b/apps/desktop/src/windows.ts
@@ -932,6 +932,7 @@ export function openControlCenterWindow(route: ControlCenterRoute = "dashboard")
   });
 
   controlCenterWindow = window;
+  const windowWebContentsId = window.webContents.id;
   syncDockVisibilityForInternalUi();
   window.setMenu(null);
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
@@ -953,7 +954,7 @@ export function openControlCenterWindow(route: ControlCenterRoute = "dashboard")
     console.error("Control Center renderer process gone.", details);
     logError("ui", "control center renderer gone", details);
   });
-  window.on("closed", () => { clearConversationSubscription(window.webContents.id); clearVoiceAssistantSubscription(window.webContents.id); controlCenterWindow = null; syncDockVisibilityForInternalUi(); });
+  window.on("closed", () => { clearConversationSubscription(windowWebContentsId); clearVoiceAssistantSubscription(windowWebContentsId); controlCenterWindow = null; syncDockVisibilityForInternalUi(); });
   window.once("ready-to-show", () => { window.show(); window.focus(); });
   pendingControlCenterRoute = safeRoute;
   window.webContents.on("did-finish-load", () => flushPendingControlCenterRoute(window));


### PR DESCRIPTION
## Summary
Fixes #178 — opening Control Center and then closing it throws an uncaught main-process exception (`TypeError: Object has been destroyed`), surfaced as a native Electron crash dialog, leaving the app degraded (pet stops animating, becomes undraggable).

## Root cause
In `openControlCenterWindow()`, the window's `"closed"` handler reads `window.webContents.id`:

```ts
window.on("closed", () => { clearConversationSubscription(window.webContents.id); ... });
```

By the time `"closed"` fires, the window (and its `webContents`) are already destroyed, so accessing `window.webContents` throws. Reproduced the exact stack trace (`TypeError: Object has been destroyed` / `BrowserWindow.<anonymous>` / `BrowserWindow.emit`) two ways: a minimal isolated script against this repo's own bundled Electron, and live in the actual app UI by building the original v3.5.0 code and triggering it through Control Center.

Reproduced on Linux, but this is a plain Electron `BrowserWindow`/`WebContents` lifecycle issue independent of platform — confirmed against Electron 42.0.0 with no OS-specific code path involved.

## Fix
Capture `window.webContents.id` into a local variable right after window creation, before it can ever be destroyed, and use that captured value in the `"closed"` handler instead — the same pattern already used correctly elsewhere in this file (e.g. `default-pet-controller.ts` captures `.id` before registering its own `closed` listener).

## Testing
- `pnpm typecheck`, `pnpm build`, `pnpm test` all pass
- Reproduced the original crash live in the app (not just isolated) by temporarily reverting the fix, rebuilding, and triggering it through the UI; confirmed the fix eliminates it on rebuild
- Ran the patched build as a live soak test (20+ min), including repeatedly opening/closing Control Center — no crash
- Rebooted the test machine and confirmed the fix survives a fresh autostart launch, including reopening Control Center again post-reboot — no crash
